### PR TITLE
Fixed skolemization bug

### DIFF
--- a/src/quantifiers/quantifier.rs
+++ b/src/quantifiers/quantifier.rs
@@ -93,7 +93,7 @@ pub fn instantiate_quantifiers(
             // let negated_term =
             //     if let Universal = quantifier.polarity {egraph.context.not(term)} else {term};
 
-            let polarity = quantifier.polarity == Polarity::Universal;
+            let polarity = quantifier.polarity == Polarity::Existential;
 
             // todo: replace this with the skolemized flag in the quantifier
             if egraph.added_skolemizations.contains(&quantifier.id) {

--- a/tests/regression_test.rs
+++ b/tests/regression_test.rs
@@ -102,7 +102,7 @@ fn regression_test() {
                 .unwrap_or_else(|| panic!("No expected result found for {}", relative_path));
 
             // Run solver with timeout
-            let child = Command::new("target/release/sundance_smt")
+            let child = Command::new("target/release/sundance-smt")
                 .args([path.to_str().unwrap()])
                 .stdout(std::process::Stdio::piped())
                 .stderr(std::process::Stdio::piped())


### PR DESCRIPTION
*Description of changes:* I fixed the bug relating to skolemization. We were calculating the wrong polarity in `quantifier.rs`. We now pass all regression tests


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
