### PR TITLE
Fix the types assigned to arithmetic variables

### DIFF
--- a/src/arithmetic/lia/context.rs
+++ b/src/arithmetic/lia/context.rs
@@ -181,7 +181,7 @@ impl ConvContext {
                 }
             }
             None => {
-                Var::real(new_id) // by default al slack variables will have type Real
+                Var::real(new_id) // by default all slack variables have type Real
             }
         };
         self.next_id += 1;

--- a/src/arithmetic/lia/frontend.rs
+++ b/src/arithmetic/lia/frontend.rs
@@ -153,7 +153,7 @@ fn convert_linear_term(ctx: &mut ConvContext, term: &Term) -> FrontendResult<Lin
     match term.get().repr() {
         ATerm::Constant(c, _) => Ok(LinExpr(vec![c.convert_constant()?])),
         // handle variables
-        ATerm::Global(smt_ast::alg::QualifiedIdentifier(id, sort), _) => {
+        ATerm::Global(smt_ast::alg::QualifiedIdentifier(id, _), sort) => {
             let name = id.symbol.get();
             let var_typ = match sort {
                 Some(hs) => {
@@ -171,8 +171,7 @@ fn convert_linear_term(ctx: &mut ConvContext, term: &Term) -> FrontendResult<Lin
                     }
                 }
                 None => {
-                    log::warn!("no sort information for {name}, assuming type is Real");
-                    VarType::Real
+                    panic!("no sort information for {name}")
                 }
             };
             let var = ctx.allocate_var_term(name, var_typ, term.clone());
@@ -663,7 +662,6 @@ mod tests {
     }
 
     #[test]
-    #[ignore = "broken after merge"]
     fn test_convert_smt_var_types_converted() {
         let smt = r#"
             (set-logic QF_LIA)
@@ -685,7 +683,6 @@ mod tests {
     }
 
     #[test]
-    #[ignore = "broken after merge"]
     fn test_constant_division() {
         let smt = r#"
             (set-logic QF_LIA)

--- a/src/arithmetic/lia/lira_solver.rs
+++ b/src/arithmetic/lia/lira_solver.rs
@@ -488,7 +488,6 @@ mod tests {
 
     // Repeat the manual test above but using the actual LIRA solver branch-and-bound implementation
     #[test]
-    #[ignore = "broken after merge"]
     fn branch_and_bound_triangle() {
         let _ = env_logger::builder().is_test(true).try_init();
         // If x, y are Real this problem is FEASBILE, ex. model {x := 1/3, y := 1/3}
@@ -509,7 +508,6 @@ mod tests {
     }
 
     #[test]
-    #[ignore = "broken after merge"]
     fn unsat_2_sat_branch_and_bound() {
         let _ = env_logger::builder().is_test(true).try_init();
 
@@ -556,7 +554,6 @@ mod tests {
     ///
     /// The encoding in this unit test cost $2.61
     #[test]
-    #[ignore = "broken after merge"]
     fn unsat_3_sat_branch_and_bound() {
         let _ = env_logger::builder().is_test(true).try_init();
 
@@ -616,7 +613,6 @@ mod tests {
     ///
     /// https://www.desmos.com/calculator/y1wwdqoqle
     #[test]
-    #[ignore = "broken after merge"]
     fn grind_test_playground() {
         let smt1 = r#"
         (declare-const x Int)


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Incorrect types were being assigned to integer variables due to a combination of Yaspar updates (sort info moving) and a default fall-through type being in place. The fall-through has been removed and the types are now matched from the correct Yaspar AST field.

The arithmetic unit tests that were previously ignored are now enabled.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
