### PR TITLE
Add regression unit test for #30

### DIFF
--- a/src/arithmetic/lia/lira_solver.rs
+++ b/src/arithmetic/lia/lira_solver.rs
@@ -781,4 +781,20 @@ mod tests {
             // println!("{conflict:#?}");
         }
     }
+
+    #[test]
+    fn regression_issue_30() {
+        let smt = r#"
+        (set-logic QF_LRA)
+        (declare-const x Real)
+        (assert (= (* 2 x) 3))
+        (check-sat)
+        "#;
+        let result = solve_smtlib(smt).expect("solver failed");
+        assert!(matches!(result, SolverDecisionApi::FEASIBLE(_)),);
+        if let SolverDecisionApi::FEASIBLE(assg) = result {
+            let (_, val) = assg.iter().next().unwrap();
+            assert_eq!(Rational::from(2) * val, Rational::from(3));
+        }
+    }
 }


### PR DESCRIPTION
*Issue #, if available:* https://github.com/yaspar-org/Sundance-SMT/issues/30

*Description of changes:*

Add a unit test demonstrating that the internal arithmetic solver isn't affected by #30 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
