### PR TITLE
Implement Tableau for TableauSparse

### DIFF
--- a/src/arithmetic/lia/sparse.rs
+++ b/src/arithmetic/lia/sparse.rs
@@ -199,6 +199,16 @@ impl<V: Zero + fmt::Debug> Matrix<V> {
         })
     }
 
+    /// Return the number of rows in the matrix
+    pub fn nrows(&self) -> usize {
+        self.baserows.len()
+    }
+
+    /// Return the number of columns in the matrix
+    pub fn ncols(&self) -> usize {
+        self.basecols.len()
+    }
+
     /// Get the value of an element in the matrix
     ///
     /// Returns Some(&Zero) if the element coordinates are in-bounds but the node

--- a/src/arithmetic/lia/tableau_dense.rs
+++ b/src/arithmetic/lia/tableau_dense.rs
@@ -35,6 +35,31 @@ impl TableauDense {
         })
     }
 
+    /// Make a new Tableau from a vector of tuples (row, col, value).
+    pub fn from_tuples(
+        nrows: usize,
+        ncols: usize,
+        t: Vec<(usize, usize, Rational)>,
+    ) -> TableauResult<Self> {
+        if nrows == 0 || ncols == 0 {
+            return Err(TableauError(
+                "tableau dimensions must be non-zero".to_string(),
+            ));
+        }
+        let mut data = Array2D::filled_with(Rational::from(0), nrows, ncols);
+        for (row, col, value) in t {
+            if row >= nrows || col >= ncols {
+                return Err(TableauError("tuple index out of bounds".to_string()));
+            }
+            data[(row, col)] = value;
+        }
+        Ok(TableauDense {
+            nrows,
+            ncols,
+            data: Box::new(data),
+        })
+    }
+
     /// Return the number of rows in the tableau (= number of basic variables)
     pub fn nrows(&self) -> usize {
         self.data.num_rows()
@@ -171,6 +196,27 @@ mod tests {
             vec![rbig!(-1), rbig!(-1)],
             vec![rbig!(0), rbig!(1)],
             vec![rbig!(-1), rbig!(-1)],
+        ];
+        let expected_tab = TableauDense::from_rows(&expected_data).unwrap();
+        assert_eq!(tab, expected_tab);
+    }
+
+    #[test]
+    fn from_tuples_3x2() {
+        let tuples = vec![
+            (0, 0, rbig!(1)),
+            (0, 1, rbig!(1)),
+            (1, 0, rbig!(2)),
+            (1, 1, rbig!(-1)),
+            (2, 0, rbig!(-1)),
+            (2, 1, rbig!(2)),
+        ];
+        let tab = TableauDense::from_tuples(3, 2, tuples).unwrap();
+
+        let expected_data = [
+            vec![rbig!(1), rbig!(1)],
+            vec![rbig!(2), rbig!(-1)],
+            vec![rbig!(-1), rbig!(2)],
         ];
         let expected_tab = TableauDense::from_rows(&expected_data).unwrap();
         assert_eq!(tab, expected_tab);

--- a/src/arithmetic/lia/tableau_sparse.rs
+++ b/src/arithmetic/lia/tableau_sparse.rs
@@ -1,14 +1,78 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-//! todo:
+//! A sparse tableaux implementation for use in the lia simplex algorithm
 
 use crate::arithmetic::lia::sparse;
+use crate::arithmetic::lia::tableau::{Tableau, TableauError, TableauResult};
 use crate::arithmetic::lia::types::Rational;
 
-/// todo:
+/// TableauSparse wraps a sparse matrix over the [Rational]s and implements
+/// the [Tableau] interface.
 #[allow(dead_code)]
 #[derive(Debug)]
 pub struct TableauSparse {
     matrix: sparse::Matrix<Rational>,
+}
+
+impl TableauSparse {
+    /// Make a new Tableau from a vector of tuples (row, col, value).
+    pub fn from_tuples(
+        nrows: usize,
+        ncols: usize,
+        t: Vec<(usize, usize, Rational)>,
+    ) -> TableauResult<Self> {
+        let matrix = sparse::Matrix::from_tuples(nrows, ncols, t).map_err(|e| TableauError(e.0))?;
+        Ok(TableauSparse { matrix })
+    }
+
+    /// Return the number of rows in the tableau (= number of basic variables)
+    pub fn nrows(&self) -> usize {
+        self.matrix.nrows()
+    }
+
+    /// Return the number of columns in the tableau (= number of basic + non-basic variables)
+    pub fn ncols(&self) -> usize {
+        self.matrix.ncols()
+    }
+}
+
+impl Tableau for TableauSparse {
+    fn pivot(&mut self, row: usize, col: usize) -> TableauResult<()> {
+        self.matrix.pivot(row, col).map_err(|e| TableauError(e.0))
+    }
+
+    fn get(&self, row: usize, col: usize) -> TableauResult<&Rational> {
+        self.matrix
+            .get(row, col)
+            .ok_or_else(|| TableauError(format!("Index out of bounds: ({}, {})", row, col)))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::arithmetic::lia::types::rbig;
+
+    #[test]
+    fn from_tuples_3x2() {
+        let tuples = vec![
+            (0, 0, rbig!(1)),
+            (0, 1, rbig!(1)),
+            (1, 0, rbig!(2)),
+            (1, 1, rbig!(-1)),
+            (2, 0, rbig!(-1)),
+            (2, 1, rbig!(2)),
+        ];
+        let tab = TableauSparse::from_tuples(3, 2, tuples).unwrap();
+
+        assert_eq!(tab.nrows(), 3);
+        assert_eq!(tab.ncols(), 2);
+        assert_eq!(*tab.get(0, 0).unwrap(), rbig!(1));
+        assert_eq!(*tab.get(0, 1).unwrap(), rbig!(1));
+        assert_eq!(*tab.get(1, 0).unwrap(), rbig!(2));
+        assert_eq!(*tab.get(1, 1).unwrap(), rbig!(-1));
+        assert_eq!(*tab.get(2, 0).unwrap(), rbig!(-1));
+        assert_eq!(*tab.get(2, 1).unwrap(), rbig!(2));
+    }
 }


### PR DESCRIPTION
*Description of changes:*

Add `TableauSparse` which wraps a sparse matrix and implement the `Tableau` trait for it. Also adds `from_tuples` to both the dense and sparse tableau implementations.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
