### PR TITLE
Switch arithmetic logging to debug_println

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,8 +25,6 @@ cadical-sys = { version = "0.7.0" }
 array2d = "^0.3"
 clap = { version = "4.5.40", features = ["derive"] }
 dashu = { version = "^0.4", features = ["num-traits"] }
-env_logger = "^0.11"
-log = "^0.4"
 num-traits = "^0.2"
 serde_json = "1.0"
 slotmap = "^1.0"

--- a/src/arithmetic/lia/context.rs
+++ b/src/arithmetic/lia/context.rs
@@ -3,7 +3,7 @@
 
 //! Context tracked during SMT to [crate::arithmetic::lia::linear_system::LinearSystem] conversion
 
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 use dashu::Rational;
 
@@ -63,6 +63,8 @@ pub struct ConvContext {
     relations: Vec<Rel<Rational>>,
     /// List of (slack) variables corresponding to relations in `self.relations`
     relation_vars: Vec<Var>,
+    /// All variables in the context, no matter how they are allocated
+    all_variables: HashSet<Var>,
 }
 
 impl ConvContext {
@@ -76,6 +78,7 @@ impl ConvContext {
             var_to_term: HashMap::new(),
             relations: Vec::new(),
             relation_vars: Vec::new(),
+            all_variables: HashSet::new(),
         }
     }
 
@@ -92,6 +95,11 @@ impl ConvContext {
     /// Return the number of contained relations
     pub fn num_relations(&self) -> usize {
         self.relations.len()
+    }
+
+    /// Return the number of defined variables
+    pub fn num_variables(&self) -> usize {
+        self.all_variables.len()
     }
 
     /// Filter associated variables and relations based on a variable predicate
@@ -126,6 +134,7 @@ impl ConvContext {
         // TODO: intern the strings instead of copying
         self.name_to_var.insert(name.to_string(), new_var);
         self.var_to_name.insert(new_var, name.to_string());
+        self.all_variables.insert(new_var);
         new_var
     }
 
@@ -146,6 +155,7 @@ impl ConvContext {
         self.var_to_name.insert(new_var, name.to_string());
         self.term_to_var.insert(term.clone(), new_var);
         self.var_to_term.insert(new_var, term);
+        self.all_variables.insert(new_var);
         new_var
     }
 
@@ -189,6 +199,7 @@ impl ConvContext {
         self.var_to_term.insert(new_var, term);
         self.name_to_var.insert(new_var_name.clone(), new_var);
         self.var_to_name.insert(new_var, new_var_name);
+        self.all_variables.insert(new_var);
         new_var
     }
 
@@ -231,13 +242,13 @@ impl ConvContext {
         self.term_to_var.get(&term).copied()
     }
 
-    /// Copy and return all the ids in the context
+    /// Copy and return all the vars in the context
     pub fn get_all_vars(&self) -> impl Iterator<Item = Var> {
-        self.var_to_name.keys().copied()
+        self.all_variables.clone().into_iter()
     }
 
     #[allow(dead_code)]
-    /// Get name associated with an id, if present
+    /// Get name associated with an var, if present
     pub fn get_name(&self, var: Var) -> Option<&str> {
         self.var_to_name.get(&var).map(|s| s.as_str())
     }

--- a/src/arithmetic/lia/frontend.rs
+++ b/src/arithmetic/lia/frontend.rs
@@ -4,7 +4,6 @@
 //! Conversion of SMT text to parser AST and then to [LinearSystem] relations
 //! and solver objects.
 
-use log;
 use std::collections;
 use std::fmt::{self, Display};
 use std::ops;
@@ -27,6 +26,7 @@ use crate::arithmetic::lia::solver_result_api::SolverDecisionApi;
 use crate::arithmetic::lia::tableau_dense::TableauDense;
 use crate::arithmetic::lia::types::{FBig, Integer, Rational, UBig};
 use crate::arithmetic::lia::variables::VarType;
+use crate::debug_println;
 
 /// Error type for conversion issues from [Term] to [Rel]
 #[derive(Debug)]
@@ -457,7 +457,12 @@ fn smt_to_terms(smt: &str) -> FrontendResult<Vec<Term>> {
 /// pre-processed away upstream.
 pub fn convert_smt(smt_input: &str) -> FrontendResult<ConvContext> {
     let terms = smt_to_terms(smt_input)?;
-    log::debug!("num_parsed_terms={}", terms.len());
+    debug_println!(
+        15,
+        0,
+        "lia::frontend: number of converted terms = {}",
+        terms.len()
+    );
     convert_terms(&terms)
 }
 
@@ -516,6 +521,13 @@ pub fn solve_ctx_raw(ctx: &mut ConvContext) -> FrontendResult<SolverDecision> {
     // preprocess the input relations, detect trivial cases, and otherwise return a [LinearSystem]
     // from which to build a solver.
     let result = preprocess(ctx);
+    debug_println!(
+        21,
+        0,
+        "lia::frontend: num_variables = {}, num_relations = {}",
+        ctx.num_variables(),
+        ctx.num_relations()
+    );
     let sys = match result {
         PreprocessResult::TriviallySat => {
             return Ok(SolverDecision::FEASIBLE(default_model(ctx.get_all_vars())));
@@ -690,7 +702,6 @@ mod tests {
 
     #[test]
     fn test_top_level_solve_smtlib() {
-        let _ = env_logger::builder().is_test(true).try_init();
         let smt = r#"
 (set-logic QF_LRA)
 (declare-fun x0 () Real)
@@ -715,7 +726,6 @@ mod tests {
     /// relation "0 <= 5" should be removed during normalization.
     #[test]
     fn test_trivially_sat_relation_removal() {
-        let _ = env_logger::builder().is_test(true).try_init();
         let smt_input = r#"
 (set-logic QF_LRA)
 (declare-fun x0 () Real)
@@ -746,7 +756,6 @@ mod tests {
     /// The resulting system is trivially satisfiable.
     #[test]
     fn test_trivially_sat() {
-        let _ = env_logger::builder().is_test(true).try_init();
         let smt_input = r#"
 (set-logic QF_LRA)
 (declare-fun x0 () Real)
@@ -774,7 +783,6 @@ mod tests {
     /// the second relation.
     #[test]
     fn test_frontend_trivially_unsat_relation_preprocessing() {
-        let _ = env_logger::builder().is_test(true).try_init();
         let smt_input = r#"
 (set-logic QF_LRA)
 (declare-fun x0 () Real)

--- a/src/arithmetic/lia/linear_system.rs
+++ b/src/arithmetic/lia/linear_system.rs
@@ -26,6 +26,7 @@ use crate::arithmetic::lia::qdelta::QDelta;
 use crate::arithmetic::lia::tableau_dense::TableauDense;
 use crate::arithmetic::lia::utils;
 use crate::arithmetic::lia::variables::{Owner, Var, VarInfo};
+use crate::debug_println;
 
 /// Generic frontend error
 #[derive(Debug)]
@@ -714,6 +715,7 @@ impl LinearSystem {
         // 0 <= x3 - x5  --> <0, 1, -1>
         //
         // time complexity is expected worst case O(#relations * #var)
+        let mut num_non_zero: usize = 0;
         let mut equations: Vec<Vec<Rational>> = Vec::new();
         let nvars = var_ids.len();
         for (rel, _) in self.ctx.get_relations() {
@@ -723,6 +725,7 @@ impl LinearSystem {
                     let col = var_id_col_map.get(&t.var).unwrap();
                     if !t.coeff_zero() {
                         row[*col] = t.coeff.clone();
+                        num_non_zero += 1;
                     }
                 }
             }
@@ -730,6 +733,14 @@ impl LinearSystem {
         }
         // all rows should have the same length: nvars
         debug_assert!(equations.iter().all(|r| r.len() == nvars));
+        debug_println!(
+            21,
+            0,
+            "lia::linear_system: nvars = {}, neqs = {}, num_non_zero = {}",
+            nvars,
+            equations.len(),
+            num_non_zero
+        );
         LRASolver::from_eqs(basic, non_basic, equations, self.ctx)
             .map_err(|e| LinearSystemError(format!("error building tableau: {}", e)))
     }
@@ -1076,8 +1087,6 @@ mod tests {
     ///
     #[test]
     fn solve_basic_feasible_system() {
-        let _ = env_logger::builder().is_test(true).try_init();
-
         let mut ctx = ConvContext::new();
         let x = ctx.allocate_var("x", VarType::Real);
         let y = ctx.allocate_var("y", VarType::Real);
@@ -1105,8 +1114,6 @@ mod tests {
     ///
     #[test]
     fn solve_unbounded_feasible_system() {
-        let _ = env_logger::builder().is_test(true).try_init();
-
         let mut ctx = ConvContext::new();
         let x = ctx.allocate_var("x", VarType::Real);
         let y = ctx.allocate_var("y", VarType::Real);
@@ -1169,8 +1176,6 @@ mod tests {
     ///
     #[test]
     fn solve_basic_infeasible_system() {
-        let _ = env_logger::builder().is_test(true).try_init();
-
         let mut ctx = ConvContext::new();
         let x0 = ctx.allocate_var("x0", VarType::Real);
         let x1 = ctx.allocate_var("x1", VarType::Real);
@@ -1344,8 +1349,6 @@ mod tests {
     /// x1 >  -1 x0 + 1  -->  x0 + x1 > 1
     #[test]
     fn solve_system_with_strict_gt() {
-        let _ = env_logger::builder().is_test(true).try_init();
-
         let mut ctx = ConvContext::new();
         let x0 = ctx.allocate_var("x0", VarType::Real);
         let x1 = ctx.allocate_var("x1", VarType::Real);
@@ -1394,7 +1397,6 @@ mod tests {
     ///
     #[test]
     fn solve_strict_system_strictly_in_unit_cube() {
-        let _ = env_logger::builder().is_test(true).try_init();
         let (mut solver, _x, _y) = open_polytope_in_unit_cube();
         let result = solver.solve().expect("simplex failed");
         if let SolverDecision::FEASIBLE(assg) = result {
@@ -1408,7 +1410,6 @@ mod tests {
 
     #[test]
     fn solve_strict_system_strictly_in_unit_cube_then_assert_lower() {
-        let _ = env_logger::builder().is_test(true).try_init();
         let (mut solver, x, _y) = open_polytope_in_unit_cube();
         assert!(matches!(
             solver.solve().expect("simplex failed"),
@@ -1455,7 +1456,6 @@ mod tests {
 
     #[test]
     fn solve_strict_system_strictly_in_unit_cube_then_assert_upper() {
-        let _ = env_logger::builder().is_test(true).try_init();
         let (mut solver, x, y) = open_polytope_in_unit_cube();
         if let SolverDecision::FEASIBLE(ass) = solver.solve().expect("simplex failed") {
             // test x and y's values
@@ -1517,8 +1517,6 @@ mod tests {
     /// system is infeasible over Z.
     #[test]
     fn solve_non_strict_lia_system_strictly_in_unit_cube() {
-        let _ = env_logger::builder().is_test(true).try_init();
-
         let mut ctx = ConvContext::new();
         let x = ctx.allocate_var("x", VarType::Real);
         let y = ctx.allocate_var("y", VarType::Real);
@@ -1588,8 +1586,6 @@ mod tests {
     /// doesn't automatically filter trivially satisfiable relations.
     #[test]
     fn test_trivially_sat_relation_removal() {
-        let _ = env_logger::builder().is_test(true).try_init();
-
         let mut ctx = ConvContext::new();
         let x0 = ctx.allocate_var("x0", VarType::Real);
         let x1 = ctx.allocate_var("x1", VarType::Real);
@@ -1625,8 +1621,6 @@ mod tests {
     /// detect that it's infeasible.
     #[test]
     fn test_trivially_unsat_relation_preprocessing() {
-        let _ = env_logger::builder().is_test(true).try_init();
-
         let mut ctx = ConvContext::new();
         let x0 = ctx.allocate_var("x0", VarType::Real);
         let x1 = ctx.allocate_var("x1", VarType::Real);

--- a/src/arithmetic/lia/lira_solver.rs
+++ b/src/arithmetic/lia/lira_solver.rs
@@ -8,8 +8,8 @@
 
 use std::fmt;
 
+use crate::debug_println;
 use dashu::{Integer, Rational};
-use log;
 use slotmap;
 
 use crate::arithmetic::lia::bounds::Bounds;
@@ -104,42 +104,61 @@ impl BrtExplorer {
                 BrtNodeState::Active(_) | BrtNodeState::Branched(_, _, _) => break,
                 BrtNodeState::Pruned(c) => c.clone(), // TODO: resolve: cloning conflicts at every node is expensive
             };
-            log::debug!(
-                "bnb::resolve: current node is pruned and has conflicts {:?}",
+            debug_println!(
+                15,
+                0,
+                "lia::lira_solver::resolve: current node is pruned and has conflicts {:?}",
                 current_conflict
             );
-            log::debug!("bnb::resolve: parent node {:?}", self.arena[parent_k]);
+            debug_println!(
+                15,
+                0,
+                "lia::lira_solver::resolve: parent node {:?}",
+                self.arena[parent_k]
+            );
 
             // Parent state
             match self.arena[parent_k].state {
                 BrtNodeState::Branched(var, left_k, right_k) => {
-                    log::debug!("bnb::resolve: parent node is branched on {var}");
+                    debug_println!(
+                        15,
+                        0,
+                        "lia::lira_solver::resolve: parent node is branched on {var}"
+                    );
                     let other_k = if current_k == left_k { right_k } else { left_k };
                     let other_conflict = match &self.arena[other_k].state {
                         // the other branch hasn't been fully explored yet
                         BrtNodeState::Active(_) => {
-                            log::debug!(
-                                "bnb::resolve: other branch is still active; ending conflict resolution"
+                            debug_println!(
+                                15,
+                                0,
+                                "lia::lira_solver::resolve: other branch is still active; ending conflict resolution"
                             );
                             return self.arena[parent_k].level.unwrap(); // safe b/c parent is branched, not active
                         }
                         BrtNodeState::Branched(other_var, _, _) => {
                             debug_assert!(var == *other_var);
-                            log::debug!(
-                                "bnb::resolve: other branch is still branched; ending conflict resolution"
+                            debug_println!(
+                                15,
+                                0,
+                                "lia::lira_solver::resolve: other branch is still branched; ending conflict resolution"
                             );
                             return self.arena[parent_k].level.unwrap(); // safe b/c parent is branched, not active
                         }
                         // the other branch is fully explored and pruned
                         BrtNodeState::Pruned(c) => c,
                     };
-                    log::debug!(
-                        "bnb::resolve: other branch is pruned and has conflicts {:?}",
+                    debug_println!(
+                        15,
+                        0,
+                        "lia::lira_solver::resolve: other branch is pruned and has conflicts {:?}",
                         other_conflict
                     );
                     current_conflict = current_conflict.resolve(var, other_conflict);
-                    log::debug!(
-                        "bnb::resolve: after resolution conflicts are {:?}",
+                    debug_println!(
+                        15,
+                        0,
+                        "lia::lira_solver::resolve: after resolution conflicts are {:?}",
                         current_conflict
                     );
                     self.arena[parent_k].state = BrtNodeState::Pruned(current_conflict);
@@ -147,7 +166,7 @@ impl BrtExplorer {
                 // If the parent is Active or Pruned, it's a bug
                 // there's nothing to resolve
                 BrtNodeState::Pruned(_) | BrtNodeState::Active(_) => {
-                    unreachable!("bnb::resolve: unexpected active/pruned parent")
+                    unreachable!("lia::lira_solver::resolve: unexpected active/pruned parent")
                 }
             }
             current_k = parent_k;
@@ -196,7 +215,7 @@ impl<T: Tableau + fmt::Debug> LIRASolver<T> {
             BrtNodeState::Active(setup) => {
                 match setup {
                     BrtAction::BranchTo(Branch { var, bounds }) => {
-                        log::debug!("bnb: pushing branch {var} in {bounds}");
+                        debug_println!(15, 0, "lia::lira_solver: pushing branch {var} in {bounds}");
                         match (&bounds.lower, &bounds.upper) {
                             (Some(l), None) => {
                                 new_bt_level = Some(self.lra_solver.set_backtrack());
@@ -204,8 +223,10 @@ impl<T: Tableau + fmt::Debug> LIRASolver<T> {
                                     .lra_solver
                                     .assert_lower(var, &QDelta::from(Rational::from(l.clone())))?;
                                 if let Some(false) = ass_res {
-                                    log::debug!(
-                                        "bnb: (assert_lower) branch is trivially INFEASIBLE"
+                                    debug_println!(
+                                        15,
+                                        0,
+                                        "lia::lira_solver: (assert_lower) branch is trivially INFEASIBLE"
                                     );
                                     // conflict is the single variable asserted upon
                                     new_current_state = Some(BrtNodeState::Pruned(
@@ -220,8 +241,10 @@ impl<T: Tableau + fmt::Debug> LIRASolver<T> {
                                     .assert_upper(var, &QDelta::from(Rational::from(u.clone())))?;
                                 if let Some(false) = ass_res {
                                     // branch is trivially UNSAT
-                                    log::debug!(
-                                        "bnb: (assert_upper) branch is trivially INFEASIBLE"
+                                    debug_println!(
+                                        15,
+                                        0,
+                                        "lia::lira_solver: (assert_upper) branch is trivially INFEASIBLE"
                                     );
                                     // conflict is the single variable asserted upon
                                     new_current_state = Some(BrtNodeState::Pruned(
@@ -270,14 +293,18 @@ impl<T: Tableau + fmt::Debug> LIRASolver<T> {
     /// TODO: lira_solver::solve: document branch-and-bound algorithm using incremental simplex
     /// TODO: lira_solver::solve: clean up debug statements
     pub fn solve(&mut self) -> SolverResult<SolverDecision> {
-        log::debug!(
-            "bnb: starting LIRASolver with lra_solver: {:?}",
+        debug_println!(
+            21,
+            0,
+            "lia::lira_solver: starting LIRASolver with lra_solver: {:?}",
             self.lra_solver
         );
 
         while let Some(current_k) = self.explorer.active.pop() {
-            log::debug!(
-                "bnb::solve: pop & setup node {:?}",
+            debug_println!(
+                15,
+                0,
+                "lia::lira_solver::solve: pop & setup node {:?}",
                 self.explorer.arena[current_k]
             );
             self.setup_active(current_k)?;
@@ -291,34 +318,56 @@ impl<T: Tableau + fmt::Debug> LIRASolver<T> {
             }
 
             // setup done, now solve and update state and active
-            log::debug!("bnb: solving over Q");
+            debug_println!(21, 0, "lia::lira_solver: solving over Q");
             match self.lra_solver.solve()? {
                 SolverDecision::INFEASIBLE(cs) => {
-                    log::debug!("bnb: INFEASIBLE, pruning node and backtracking");
+                    debug_println!(
+                        15,
+                        0,
+                        "lia::lira_solver: INFEASIBLE, pruning node and backtracking"
+                    );
                     self.explorer.arena[current_k].state = BrtNodeState::Pruned(cs);
                     let level = self.explorer.resolve(current_k);
                     // Resolve optionally returns a final level to backtrack to; this
                     // may jump several levels back, not just to the parent.
-                    log::debug!("bnb: after resolution, backtracking to level {level}");
+                    debug_println!(
+                        15,
+                        0,
+                        "lia::lira_solver: after resolution, backtracking to level {level}"
+                    );
                     self.lra_solver.backtrack(level)
                 }
                 SolverDecision::FEASIBLE(assg) => {
-                    log::debug!("bnb: FEASIBLE, checking for non-integral assignments");
+                    debug_println!(
+                        15,
+                        0,
+                        "lia::lira_solver: FEASIBLE, checking for non-integral assignments"
+                    );
                     // identify the first integer type variable whose assigned value is not integral
                     let (x, val) = match self.find_next_int_var() {
                         None => return Ok(SolverDecision::FEASIBLE(assg)), // rational solution meets all type constraints
                         Some((x, val)) => {
-                            log::debug!("bnb: FEASIBLE, {x} is not assigned an integer: {val}");
+                            debug_println!(
+                                15,
+                                0,
+                                "lia::lira_solver: FEASIBLE, {x} is not assigned an integer: {val}"
+                            );
                             (x, val)
                         }
                     };
 
                     // (x : Int) is assigned a non-integer solution, so we branch
-                    log::debug!("bnb: branching on var {x} with current assignment {val}");
+                    debug_println!(
+                        15,
+                        0,
+                        "lia::lira_solver: branching on var {x} with current assignment {val}"
+                    );
                     let lower_branch = Bounds::below_of(val.floor()); // new upper bound for `x` in branch 1
                     let upper_branch = Bounds::above_of(val.ceil()); // new lower bound for `x` in branch 2
-                    log::debug!(
-                        "bnb: lower branch: {x} in {lower_branch}, upper branch: {x} in {upper_branch}"
+                    debug_println!(
+                        15,
+                        0,
+                        "lia::lira_solver: lower branch: {x} in {lower_branch}, upper branch: {x} in {upper_branch}"
                     );
 
                     // construct new lower and upper nodes to explore, add them to the tree
@@ -411,7 +460,6 @@ impl<T: Tableau + fmt::Debug> LIRASolver<T> {
 #[cfg(test)]
 mod tests {
     use dashu::{Rational, rbig};
-    use env_logger;
 
     use crate::arithmetic::lia::frontend::{smt_to_lra_solver, solve_smtlib};
     use crate::arithmetic::lia::lira_solver::LIRASolver;
@@ -421,7 +469,6 @@ mod tests {
     /// Execute branch and bound manually on an UNSAT QF_LIA problem
     #[test]
     fn manual_branch_and_bound_triangle() {
-        let _ = env_logger::builder().is_test(true).try_init();
         // If x, y are Real this problem is FEASBILE, ex. model {x := 1/3, y := 1/3}
         let smt_input = r#"
         (set-logic QF_LIRA)
@@ -489,7 +536,6 @@ mod tests {
     // Repeat the manual test above but using the actual LIRA solver branch-and-bound implementation
     #[test]
     fn branch_and_bound_triangle() {
-        let _ = env_logger::builder().is_test(true).try_init();
         // If x, y are Real this problem is FEASBILE, ex. model {x := 1/3, y := 1/3}
         let smt_input = r#"
         (set-logic QF_LIRA)
@@ -509,8 +555,6 @@ mod tests {
 
     #[test]
     fn unsat_2_sat_branch_and_bound() {
-        let _ = env_logger::builder().is_test(true).try_init();
-
         // Encode the 2-variable 2-SAT problem:
         // (x y) ∧ (-x y) ∧ (x -y) ∧ (-x -y)
         let smt_input = r#"
@@ -555,8 +599,6 @@ mod tests {
     /// The encoding in this unit test cost $2.61
     #[test]
     fn unsat_3_sat_branch_and_bound() {
-        let _ = env_logger::builder().is_test(true).try_init();
-
         // This encodes the 3-SAT problem:
         // (𝑥∨𝑦∨𝑧)∧(𝑥∨𝑦∨¬𝑧)∧(𝑥∨¬𝑦∨𝑧)∧(𝑥∨¬𝑦∨¬𝑧)∧(¬𝑥∨𝑦∨𝑧)∧(¬𝑥∨𝑦∨¬𝑧)∧(¬𝑥∨¬𝑦∨𝑧)∧(¬𝑥∨¬𝑦∨¬𝑧)
         let smt_input = r#"

--- a/src/arithmetic/lia/lra_solver.rs
+++ b/src/arithmetic/lia/lra_solver.rs
@@ -7,7 +7,7 @@
 //! the rational solver methods and contains data like variable info and an underlying
 //! tableau representing a linear system.
 
-use log;
+use crate::debug_println;
 use std::collections::BTreeMap;
 use std::fmt;
 
@@ -179,8 +179,10 @@ impl<T: Tableau> LRASolver<T> {
         pivot_col: usize,
         val: &QDelta,
     ) -> SolverResult<()> {
-        log::debug!(
-            "  pivot_and_update row={}, col={}, val={}",
+        debug_println!(
+            10,
+            0,
+            "lia::lra_solver:  pivot_and_update row={}, col={}, val={}",
             pivot_row,
             pivot_col,
             val
@@ -236,8 +238,10 @@ impl<T: Tableau> LRASolver<T> {
             .get(x)
             .ok_or(SolverError(format!("variable {0:?} does not exist", x)))?;
         let v = &mut self.variables[*idx];
-        log::debug!(
-            "assert_lower on variable {0:?}, lower={1}, non_basic?={2}",
+        debug_println!(
+            10,
+            0,
+            "lia::lra_solver: assert_lower on variable {0:?}, lower={1}, non_basic?={2}",
             v,
             l,
             v.is_non_basic().is_some()
@@ -246,27 +250,22 @@ impl<T: Tableau> LRASolver<T> {
         let bs = &v.bounds;
         if bs.above_upper(l) {
             // new lower bound is inconsistent with current upper bound
-            log::debug!("assert_lower: trivially inconsistent");
             return Ok(Some(false));
         } else if bs.above_lower(l) {
             // `l` is a tighter lower bound
-            log::debug!("assert_lower: new lower bound is an improvement");
             self.old_lower_bounds
                 .push((v.var, v.bounds.lower.clone(), self.backtrack_level));
             v.update_lower(l.clone());
-            log::debug!("assert_lower: new variable state: {v}");
         }
         // Note: in this check, l can be infinitesimally (in the QDelta sense) less or
         // equal to v.val
         if *l <= v.val {
-            log::debug!("assert_lower: current assignment satisfies new lower bound");
             return Ok(Some(true));
         }
         // if v.val is now outside the new lower bound, and v is a non-basic variable,
         // update v.val and adjust the basic variable values to maintain the tableau
         // invariant
         if let Some(col) = v.is_non_basic() {
-            log::debug!("assert_lower: updating tableaux");
             self.update(col, l);
         }
         Ok(None)
@@ -286,12 +285,6 @@ impl<T: Tableau> LRASolver<T> {
             .get(x)
             .ok_or(SolverError(format!("variable {0:?} does not exist", x)))?;
         let v = &mut self.variables[*idx];
-        log::debug!(
-            "assert_upper on variable {0:?}, upper={1}, non_basic?={2}",
-            v,
-            u,
-            v.is_non_basic().is_some()
-        );
 
         let bs = &v.bounds;
         if bs.below_lower(u) {
@@ -490,7 +483,6 @@ impl<T: Tableau> LRASolver<T> {
                     // strictly above the original lower bound
                     let d0 = (v.val.rat() - l.rat())
                         / (Rational::from(2) * (v.val.inf() - Rational::ONE).abs());
-                    log::debug!("d0 for var {} is {}", v, d0);
                     delta_ub.push(d0);
                 } else if l.inf().is_zero() && v.val.inf() < &Rational::ZERO {
                     // lower bound is non-strict, but assigned value is infinitesimally smaller
@@ -512,7 +504,6 @@ impl<T: Tableau> LRASolver<T> {
                     // strictly below the original upper bound
                     let d0 = (u.rat() - v.val.rat())
                         / (Rational::from(2) * (Rational::ONE + v.val.inf()).abs());
-                    log::debug!("d0 for var {} is {}", v, d0);
                     delta_ub.push(d0);
                 } else if u.inf().is_zero() && v.val.inf() > &Rational::ZERO {
                     // upper bound is non-strict, but assigned value is infinitesimally greater
@@ -527,7 +518,7 @@ impl<T: Tableau> LRASolver<T> {
         }
         let d0 = delta_ub.into_iter().min().unwrap_or(Rational::ONE); // choose δ_0 = 1 if there are no positive upper bounds
         debug_assert!(d0 >= Rational::ZERO);
-        log::debug!("δ_0 = {d0}");
+        debug_println!(10, 0, "lia::lra_solver: δ_0 = {d0}");
         d0
     }
 
@@ -554,7 +545,6 @@ impl<T: Tableau> LRASolver<T> {
         //   2. Switch to Bland's rule
         //
         for var in self.variables.iter() {
-            log::debug!("CONSIDER {}", var);
             let row = match var.is_basic() {
                 Some(r) => r,
                 None => continue,
@@ -565,11 +555,8 @@ impl<T: Tableau> LRASolver<T> {
             // 2. v.val is less than the lower bound
             // 3. v.val is greater than the upper bound
             if var.in_bounds() {
-                log::debug!("basic var (row {}) is in bounds: {}", row, var,);
                 continue;
             } else if var.below_lower() {
-                log::debug!("basic var (row {}) is below its lower bound: {}", row, var,);
-
                 // TODO: factor out loop code and simpler helper functions
                 // Try to increase basic_var's assignment to its lower bound
                 for (col, non_basic_idx) in self.non_basic.iter().enumerate() {
@@ -580,8 +567,10 @@ impl<T: Tableau> LRASolver<T> {
                     {
                         // unwrap is safe because basic_var is below its lower bound
                         let basic_lower_bound = var.bounds.lower.as_ref().unwrap().clone();
-                        log::debug!(
-                            "pivot basic (row {}) {} and non-basic (col {}) {}, update non-basic val to {}",
+                        debug_println!(
+                            15,
+                            0,
+                            "lia::lra_solver: pivot basic (row {}) {} and non-basic (col {}) {}, update non-basic val to {}",
                             row,
                             var,
                             col,
@@ -596,7 +585,13 @@ impl<T: Tableau> LRASolver<T> {
                 self.state = LRASolverState::Unsat;
                 return Ok(SimplexStepResult::Infeasible(var.var));
             } else {
-                log::debug!("basic var (row {}) is above its upper bound: {}", row, var);
+                debug_println!(
+                    15,
+                    0,
+                    "lia::lra_solver: basic var (row {}) is above its upper bound: {}",
+                    row,
+                    var
+                );
                 debug_assert!(var.bounds.upper.is_some() && var.above_upper());
                 // Try to decrease basic_var's assignment to its upper bound
                 for (col, non_basic_idx) in self.non_basic.iter().enumerate() {
@@ -611,8 +606,10 @@ impl<T: Tableau> LRASolver<T> {
                         // pivot basic_var and non_basic_var, update assignment of
                         // (previously) basic_var to its lower bound and then adjust all
                         // basic assignments so the equations hold
-                        log::debug!(
-                            "pivot basic (row {}) {} and non-basic (col {}) {}, update non-basic val to {}",
+                        debug_println!(
+                            15,
+                            0,
+                            "lia::lra_solver: pivot basic (row {}) {} and non-basic (col {}) {}, update non-basic val to {}",
                             row,
                             var,
                             col,
@@ -638,17 +635,29 @@ impl<T: Tableau> LRASolver<T> {
     pub fn solve(&mut self) -> SolverResult<SolverDecision> {
         let mut i: usize = 0;
         loop {
-            log::debug!("Stepping simplex, iteration {}", i);
+            debug_println!(21, 0, "lia::lra_solver: Stepping simplex, iteration {}", i);
             match self.step_simplex() {
                 Ok(SimplexStepResult::Unknown) => {
                     i += 1;
                 }
                 Ok(SimplexStepResult::Feasible) => {
                     let assg = self.compute_assignment();
+                    debug_println!(
+                        21,
+                        0,
+                        "lia::lra_solver::solve: simplex complete, num iterations = {}",
+                        i
+                    );
                     return Ok(SolverDecision::FEASIBLE(assg));
                 }
                 Ok(SimplexStepResult::Infeasible(v)) => {
                     let conflict = self.compute_conflict(v)?;
+                    debug_println!(
+                        21,
+                        0,
+                        "lia::lra_solver::solve: simplex complete, num iterations = {}",
+                        i
+                    );
                     return Ok(SolverDecision::INFEASIBLE(conflict));
                 }
                 Err(e) => return Err(e), // error
@@ -781,7 +790,12 @@ impl LRASolver<TableauDense> {
                 equations.len()
             )));
         }
-        log::debug!("LRASolver::from_eqs: nrows = {}", nrows);
+        debug_println!(
+            15,
+            0,
+            "lia::lra_solver: LRASolver::from_eqs: nrows = {}",
+            nrows
+        );
         // at this point: nrows == equations.len() > 0
         if equations[0].len() != ncols {
             return Err(SolverError(format!(
@@ -790,7 +804,12 @@ impl LRASolver<TableauDense> {
                 ncols,
             )));
         }
-        log::debug!("LRASolver::from_eqs: non_basic.len() = {}", ncols);
+        debug_println!(
+            15,
+            0,
+            "lia::lra_solver: LRASolver::from_eqs: non_basic.len() = {}",
+            ncols
+        );
 
         // Arrange non-basic (original) variables first, followed by basic (slack) variables
         let mut var_to_idx = BTreeMap::new();
@@ -832,7 +851,6 @@ mod tests {
     use crate::arithmetic::lia::context::ConvContext;
     use crate::arithmetic::lia::variables::{Var, VarInfo};
     use dashu::rbig;
-    use env_logger;
 
     #[test]
     fn initial_hl_tableau_invariants() {
@@ -1109,8 +1127,6 @@ mod tests {
 
     #[test]
     fn ex_5_6_run_simplex() {
-        let _ = env_logger::builder().is_test(true).try_init();
-
         // s1 | 1  1    2 <= s1
         // s2 | 2 -1    0 <= s2
         // s3 |-1  2    1 <= s3
@@ -1154,7 +1170,6 @@ mod tests {
 
     #[test]
     fn ex_triangle_hole_run_simplex_conflict() {
-        let _ = env_logger::builder().is_test(true).try_init();
         let mut tableau = ex_triangle_hole_infeasible();
         match tableau.solve().expect("Failed to run simplex") {
             SolverDecision::INFEASIBLE(conflict) => {

--- a/src/arithmetic/lia/preprocess.rs
+++ b/src/arithmetic/lia/preprocess.rs
@@ -6,6 +6,7 @@
 
 use crate::arithmetic::lia::context::ConvContext;
 use crate::arithmetic::lia::variables::Var;
+use crate::debug_println;
 use std::collections::HashSet;
 
 /// Preprocessing result
@@ -43,19 +44,22 @@ pub fn preprocess(ctx: &mut ConvContext) -> PreprocessResult {
         } else {
             // immediately return if a trivially unsat relation (e.g. 0 <= -1) is found
             if r.is_trivial_unsat() {
-                log::debug!("query is trivially UNSAT");
+                debug_println!(21, 0, "lia::preprocess: query is trivially UNSAT");
                 return PreprocessResult::TriviallyUnsat(*v);
             }
         }
     }
-    log::debug!(
-        "num_monomials={}, num_trivial_relations={}",
+    debug_println!(
+        21,
+        0,
+        "lia::preprocess: num_monomials={}, num_trivial_relations={}",
         num_monomials,
         num_trivial
     );
     // Remove the trivially SAT relations (e.g. 0 <= 1).
     ctx.filter_vars(|v| !to_remove.contains(v));
     if ctx.num_relations() == 0 {
+        debug_println!(21, 0, "lia::preprocess: query is trivially SAT");
         return PreprocessResult::TriviallySat;
     }
     PreprocessResult::Unknown

--- a/src/arithmetic/lia/solver_result_api.rs
+++ b/src/arithmetic/lia/solver_result_api.rs
@@ -31,8 +31,6 @@ impl SolverDecisionApi {
     ) -> SolverResult<Self> {
         match decision {
             SolverDecision::FEASIBLE(assg) => {
-                log::debug!("from_solver_decision: assg {:?}", assg);
-                log::debug!("from_solver_decision: term map {:?}", var_term_map);
                 // let term_assign = BTreeMap::new();
                 let term_assign = assg
                     .into_iter()


### PR DESCRIPTION
*Description of changes:*

Switch logging in the arithmetic module to use `debug_println!` macro and remove all the `env_logger` uses. There are also some logging improvements included.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
