### PR TITLE
Question: could we use IndexMap for egraph predecessors?

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ num-traits = "^0.2"
 serde_json = "1.0"
 slotmap = "^1.0"
 z3 = { version = "0.19.8", optional = true }
+indexmap = "2"
 num = "0.4.3"
 
 [dev-dependencies]

--- a/src/cadical_propagator.rs
+++ b/src/cadical_propagator.rs
@@ -15,8 +15,9 @@ use crate::log::is_important;
 use crate::proof::proof_tracer::SMTProofTracker;
 use crate::quantifiers::quantifier::QuantifierInstance::{Instantiation, Skolemization};
 use crate::quantifiers::quantifier::instantiate_quantifiers;
-use crate::utils::{DeterministicHashMap, DeterministicHashSet};
+use crate::utils::DeterministicHashSet;
 use cadical_sys::{CaDiCal, ExternalPropagator};
+use indexmap::IndexMap;
 use std::cell::RefCell;
 use std::rc::Rc;
 
@@ -383,7 +384,7 @@ impl<'a> ExternalPropagator for CustomExternalPropagator<'a> {
 
         // once we get to level 0, we don't need to keep track of this anymore since we have reached the bottom case
         if level == 0 {
-            self.egraph.predecessors_created_by_quantifiers = DeterministicHashMap::new();
+            self.egraph.predecessors_created_by_quantifiers = IndexMap::new();
         }
 
         // redoing the union_to_eclass stuff

--- a/src/egraphs/congruence_closure.rs
+++ b/src/egraphs/congruence_closure.rs
@@ -1037,7 +1037,7 @@ fn union_predecessors(
                 predecessor_u.level,
                 egraph.predecessor_level[predecessor_u.level]
             );
-            egraph.predecessors[u as usize].remove(pred_u_key);
+            egraph.predecessors[u as usize].swap_remove(pred_u_key);
             continue;
         }
         debug_println!(
@@ -1144,7 +1144,7 @@ fn union_predecessors(
                 level,
                 egraph.predecessor_hash
             );
-            egraph.predecessors[v as usize].remove(pred_v_key);
+            egraph.predecessors[v as usize].swap_remove(pred_v_key);
             continue;
         }
         debug_println!(

--- a/src/egraphs/congruence_closure.rs
+++ b/src/egraphs/congruence_closure.rs
@@ -6,6 +6,7 @@
 use crate::datatypes::axioms::{learn_ctor_selector_clauses, learn_or_not_term_tester_term};
 use crate::egraphs::proofforest::ProofForestEdge;
 use crate::utils::{DeterministicHashMap, DeterministicHashSet, fmt_termlist};
+use indexmap::IndexMap;
 use yaspar_ir::ast::alg::CheckIdentifier;
 use yaspar_ir::ast::{FetchSort, IdentifierKind, Repr, Term, TermAllocator};
 
@@ -45,7 +46,7 @@ pub fn process_assignment(
                 term: Some((*t, egraph.true_term)),
                 parent: 0,
                 child: 0,
-                disequalities: DeterministicHashMap::new(),
+                disequalities: IndexMap::new(),
                 level,
                 hash: egraph.predecessor_hash,
                 children: DeterministicHashSet::new(),
@@ -81,7 +82,7 @@ pub fn process_assignment(
                 term: Some((*t, egraph.false_term)),
                 parent: 0,
                 child: 0,
-                disequalities: DeterministicHashMap::new(),
+                disequalities: IndexMap::new(),
                 level,
                 hash: egraph.predecessor_hash,
                 children: DeterministicHashSet::new(),
@@ -199,7 +200,7 @@ pub fn process_assignment(
                     term: Some((t1, t2)),
                     parent: 0,
                     child: 0,
-                    disequalities: DeterministicHashMap::new(),
+                    disequalities: IndexMap::new(),
                     level,
                     hash: egraph.predecessor_hash,
                     children: DeterministicHashSet::new(),
@@ -938,7 +939,7 @@ fn make_root(vertex: u64, proof_parent: ProofForestEdge, egraph: &mut Egraph) {
                     pairs,
                     parent: vertex,
                     child: parent,
-                    disequalities: DeterministicHashMap::new(),
+                    disequalities: IndexMap::new(),
                     level,
                     hash,
                     children,
@@ -965,7 +966,7 @@ fn make_root(vertex: u64, proof_parent: ProofForestEdge, egraph: &mut Egraph) {
                     term,
                     parent: vertex,
                     child: parent,
-                    disequalities: DeterministicHashMap::new(),
+                    disequalities: IndexMap::new(),
                     level,
                     hash,
                     children,
@@ -1209,7 +1210,7 @@ fn union_predecessors(
                         pairs: terms_pairwise,
                         parent: 0,
                         child: 0,
-                        disequalities: DeterministicHashMap::new(),
+                        disequalities: IndexMap::new(),
                         level,
                         hash: egraph.predecessor_hash,
                         children: DeterministicHashSet::new(),
@@ -1394,7 +1395,7 @@ pub fn proof_forest_backtrack(
     let childs_child = get_child(&child_edge);
 
     // we are adding disequalities from the "parent" edge to the child
-    let mut new_disequalities = DeterministicHashMap::new();
+    let mut new_disequalities = IndexMap::new();
     for (k, v) in child_edge.disequalities().iter() {
         if egraph.valid_hash(v.hash, v.level) {
             debug_println!(11, 0, "Keeping disequality {}: {} in {}", k, v, child);

--- a/src/egraphs/egraph.rs
+++ b/src/egraphs/egraph.rs
@@ -11,6 +11,7 @@ use crate::egraphs::datastructures::{
 use crate::egraphs::proofforest::*;
 use crate::egraphs::utils::get_subterms;
 use crate::utils::{DeterministicHashMap, DeterministicHashSet};
+use indexmap::IndexMap;
 use sat_interface::Formula;
 use std::collections::{HashMap, HashSet};
 use std::default::Default;
@@ -273,7 +274,7 @@ impl Egraph {
             proof_forest: vec![ProofForestEdge::Root {
                 size: 1000,
                 child: 0,
-                disequalities: DeterministicHashMap::new(),
+                disequalities: IndexMap::new(),
                 children: DeterministicHashSet::new(),
             }], // think about whether using a vector or hashmap is better here
             // note: this is an option because if you are a subterm of a quantifier, you are not in the proof forest. TODO: maybe there is a better way to think about this
@@ -408,7 +409,7 @@ impl Egraph {
         &mut self,
         term: &Term,
         guard: Option<u64>,
-        disequalities: Option<DeterministicHashMap<u64, DisequalTerm>>,
+        disequalities: Option<IndexMap<u64, DisequalTerm>>,
     ) -> bool {
         // returns a vector of literals which do not occur in the propositional skeleton
         debug_println!(
@@ -429,7 +430,7 @@ impl Egraph {
                 ProofForestEdge::Root {
                     size: 1000,
                     child: 0,
-                    disequalities: DeterministicHashMap::new(),
+                    disequalities: IndexMap::new(),
                     children: DeterministicHashSet::new(),
                 },
             );
@@ -471,7 +472,7 @@ impl Egraph {
         //             term: None,
         //             parent: 0,
         //             child: 0,
-        //             disequalities: DeterministicHashMap::new(),
+        //             disequalities: IndexMap::new(),
         //             level: 0,
         //             hash: 0,
         //             children: DeterministicHashSet::new()
@@ -490,7 +491,7 @@ impl Egraph {
         //             term: None,
         //             parent: 0,
         //             child: 0,
-        //             disequalities: DeterministicHashMap::new(),
+        //             disequalities: IndexMap::new(),
         //             level: 0,
         //             hash: 0,
         //             children: DeterministicHashSet::new()
@@ -600,7 +601,7 @@ impl Egraph {
                 ProofForestEdge::Root {
                     size: 1000,
                     child: 0,
-                    disequalities: DeterministicHashMap::new(),
+                    disequalities: IndexMap::new(),
                     children: DeterministicHashSet::new(),
                 },
             );
@@ -718,7 +719,7 @@ impl Egraph {
                         size: 0,
                         parent: term_num,
                         child: *pred_key,
-                        disequalities: DeterministicHashMap::new(),
+                        disequalities: IndexMap::new(),
                         level: self.decision_level,
                         hash: self.predecessor_hash,
                         children: DeterministicHashSet::new(),
@@ -753,7 +754,7 @@ impl Egraph {
         parent: Option<u64>,
         guard: Option<u64>,
         from_quantifier: bool,
-        disequalities: Option<DeterministicHashMap<u64, DisequalTerm>>,
+        disequalities: Option<IndexMap<u64, DisequalTerm>>,
     ) {
         debug_println!(
             22,

--- a/src/egraphs/egraph.rs
+++ b/src/egraphs/egraph.rs
@@ -237,7 +237,7 @@ pub struct Egraph {
     /// this is a list of skolemized terms
     pub added_skolemizations: DeterministicHashSet<u64>,
     /// keeps track of terms created by quantifier instantiation and their predecessors
-    pub predecessors_created_by_quantifiers: DeterministicHashMap<u64, DeterministicHashSet<u64>>,
+    pub predecessors_created_by_quantifiers: IndexMap<u64, DeterministicHashSet<u64>>,
     /// keeps track of info about datatypes
     pub datatype_info: DatatypeInfo,
     /// keeps track of all constructors (from dt preprocessing pass)
@@ -289,7 +289,7 @@ impl Egraph {
             false_term: fal.uid(),
             added_instantiations: HashMap::default(),
             added_skolemizations: DeterministicHashSet::default(),
-            predecessors_created_by_quantifiers: DeterministicHashMap::new(),
+            predecessors_created_by_quantifiers: IndexMap::new(),
             datatype_info,
             term_constructors: DeterministicHashMap::new(),
             union_to_eclass: DeterministicHashSet::new(),

--- a/src/egraphs/egraph.rs
+++ b/src/egraphs/egraph.rs
@@ -216,7 +216,7 @@ pub struct Egraph {
     /// keeps track of a stack of "edges" to backtrack on
     pub proof_forest_backtrack_stack: Vec<(usize, ProofForestEdge, u64, ProofForestEdge)>,
     /// this is a map from terms (u64) -> (term in the same egraph, predecesssor of term in same egraph)
-    pub predecessors: Vec<DeterministicHashMap<u64, Predecessor>>, // u64 -> Vec<Predecessor> TODO: there might be a better way to do this
+    pub predecessors: Vec<indexmap::IndexMap<u64, Predecessor>>, // u64 -> Vec<Predecessor> TODO: there might be a better way to do this
     /// number to keep track of the current hash
     pub predecessor_hash: u64,
     /// mapping from levels -> corresponding hash
@@ -278,7 +278,7 @@ impl Egraph {
             }], // think about whether using a vector or hashmap is better here
             // note: this is an option because if you are a subterm of a quantifier, you are not in the proof forest. TODO: maybe there is a better way to think about this
             proof_forest_backtrack_stack: Vec::new(),
-            predecessors: vec![DeterministicHashMap::new()],
+            predecessors: vec![indexmap::IndexMap::new()],
             predecessor_hash: 1,
             predecessor_level: vec![1, 1],
             assertions: vec![],
@@ -434,7 +434,7 @@ impl Egraph {
                 },
             );
             self.predecessors
-                .resize(self.predecessors.len() * 2, DeterministicHashMap::new());
+                .resize(self.predecessors.len() * 2, indexmap::IndexMap::new());
         }
 
         // if this has already been inserted, then we don't need to do anything
@@ -605,7 +605,7 @@ impl Egraph {
                 },
             );
             self.predecessors
-                .resize(self.predecessors.len() * 2, DeterministicHashMap::new());
+                .resize(self.predecessors.len() * 2, indexmap::IndexMap::new());
         }
 
         // if this has already been inserted, then we don't need to do anything
@@ -664,7 +664,7 @@ impl Egraph {
             debug_println!(6, 0, "before9");
             // if the predecessor is not valid, then we can remove it from the predecessors list (this can happen because of backtracking) and continue
             if !self.valid_hash(pred.hash, pred.level) {
-                self.predecessors[subterm_root as usize].remove(pred_key);
+                self.predecessors[subterm_root as usize].swap_remove(pred_key);
                 debug_println!(
                     16,
                     1,

--- a/src/egraphs/proofforest.rs
+++ b/src/egraphs/proofforest.rs
@@ -4,7 +4,8 @@
 //! datastructures for proof forest inside of the egraph
 use crate::debug_println;
 use crate::egraphs::datastructures::DisequalTerm;
-use crate::utils::{DeterministicHashMap, DeterministicHashSet};
+use crate::utils::DeterministicHashSet;
+use indexmap::IndexMap;
 use std::fmt;
 
 /// Represents an edge in the egraph's proof forest
@@ -16,7 +17,7 @@ pub enum ProofForestEdge {
     Root {
         size: u64, // TODO: I don't know of a good way to recover the size when backtracking, so I need to figure out an efficient way to do this or maybe just remove size
         child: u64, // TODO: I am not 100% sure if child actually does anything, I think it is useful for reversing edges in the proof forest, but not 100% sure
-        disequalities: DeterministicHashMap<u64, DisequalTerm>, // TODO: this might lead to a lot of allocations
+        disequalities: IndexMap<u64, DisequalTerm>, // TODO: this might lead to a lot of allocations
         children: DeterministicHashSet<u64>,
     },
     /// Represents a node with an equality relationship
@@ -25,7 +26,7 @@ pub enum ProofForestEdge {
         size: u64,
         parent: u64,
         child: u64,
-        disequalities: DeterministicHashMap<u64, DisequalTerm>,
+        disequalities: IndexMap<u64, DisequalTerm>,
         level: usize,
         hash: u64,
         children: DeterministicHashSet<u64>,
@@ -36,7 +37,7 @@ pub enum ProofForestEdge {
         size: u64,
         parent: u64,
         child: u64,
-        disequalities: DeterministicHashMap<u64, DisequalTerm>,
+        disequalities: IndexMap<u64, DisequalTerm>,
         level: usize,
         hash: u64,
         children: DeterministicHashSet<u64>,
@@ -169,7 +170,7 @@ impl ProofForestEdge {
     }
 
     /// Get a reference to the disequalities vector for any ProofForestEdge variant
-    pub fn disequalities(&self) -> &DeterministicHashMap<u64, DisequalTerm> {
+    pub fn disequalities(&self) -> &IndexMap<u64, DisequalTerm> {
         match self {
             ProofForestEdge::Root { disequalities, .. } => disequalities,
             ProofForestEdge::Equality { disequalities, .. } => disequalities,
@@ -187,7 +188,7 @@ impl ProofForestEdge {
     }
 
     /// Get a mutable reference to the disequalities vector for any ProofForestEdge variant
-    pub fn disequalities_mut(&mut self) -> &mut DeterministicHashMap<u64, DisequalTerm> {
+    pub fn disequalities_mut(&mut self) -> &mut IndexMap<u64, DisequalTerm> {
         match self {
             ProofForestEdge::Root { disequalities, .. } => disequalities,
             ProofForestEdge::Equality { disequalities, .. } => disequalities,
@@ -196,10 +197,7 @@ impl ProofForestEdge {
     }
 
     /// Set the disequalities in a ProofForestEdge
-    pub fn set_disequalities(
-        self,
-        diseq: DeterministicHashMap<u64, DisequalTerm>,
-    ) -> ProofForestEdge {
+    pub fn set_disequalities(self, diseq: IndexMap<u64, DisequalTerm>) -> ProofForestEdge {
         match self {
             ProofForestEdge::Root {
                 size,


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* I ran [samply](https://github.com/mstange/samply) on a few long running examples from the regression test suite. One thing I noticed was a decent amount of time spent in BTreeMap insert and remove, specifically on `predecessors` in the Egraph. This makes sense as updating this is surely part of the hot path for CC. However it made me wonder whether some other kind of map could be used. I assume we don't want to use HashMap so that we have deterministic ordering. From my understanding, BTreeMap order is based on the keys, while IndexMap order is based on insertion order. The keys in this case seem to be term IDs, so if these aren't assigned in any special way then maybe insertion order is fine here too?

I would be curious to know what others think. If there isn't an obvious reason this would kill stability, it seems to be worth benchmarking. It may not make a *huge* difference, but possibly noticeable.


---


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
