### PR TITLE
Enable switching tableau implementations at runtime

### DIFF
--- a/src/arithmetic/lia/frontend.rs
+++ b/src/arithmetic/lia/frontend.rs
@@ -23,7 +23,7 @@ use crate::arithmetic::lia::lra_solver::LRASolver;
 use crate::arithmetic::lia::preprocess::{PreprocessResult, preprocess};
 use crate::arithmetic::lia::solver_result::{Conflict, SolverDecision, SolverError, default_model};
 use crate::arithmetic::lia::solver_result_api::SolverDecisionApi;
-use crate::arithmetic::lia::tableau_dense::TableauDense;
+use crate::arithmetic::lia::tableau::TableauKind;
 use crate::arithmetic::lia::types::{FBig, Integer, Rational, UBig};
 use crate::arithmetic::lia::variables::VarType;
 use crate::debug_println;
@@ -480,9 +480,9 @@ fn convert_terms(terms: &[Term]) -> FrontendResult<ConvContext> {
 }
 
 /// Parse an SMT script and build a QF_LRA solver without preprocessing
-pub fn smt_to_lra_solver(smt_input: &str) -> FrontendResult<LRASolver<TableauDense>> {
+pub fn smt_to_lra_solver(smt_input: &str) -> FrontendResult<LRASolver> {
     let ctx = convert_smt(smt_input)?;
-    Ok(LinearSystem::new(ctx).to_lra_solver(true)?)
+    Ok(LinearSystem::new(ctx).to_lra_solver(true, TableauKind::Dense)?)
 }
 
 /// Top-level arithmetic solving function
@@ -540,7 +540,7 @@ pub fn solve_ctx_raw(ctx: &mut ConvContext) -> FrontendResult<SolverDecision> {
         PreprocessResult::Unknown => LinearSystem::new(ctx.clone()),
     };
     let lra_solver = sys
-        .to_lra_solver(true)
+        .to_lra_solver(true, TableauKind::Dense)
         .map_err(|e| FrontendError(format!("error building lra_solver: {}", e)))?;
     let mut lira_solver = LIRASolver::new(lra_solver);
     lira_solver

--- a/src/arithmetic/lia/linear_system.rs
+++ b/src/arithmetic/lia/linear_system.rs
@@ -23,7 +23,7 @@ use crate::arithmetic::lia::bounds::Bounds;
 use crate::arithmetic::lia::context::ConvContext;
 use crate::arithmetic::lia::lra_solver::LRASolver;
 use crate::arithmetic::lia::qdelta::QDelta;
-use crate::arithmetic::lia::tableau_dense::TableauDense;
+use crate::arithmetic::lia::tableau::TableauKind;
 use crate::arithmetic::lia::utils;
 use crate::arithmetic::lia::variables::{Owner, Var, VarInfo};
 use crate::debug_println;
@@ -661,7 +661,8 @@ impl LinearSystem {
     pub fn to_lra_solver(
         self,
         relation_bounds: bool,
-    ) -> LinearSystemResult<LRASolver<TableauDense>> {
+        tableau_kind: TableauKind,
+    ) -> LinearSystemResult<LRASolver> {
         // original variable id's
         let var_set = self.var_id_set();
         let mut var_ids: Vec<Var> = var_set.iter().copied().collect();
@@ -741,7 +742,7 @@ impl LinearSystem {
             equations.len(),
             num_non_zero
         );
-        LRASolver::from_eqs(basic, non_basic, equations, self.ctx)
+        LRASolver::from_eqs(basic, non_basic, equations, self.ctx, tableau_kind)
             .map_err(|e| LinearSystemError(format!("error building tableau: {}", e)))
     }
 }
@@ -755,7 +756,7 @@ mod tests {
         linear_system::{LinearSystem, Mon, Rel},
         lra_solver::LRASolver,
         solver_result::SolverDecision,
-        tableau_dense::TableauDense,
+        tableau::TableauKind,
         types::{Rational, rbig},
         variables::{Var, VarType},
     };
@@ -1094,8 +1095,20 @@ mod tests {
         let _s2 = ctx.allocate_relation(Rel::mk_ge(vec![Mon::new(2, x), Mon::new(-1, y)], 0));
         let _s3 = ctx.allocate_relation(Rel::mk_ge(vec![Mon::new(-1, x), Mon::new(2, y)], 1));
 
+        let sys = LinearSystem::new(ctx.clone());
+        let mut solver = sys
+            .to_lra_solver(true, TableauKind::Dense)
+            .expect("failed to build solver");
+
+        assert!(solver.is_valid());
+        let result = solver.solve().expect("simplex failed");
+        assert!(matches!(result, SolverDecision::FEASIBLE(_)));
+
+        // Same test but with sparse tableau
         let sys = LinearSystem::new(ctx);
-        let mut solver = sys.to_lra_solver(true).expect("failed to build solver");
+        let mut solver = sys
+            .to_lra_solver(true, TableauKind::Sparse)
+            .expect("failed to build solver");
 
         assert!(solver.is_valid());
         let result = solver.solve().expect("simplex failed");
@@ -1123,7 +1136,9 @@ mod tests {
         let _s2 = ctx.allocate_relation(Rel::mk_ge(vec![Mon::new(2, x), Mon::new(-1, y)], 0));
 
         let sys = LinearSystem::new(ctx);
-        let mut solver = sys.to_lra_solver(false).expect("failed to build solver");
+        let mut solver = sys
+            .to_lra_solver(false, TableauKind::Dense)
+            .expect("failed to build solver");
 
         assert!(solver.is_valid());
         let result = solver.solve().expect("simplex failed");
@@ -1184,7 +1199,9 @@ mod tests {
         let _r3 = ctx.allocate_relation(Rel::mk_ge(vec![Mon::new(1, x1), Mon::new(1, x0)], 1));
 
         let sys = LinearSystem::new(ctx);
-        let mut solver = sys.to_lra_solver(true).expect("failed to build solver");
+        let mut solver = sys
+            .to_lra_solver(true, TableauKind::Dense)
+            .expect("failed to build solver");
         assert!(solver.is_valid());
         assert!(matches!(
             solver.solve().expect("simplex failed"),
@@ -1253,8 +1270,10 @@ mod tests {
         let _r14 = ctx.allocate_relation(Rel::mk_eq(vec![Mon::new(1, x70)], 4));
         let _r15 = ctx.allocate_relation(Rel::mk_gt(vec![Mon::new(1, x59)], 0));
 
-        let sys = LinearSystem::new(ctx);
-        let mut solver = sys.to_lra_solver(true).expect("failed to build solver");
+        let sys = LinearSystem::new(ctx.clone());
+        let mut solver = sys
+            .to_lra_solver(true, TableauKind::Dense)
+            .expect("failed to build solver");
         assert!(solver.is_valid());
         let result = solver.solve().expect("simplex failed");
         // validate the assignment
@@ -1266,6 +1285,16 @@ mod tests {
                 "expected strictly positive solution"
             );
         }
+
+        // same test but with sparse tableau
+        let sys = LinearSystem::new(ctx);
+        let mut solver = sys
+            .to_lra_solver(true, TableauKind::Sparse)
+            .expect("failed to build solver");
+        assert!(solver.is_valid());
+        let result = solver.solve().expect("simplex failed");
+        // validate the assignment
+        assert!(matches!(result, SolverDecision::FEASIBLE(_)));
     }
 
     /// Solve an UNSAT 3-SAT problem
@@ -1325,8 +1354,10 @@ mod tests {
             Rational::from(-2),
         ));
 
-        let sys = LinearSystem::new(ctx);
-        let mut solver = sys.to_lra_solver(true).expect("failed to build solver");
+        let sys = LinearSystem::new(ctx.clone());
+        let mut solver = sys
+            .to_lra_solver(true, TableauKind::Dense)
+            .expect("failed to build solver");
         assert!(solver.is_valid());
         let result = solver.solve().expect("simplex failed");
         // validate the assignment
@@ -1341,6 +1372,16 @@ mod tests {
         } else {
             unreachable!("unexpected result");
         }
+
+        // same test but with sparse tableau
+        let sys = LinearSystem::new(ctx);
+        let mut solver = sys
+            .to_lra_solver(true, TableauKind::Sparse)
+            .expect("failed to build solver");
+        assert!(solver.is_valid());
+        let result = solver.solve().expect("simplex failed");
+        // validate the assignment
+        assert!(matches!(result, SolverDecision::FEASIBLE(_)));
     }
 
     /// System is infeasible:
@@ -1356,7 +1397,9 @@ mod tests {
         let _r2 = ctx.allocate_relation(Rel::mk_gt(vec![Mon::new(1, x0), Mon::new(1, x1)], 1));
 
         let sys = LinearSystem::new(ctx);
-        let mut solver = sys.to_lra_solver(true).expect("failed to build solver");
+        let mut solver = sys
+            .to_lra_solver(true, TableauKind::Dense)
+            .expect("failed to build solver");
 
         assert!(solver.is_valid());
         let result = solver.solve().expect("simplex failed");
@@ -1374,7 +1417,7 @@ mod tests {
     /// s2 |     1 |            s2 <= 2/3 - δ
     /// s3 |  1    | 1/3 + δ <= s3
     ///
-    fn open_polytope_in_unit_cube() -> (LRASolver<TableauDense>, Var, Var) {
+    fn open_polytope_in_unit_cube() -> (LRASolver, Var, Var) {
         let mut ctx = ConvContext::new();
         let x = ctx.allocate_var("x", VarType::Real);
         let y = ctx.allocate_var("y", VarType::Real);
@@ -1383,7 +1426,9 @@ mod tests {
         let _r3 = ctx.allocate_relation(Rel::mk_gt(vec![Mon::new(1, x)], rbig!(1 / 3)));
 
         let sys = LinearSystem::new(ctx);
-        let solver = sys.to_lra_solver(true).expect("failed to build solver");
+        let solver = sys
+            .to_lra_solver(true, TableauKind::Dense)
+            .expect("failed to build solver");
         assert!(solver.is_valid());
         (solver, x, y)
     }
@@ -1525,7 +1570,7 @@ mod tests {
         let _r3 = ctx.allocate_relation(Rel::mk_ge(vec![Mon::new(1, x)], rbig!(1 / 3)));
 
         let sys = LinearSystem::new(ctx);
-        let mut solver = sys.to_lra_solver(true).unwrap();
+        let mut solver = sys.to_lra_solver(true, TableauKind::Dense).unwrap();
 
         let result = solver.solve().unwrap();
         if let SolverDecision::FEASIBLE(assg) = result {
@@ -1552,7 +1597,7 @@ mod tests {
         let _r4 = ctx.allocate_relation(Rel::mk_le(vec![Mon::new(1, x)], rbig!(0))); // new bound x <= 0
 
         let sys = LinearSystem::new(ctx);
-        let mut solver = sys.to_lra_solver(true).unwrap();
+        let mut solver = sys.to_lra_solver(true, TableauKind::Dense).unwrap();
         assert!(matches!(
             solver.solve().unwrap(),
             SolverDecision::INFEASIBLE(_)
@@ -1568,7 +1613,7 @@ mod tests {
         let _r4 = ctx.allocate_relation(Rel::mk_ge(vec![Mon::new(1, y)], rbig!(1))); // new bound y >= 1
 
         let sys = LinearSystem::new(ctx);
-        let mut solver = sys.to_lra_solver(true).unwrap();
+        let mut solver = sys.to_lra_solver(true, TableauKind::Dense).unwrap();
         assert!(matches!(
             solver.solve().unwrap(),
             SolverDecision::INFEASIBLE(_)
@@ -1604,7 +1649,9 @@ mod tests {
         );
 
         // Verify that the system is still solvable
-        let mut solver = sys.to_lra_solver(true).expect("failed to build tableau");
+        let mut solver = sys
+            .to_lra_solver(true, TableauKind::Dense)
+            .expect("failed to build tableau");
         assert!(solver.is_valid());
         let result = solver.solve().expect("simplex failed");
         assert!(matches!(result, SolverDecision::FEASIBLE(_)));
@@ -1631,7 +1678,9 @@ mod tests {
         assert_eq!(sys.num_relations(), 2, "Expected 2 relations");
 
         // Verify that the system is infeasible
-        let mut solver = sys.to_lra_solver(true).expect("failed to build solver");
+        let mut solver = sys
+            .to_lra_solver(true, TableauKind::Dense)
+            .expect("failed to build solver");
         let result = solver.solve().expect("solver failed");
         assert!(matches!(result, SolverDecision::INFEASIBLE(_)));
     }

--- a/src/arithmetic/lia/lira_solver.rs
+++ b/src/arithmetic/lia/lira_solver.rs
@@ -6,9 +6,6 @@
 //! The [LIRASolver] is a wrapper around [LRASolver] which manages solver state for mixed
 //! integer and real arithmetic problems.
 
-use std::fmt;
-
-use crate::debug_println;
 use dashu::{Integer, Rational};
 use slotmap;
 
@@ -16,8 +13,8 @@ use crate::arithmetic::lia::bounds::Bounds;
 use crate::arithmetic::lia::lra_solver::LRASolver;
 use crate::arithmetic::lia::qdelta::QDelta;
 use crate::arithmetic::lia::solver_result::{Conflict, SolverDecision, SolverResult};
-use crate::arithmetic::lia::tableau::Tableau;
 use crate::arithmetic::lia::variables::{Var, VarType};
+use crate::debug_println;
 
 // ---- New Implementation
 
@@ -177,16 +174,16 @@ impl BrtExplorer {
 
 /// Linear integer and real arithmetic solver
 #[derive(Debug)]
-pub struct LIRASolver<T: Tableau + fmt::Debug> {
+pub struct LIRASolver {
     /// The underlying LRA solver
-    lra_solver: LRASolver<T>,
+    lra_solver: LRASolver,
     /// Stack of variable bounds for tracking during solving
     explorer: BrtExplorer,
 }
 
-impl<T: Tableau + fmt::Debug> LIRASolver<T> {
+impl LIRASolver {
     /// Create a new LIRASolver with the given LRASolver
-    pub fn new(lra_solver: LRASolver<T>) -> Self {
+    pub fn new(lra_solver: LRASolver) -> Self {
         let root = BrtNode {
             level: Some(0usize),
             state: BrtNodeState::Active(BrtAction::NoOp),
@@ -421,12 +418,12 @@ impl<T: Tableau + fmt::Debug> LIRASolver<T> {
     }
 
     /// Get a reference to the underlying LRASolver
-    pub fn lra_solver(&self) -> &LRASolver<T> {
+    pub fn lra_solver(&self) -> &LRASolver {
         &self.lra_solver
     }
 
     /// Get a mutable reference to the underlying LRASolver
-    pub fn lra_solver_mut(&mut self) -> &mut LRASolver<T> {
+    pub fn lra_solver_mut(&mut self) -> &mut LRASolver {
         &mut self.lra_solver
     }
 

--- a/src/arithmetic/lia/lra_solver.rs
+++ b/src/arithmetic/lia/lra_solver.rs
@@ -17,8 +17,7 @@ use crate::arithmetic::lia::qdelta::QDelta;
 use crate::arithmetic::lia::solver_result::{
     Assignment, Conflict, SolverDecision, SolverError, SolverResult,
 };
-use crate::arithmetic::lia::tableau::Tableau;
-use crate::arithmetic::lia::tableau_dense::TableauDense;
+use crate::arithmetic::lia::tableau::{Tableau, TableauImpl, TableauKind};
 use crate::arithmetic::lia::types::Rational;
 use crate::arithmetic::lia::variables::{Owner, Var, VarInfo};
 use dashu::base::{Abs, Inverse};
@@ -48,7 +47,7 @@ enum SimplexStepResult {
 }
 
 /// Linear real arithmetic solver
-pub struct LRASolver<T: Tableau + fmt::Debug> {
+pub struct LRASolver {
     /// Variable info for all original and slack variables. The vector itself should be immutable,
     /// but VarInfo pointed to are mutated during solving.
     ///
@@ -62,7 +61,7 @@ pub struct LRASolver<T: Tableau + fmt::Debug> {
     /// Low-level tableau representing equations b/w basic and non-basic variables. The tableau has
     /// rows and columns corresponding to the basic and non-basic variable vectors, not in the
     /// fixed variable order.
-    tableau: T,
+    tableau: TableauImpl,
 
     // -- Non-variable solver state --
     /// Solver decision state
@@ -91,10 +90,7 @@ pub struct LRASolver<T: Tableau + fmt::Debug> {
     ctx: ConvContext,
 }
 
-impl<T> fmt::Debug for LRASolver<T>
-where
-    T: Tableau + fmt::Debug,
-{
+impl fmt::Debug for LRASolver {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let mut s = String::new();
         s.push_str("Variables:\n  [\n");
@@ -113,7 +109,7 @@ where
 }
 
 /// Shared functionality among all concrete instances of LRASolver
-impl<T: Tableau> LRASolver<T> {
+impl LRASolver {
     /// Perform a low-level swap of variable info between a basic and a non-basic variable.
     ///
     /// - `row` is the tableau row owned by the basic variable
@@ -760,7 +756,7 @@ impl<T: Tableau> LRASolver<T> {
     }
 }
 
-impl LRASolver<TableauDense> {
+impl LRASolver {
     /// Construct a new high-level tableau from:
     ///
     /// - basic variables, given in row order
@@ -774,6 +770,7 @@ impl LRASolver<TableauDense> {
         non_basic_info: Vec<VarInfo<QDelta>>,
         equations: Vec<Vec<Rational>>,
         ctx: ConvContext,
+        tableau_kind: TableauKind,
     ) -> SolverResult<Self> {
         let ncols = non_basic_info.len();
         let nrows = basic_info.len();
@@ -828,11 +825,21 @@ impl LRASolver<TableauDense> {
         let non_basic: Vec<usize> = (0..ncols).collect();
         let basic: Vec<usize> = (ncols..ncols + nrows).collect();
 
+        // Convert dense row data to tuples for the Tableau constructor
+        let mut tuples = Vec::new();
+        for (r, row) in equations.iter().enumerate() {
+            for (c, val) in row.iter().enumerate() {
+                if !val.is_zero() {
+                    tuples.push((r, c, val.clone()));
+                }
+            }
+        }
+
         Ok(Self {
             variables,
             basic,
             non_basic,
-            tableau: TableauDense::from_rows(&equations)?,
+            tableau: TableauImpl::new(tableau_kind, nrows, ncols, tuples)?,
             state: LRASolverState::Unknown,
             old_lower_bounds: vec![],
             old_upper_bounds: vec![],
@@ -849,6 +856,8 @@ mod tests {
     use super::*;
     use crate::arithmetic::lia::bounds::Bounds;
     use crate::arithmetic::lia::context::ConvContext;
+    use crate::arithmetic::lia::tableau::TableauKind;
+    use crate::arithmetic::lia::tableau_dense::TableauDense;
     use crate::arithmetic::lia::variables::{Var, VarInfo};
     use dashu::rbig;
 
@@ -867,7 +876,8 @@ mod tests {
         ];
         let equations = vec![vec![Rational::ONE; 2]; 2];
         let ctx = ConvContext::default();
-        let tableau = LRASolver::from_eqs(basic, non_basic, equations, ctx).unwrap();
+        let tableau =
+            LRASolver::from_eqs(basic, non_basic, equations, ctx, TableauKind::Dense).unwrap();
         assert!(tableau.assert_basic_assignments());
         assert!(tableau.assert_non_basic_in_bounds());
     }
@@ -918,7 +928,7 @@ mod tests {
     /// s2 | 2 -1    0 <= s2
     /// s3 |-1  2    1 <= s3
     ///
-    fn ex_5_6_tableau() -> LRASolver<TableauDense> {
+    fn ex_5_6_tableau() -> LRASolver {
         let basic = vec![
             VarInfo::new(Var::real(1), Owner::Basic(0)).with_bounds(Bounds::above_of(2)), // 2 <= s1
             VarInfo::new(Var::real(2), Owner::Basic(1)).with_bounds(Bounds::above_of(0)), // 0 <= s2
@@ -934,7 +944,7 @@ mod tests {
             vec![rbig!(-1), rbig!(2)],
         ];
         let ctx = ConvContext::default();
-        LRASolver::from_eqs(basic, non_basic, equations, ctx).unwrap()
+        LRASolver::from_eqs(basic, non_basic, equations, ctx, TableauKind::Dense).unwrap()
     }
 
     /// A simple infeasible tableau to test
@@ -953,7 +963,7 @@ mod tests {
     ///
     /// Initially, when all variables are assigned 0, the bounds on `s3` are violated.
     ///
-    fn ex_triangle_hole_infeasible() -> LRASolver<TableauDense> {
+    fn ex_triangle_hole_infeasible() -> LRASolver {
         let basic = vec![
             VarInfo::new(Var::real(1), Owner::Basic(0)).with_bounds(Bounds::below_of(0)),
             VarInfo::new(Var::real(2), Owner::Basic(1)).with_bounds(Bounds::below_of(0)),
@@ -970,7 +980,14 @@ mod tests {
             vec![rbig!(0), rbig!(1)],
             vec![rbig!(-1), rbig!(-1)],
         ];
-        LRASolver::from_eqs(basic, non_basic, equations, ConvContext::default()).unwrap()
+        LRASolver::from_eqs(
+            basic,
+            non_basic,
+            equations,
+            ConvContext::default(),
+            TableauKind::Dense,
+        )
+        .unwrap()
     }
 
     #[test]
@@ -983,13 +1000,16 @@ mod tests {
     #[test]
     fn ex_5_6_update_x() {
         let mut tableau = ex_5_6_tableau();
-        let orig_lltab = tableau.tableau.clone();
+        let TableauImpl::Dense(ref orig_lltab) = tableau.tableau else {
+            panic!("expected Dense tableau");
+        };
+        let orig_lltab = orig_lltab.clone();
 
         // Increase x by 2 and then update the basic variables
         tableau.update(0, &rbig!(2).into());
         assert!(tableau.assert_basic_assignments());
         assert!(tableau.assert_non_basic_in_bounds()); // -inf <= 2 <= inf
-        assert_eq!(orig_lltab, tableau.tableau); // no pivot occurred
+        assert_eq!(TableauImpl::Dense(orig_lltab), tableau.tableau); // no pivot occurred
     }
 
     #[test]
@@ -1011,7 +1031,7 @@ mod tests {
             vec![rbig!(-1), rbig!(3)],
         ];
         let expected_lltab = TableauDense::from_rows(&expected_lldata).unwrap();
-        assert_eq!(solver.tableau, expected_lltab);
+        assert_eq!(solver.tableau, TableauImpl::Dense(expected_lltab));
 
         // Check post pivot_and_update variable assignments
         assert_eq!(solver.variables[0].val, 2.into()); // x
@@ -1039,7 +1059,7 @@ mod tests {
             vec![rbig!(1 / 3), rbig!(1 / 3)],
         ];
         let expected_lltab = TableauDense::from_rows(&expected_lldata).unwrap();
-        assert_eq!(solver.tableau, expected_lltab);
+        assert_eq!(solver.tableau, TableauImpl::Dense(expected_lltab));
 
         // Check post pivot_and_update variable assignments
         assert_eq!(solver.variables[0].val, 1.into()); // x, -inf <= 1 <= +inf
@@ -1067,7 +1087,7 @@ mod tests {
             vec![rbig!(-1), rbig!(3)],
         ];
         let expected_lltab = TableauDense::from_rows(&expected_lldata).unwrap();
-        assert_eq!(solver.tableau, expected_lltab);
+        assert_eq!(solver.tableau, TableauImpl::Dense(expected_lltab));
 
         // Check post pivot_and_update variable assignments
         assert_eq!(solver.variables[0].val, 2.into()); // x

--- a/src/arithmetic/lia/tableau.rs
+++ b/src/arithmetic/lia/tableau.rs
@@ -3,6 +3,8 @@
 
 //! Trait specifying common behavior for low-level tableaux
 
+use crate::arithmetic::lia::tableau_dense::TableauDense;
+use crate::arithmetic::lia::tableau_sparse::TableauSparse;
 use crate::arithmetic::lia::types::Rational;
 use std::error;
 use std::fmt;
@@ -25,6 +27,16 @@ impl From<array2d::Error> for TableauError {
 
 /// Generic result type for tableau operations
 pub type TableauResult<T> = Result<T, TableauError>;
+
+/// Selector for which tableau implementation to use at runtime.
+#[derive(Debug, Clone, Copy)]
+pub enum TableauKind {
+    /// Dense tableau backed by a 2D array
+    Dense,
+    /// Sparse tableau backed by a sparse matrix
+    Sparse,
+}
+
 /// Tableau represents a low level tableau.
 ///
 /// Tableau logically provides a 2d array of rationals that can be pivoted on selected
@@ -34,6 +46,13 @@ pub trait Tableau
 where
     Self: fmt::Debug + Sized,
 {
+    /// Construct a tableau from a vector of (row, col, value) tuples.
+    fn from_tuples(
+        nrows: usize,
+        ncols: usize,
+        t: Vec<(usize, usize, Rational)>,
+    ) -> TableauResult<Self>;
+
     /// Pivoting exchanges a row owning variable for a column owning variable by solving
     /// the row equation for the column variable (forms the new row) and then substituting
     /// all other occurrences of the column variable with the solution.
@@ -46,4 +65,95 @@ where
 
     /// Get an element of the tableau
     fn get(&self, row: usize, col: usize) -> TableauResult<&Rational>;
+
+    /// Return the number of rows in the tableau
+    fn nrows(&self) -> usize;
+
+    /// Return the number of columns in the tableau
+    fn ncols(&self) -> usize;
+}
+
+/// Enum-dispatched tableau that selects between dense and sparse at runtime.
+#[derive(Debug)]
+pub enum TableauImpl {
+    /// Dense tableau variant
+    Dense(TableauDense),
+    /// Sparse tableau variant
+    Sparse(TableauSparse),
+}
+
+/// Equality on tableau is only directly implemented for the Dense variant. To compare sparse
+/// tableau with dense or with each other we convert to dense first. This is potentially expensive
+/// and should only be needed/used in testing.
+impl PartialEq for TableauImpl {
+    fn eq(&self, other: &Self) -> bool {
+        match (self, other) {
+            (TableauImpl::Dense(a), TableauImpl::Dense(b)) => a == b,
+            (TableauImpl::Dense(a), TableauImpl::Sparse(b)) => *a == b.to_dense(),
+            (TableauImpl::Sparse(a), TableauImpl::Dense(b)) => a.to_dense() == *b,
+            (TableauImpl::Sparse(a), TableauImpl::Sparse(b)) => a.to_dense() == b.to_dense(),
+        }
+    }
+}
+
+impl Eq for TableauImpl {}
+
+impl Tableau for TableauImpl {
+    fn from_tuples(
+        nrows: usize,
+        ncols: usize,
+        t: Vec<(usize, usize, Rational)>,
+    ) -> TableauResult<Self> {
+        // Default to dense; use TableauImpl::new() for runtime selection
+        Ok(TableauImpl::Dense(TableauDense::from_tuples(
+            nrows, ncols, t,
+        )?))
+    }
+
+    fn pivot(&mut self, row: usize, col: usize) -> TableauResult<()> {
+        match self {
+            TableauImpl::Dense(t) => t.pivot(row, col),
+            TableauImpl::Sparse(t) => t.pivot(row, col),
+        }
+    }
+
+    fn get(&self, row: usize, col: usize) -> TableauResult<&Rational> {
+        match self {
+            TableauImpl::Dense(t) => t.get(row, col),
+            TableauImpl::Sparse(t) => t.get(row, col),
+        }
+    }
+
+    fn nrows(&self) -> usize {
+        match self {
+            TableauImpl::Dense(t) => t.nrows(),
+            TableauImpl::Sparse(t) => t.nrows(),
+        }
+    }
+
+    fn ncols(&self) -> usize {
+        match self {
+            TableauImpl::Dense(t) => t.ncols(),
+            TableauImpl::Sparse(t) => t.ncols(),
+        }
+    }
+}
+
+impl TableauImpl {
+    /// Construct a TableauImpl of the given kind from tuples.
+    pub fn new(
+        kind: TableauKind,
+        nrows: usize,
+        ncols: usize,
+        t: Vec<(usize, usize, Rational)>,
+    ) -> TableauResult<Self> {
+        match kind {
+            TableauKind::Dense => Ok(TableauImpl::Dense(TableauDense::from_tuples(
+                nrows, ncols, t,
+            )?)),
+            TableauKind::Sparse => Ok(TableauImpl::Sparse(TableauSparse::from_tuples(
+                nrows, ncols, t,
+            )?)),
+        }
+    }
 }

--- a/src/arithmetic/lia/tableau_dense.rs
+++ b/src/arithmetic/lia/tableau_dense.rs
@@ -71,6 +71,14 @@ impl TableauDense {
 }
 
 impl Tableau for TableauDense {
+    fn from_tuples(
+        nrows: usize,
+        ncols: usize,
+        t: Vec<(usize, usize, Rational)>,
+    ) -> TableauResult<Self> {
+        TableauDense::from_tuples(nrows, ncols, t)
+    }
+
     fn pivot(&mut self, row: usize, col: usize) -> TableauResult<()> {
         let a_row_col = &self.data[(row, col)];
         if a_row_col.is_zero() {
@@ -125,6 +133,14 @@ impl Tableau for TableauDense {
         self.data
             .get(row, col)
             .ok_or(TableauError("dense tableau get out of bounds".to_string()))
+    }
+
+    fn nrows(&self) -> usize {
+        self.data.num_rows()
+    }
+
+    fn ncols(&self) -> usize {
+        self.data.num_columns()
     }
 }
 

--- a/src/arithmetic/lia/tableau_sparse.rs
+++ b/src/arithmetic/lia/tableau_sparse.rs
@@ -54,20 +54,29 @@ impl TableauSparse {
     /// Convert this sparse tableau to a dense tableau.
     ///
     /// Used in tests to compare the equivalence of the sparse/dense pivot algorithms.
-    pub fn to_dense(&self) -> TableauResult<TableauDense> {
+    pub fn to_dense(&self) -> TableauDense {
         let mut rows = Vec::with_capacity(self.nrows());
         for row in 0..self.nrows() {
             let mut row_vec = Vec::with_capacity(self.ncols());
             for col in 0..self.ncols() {
-                row_vec.push(self.get(row, col)?.clone());
+                row_vec.push(self.get(row, col).unwrap().clone());
             }
             rows.push(row_vec);
         }
         TableauDense::from_rows(&rows)
+            .expect("sparse tableau maintains invariant that nrows & ncols > 0")
     }
 }
 
 impl Tableau for TableauSparse {
+    fn from_tuples(
+        nrows: usize,
+        ncols: usize,
+        t: Vec<(usize, usize, Rational)>,
+    ) -> TableauResult<Self> {
+        TableauSparse::from_tuples(nrows, ncols, t)
+    }
+
     fn pivot(&mut self, row: usize, col: usize) -> TableauResult<()> {
         self.matrix.pivot(row, col).map_err(|e| TableauError(e.0))
     }
@@ -76,6 +85,14 @@ impl Tableau for TableauSparse {
         self.matrix
             .get(row, col)
             .ok_or_else(|| TableauError(format!("Index out of bounds: ({}, {})", row, col)))
+    }
+
+    fn nrows(&self) -> usize {
+        self.matrix.nrows()
+    }
+
+    fn ncols(&self) -> usize {
+        self.matrix.ncols()
     }
 }
 
@@ -122,7 +139,7 @@ mod tests {
         ];
         let dense = TableauDense::from_tuples(3, 3, tuples.clone()).unwrap();
         let sparse = TableauSparse::from_tuples(3, 3, tuples).unwrap();
-        let converted = sparse.to_dense().unwrap();
+        let converted = sparse.to_dense();
         assert_eq!(dense, converted);
     }
 
@@ -144,7 +161,7 @@ mod tests {
         let mut sparse = TableauSparse::from_tuples(3, 3, tuples).unwrap();
         dense.pivot(0, 0).unwrap();
         sparse.pivot(0, 0).unwrap();
-        let converted = sparse.to_dense().unwrap();
+        let converted = sparse.to_dense();
         assert_eq!(dense, converted);
     }
 
@@ -165,7 +182,7 @@ mod tests {
         let mut sparse = TableauSparse::from_tuples(4, 4, tuples).unwrap();
         dense.pivot(1, 2).unwrap();
         sparse.pivot(1, 2).unwrap();
-        let converted = sparse.to_dense().unwrap();
+        let converted = sparse.to_dense();
         assert_eq!(dense, converted);
     }
 
@@ -188,7 +205,7 @@ mod tests {
         let mut sparse = TableauSparse::from_tuples(10, 10, tuples).unwrap();
         dense.pivot(3, 4).unwrap();
         sparse.pivot(3, 4).unwrap();
-        let converted = sparse.to_dense().unwrap();
+        let converted = sparse.to_dense();
         assert_eq!(dense, converted);
     }
 }


### PR DESCRIPTION

*Description of changes:*

This diff replaces the generic type parameter `T: Tableau` on `LRASolver<T>` and `LIRASolver<T>` with a runtime-dispatched enum `TableauImpl`. This lets the caller choose between dense and sparse
tableau representations at runtime via a `TableauKind` enum, rather than at compile time via generics. The original dense tableau is still the default implementation.

Three existing tests in `linear_system.rs` are duplicated to also run with `TableauKind::Sparse`, verifying the sparse backend produces the same results in those cases.

Replacing `TableauKind::Dense` with `TableauKind::Sparse` in the frontend, regression tests all pass and there is no regression in the number solved with `--arithmetic internal` set.

```
Test Summary:
Total tests: 358
Correct:     339
Incorrect:   0
Timeout:     19
test regression_test ... ok
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
