### PR TITLE
Thread TableauKind through to the LIA solver frontend

### DIFF
--- a/src/arithmetic/lia/frontend.rs
+++ b/src/arithmetic/lia/frontend.rs
@@ -480,18 +480,21 @@ fn convert_terms(terms: &[Term]) -> FrontendResult<ConvContext> {
 }
 
 /// Parse an SMT script and build a QF_LRA solver without preprocessing
-pub fn smt_to_lra_solver(smt_input: &str) -> FrontendResult<LRASolver> {
+pub fn smt_to_lra_solver(smt_input: &str, tableau_kind: TableauKind) -> FrontendResult<LRASolver> {
     let ctx = convert_smt(smt_input)?;
-    Ok(LinearSystem::new(ctx).to_lra_solver(true, TableauKind::Dense)?)
+    Ok(LinearSystem::new(ctx).to_lra_solver(true, tableau_kind)?)
 }
 
 /// Top-level arithmetic solving function
 ///
 /// This provides solving a system of linear (in)equalities over the rationals as a single function
 /// call from SMT-LIB text as input.
-pub fn solve_smtlib(smt_input: &str) -> FrontendResult<SolverDecisionApi> {
+pub fn solve_smtlib(
+    smt_input: &str,
+    tableau_kind: TableauKind,
+) -> FrontendResult<SolverDecisionApi> {
     let ctx = convert_smt(smt_input)?;
-    solve_with_context(ctx)
+    solve_with_context(ctx, tableau_kind)
 }
 
 /// Top-level mixed-integer arithmetic solver
@@ -499,17 +502,23 @@ pub fn solve_smtlib(smt_input: &str) -> FrontendResult<SolverDecisionApi> {
 /// This version accepts a list of arithmetic literals and returns SAT/UNSAT/UNKNOW
 /// as usual. SAT comes with a satisfying assignment and UNSAT comes with a conflict
 /// set which is guaranteed to be a subset of the input literals.
-pub fn solve(arith_literals: &[Term]) -> FrontendResult<SolverDecisionApi> {
+pub fn solve(
+    arith_literals: &[Term],
+    tableau_kind: TableauKind,
+) -> FrontendResult<SolverDecisionApi> {
     // The context is used to construct a solver below, but also to report conflicts
     // and assignments to the outside in terms of [Term]s rather than internal variables.
     // This value is consumed below, but some of the mappings are cloned for reporting.
     let ctx = convert_terms(arith_literals)?;
-    solve_with_context(ctx)
+    solve_with_context(ctx, tableau_kind)
 }
 
-fn solve_with_context(mut ctx: ConvContext) -> FrontendResult<SolverDecisionApi> {
+fn solve_with_context(
+    mut ctx: ConvContext,
+    tableau_kind: TableauKind,
+) -> FrontendResult<SolverDecisionApi> {
     let (_, var_term_map) = ctx.get_term_var_maps(); // this is a clone
-    let decision = solve_ctx_raw(&mut ctx)?;
+    let decision = solve_ctx_raw(&mut ctx, tableau_kind)?;
     Ok(SolverDecisionApi::from_solver_decision(
         &var_term_map,
         decision,
@@ -517,7 +526,10 @@ fn solve_with_context(mut ctx: ConvContext) -> FrontendResult<SolverDecisionApi>
 }
 
 /// Run the solver given the provided context and return the resulting SolverDecision.
-pub fn solve_ctx_raw(ctx: &mut ConvContext) -> FrontendResult<SolverDecision> {
+pub fn solve_ctx_raw(
+    ctx: &mut ConvContext,
+    tableau_kind: TableauKind,
+) -> FrontendResult<SolverDecision> {
     // preprocess the input relations, detect trivial cases, and otherwise return a [LinearSystem]
     // from which to build a solver.
     let result = preprocess(ctx);
@@ -540,7 +552,7 @@ pub fn solve_ctx_raw(ctx: &mut ConvContext) -> FrontendResult<SolverDecision> {
         PreprocessResult::Unknown => LinearSystem::new(ctx.clone()),
     };
     let lra_solver = sys
-        .to_lra_solver(true, TableauKind::Dense)
+        .to_lra_solver(true, tableau_kind)
         .map_err(|e| FrontendError(format!("error building lra_solver: {}", e)))?;
     let mut lira_solver = LIRASolver::new(lra_solver);
     lira_solver
@@ -555,6 +567,7 @@ mod tests {
     use crate::arithmetic::lia::preprocess::{PreprocessResult, preprocess};
     use crate::arithmetic::lia::solver_result::SolverDecision;
     use crate::arithmetic::lia::solver_result_api::SolverDecisionApi;
+    use crate::arithmetic::lia::tableau::TableauKind;
     use crate::arithmetic::lia::types::{DBig, rbig};
     use crate::arithmetic::lia::variables::Var;
     use std::str::FromStr;
@@ -709,7 +722,7 @@ mod tests {
 (check-sat)
     "#;
         assert!(matches!(
-            solve_smtlib(smt).unwrap(),
+            solve_smtlib(smt, TableauKind::Dense).unwrap(),
             SolverDecisionApi::FEASIBLE(_)
         ));
     }
@@ -743,7 +756,7 @@ mod tests {
             unreachable!()
         }
 
-        let result = solve_smtlib(smt_input).expect("solver failed");
+        let result = solve_smtlib(smt_input, TableauKind::Dense).expect("solver failed");
         assert!(matches!(result, SolverDecisionApi::FEASIBLE(_)));
     }
 
@@ -769,7 +782,7 @@ mod tests {
             preprocess(&mut ctx),
             PreprocessResult::TriviallySat
         ));
-        let result = solve_smtlib(smt_input).expect("solver failed");
+        let result = solve_smtlib(smt_input, TableauKind::Dense).expect("solver failed");
         assert!(matches!(result, SolverDecisionApi::FEASIBLE(_)));
     }
 
@@ -794,7 +807,7 @@ mod tests {
             preprocess(&mut ctx),
             PreprocessResult::TriviallyUnsat(_)
         ));
-        let result = solve_smtlib(smt_input).expect("solver failed");
+        let result = solve_smtlib(smt_input, TableauKind::Dense).expect("solver failed");
         assert!(matches!(result, SolverDecisionApi::INFEASIBLE(_)));
     }
 
@@ -823,7 +836,8 @@ mod tests {
 (check-sat)
     "#;
 
-        let mut solver = smt_to_lra_solver(smt_input).expect("Failed to create LRA solver");
+        let mut solver =
+            smt_to_lra_solver(smt_input, TableauKind::Dense).expect("Failed to create LRA solver");
         let result = solver.solve().expect("Failed to run simplex algorithm");
         assert!(matches!(result, SolverDecision::FEASIBLE(_)));
     }
@@ -839,7 +853,8 @@ mod tests {
 (assert (>= (+ x0 x1) 1))
 (check-sat)
     "#;
-        let mut solver = smt_to_lra_solver(smt_input).expect("Failed to create LRA solver");
+        let mut solver =
+            smt_to_lra_solver(smt_input, TableauKind::Dense).expect("Failed to create LRA solver");
         let result = solver.solve().expect("Failed to run simplex algorithm");
         assert!(matches!(result, SolverDecision::INFEASIBLE(_)));
     }
@@ -856,7 +871,8 @@ mod tests {
 (assert (not b))
 (check-sat)
     "#;
-        let mut solver = smt_to_lra_solver(smt_input).expect("Failed to create LRA solver");
+        let mut solver =
+            smt_to_lra_solver(smt_input, TableauKind::Dense).expect("Failed to create LRA solver");
         let result = solver.solve().expect("Failed to run simplex algorithm");
         assert!(matches!(result, SolverDecision::FEASIBLE(_)));
     }
@@ -869,7 +885,8 @@ mod tests {
 (assert (<= (/ x0 2) 0))
 (check-sat)
     "#;
-        let mut solver = smt_to_lra_solver(smt_input).expect("Failed to create LRA solver");
+        let mut solver =
+            smt_to_lra_solver(smt_input, TableauKind::Dense).expect("Failed to create LRA solver");
         let result = solver.solve().expect("Failed to run simplex algorithm");
         assert!(matches!(result, SolverDecision::FEASIBLE(_)));
     }
@@ -882,7 +899,8 @@ mod tests {
 (assert (= x (- 1 2 3)))  ; x = (1 - 2) - 3 = -4
 (check-sat)
     "#;
-        let mut solver = smt_to_lra_solver(smt_input).expect("Failed to create LRA solver");
+        let mut solver =
+            smt_to_lra_solver(smt_input, TableauKind::Dense).expect("Failed to create LRA solver");
         let result = solver.solve().expect("Failed to run simplex algorithm");
         match result {
             SolverDecision::FEASIBLE(model) => {
@@ -902,7 +920,8 @@ mod tests {
 (assert (= x (f x)))
 (check-sat)
     "#;
-        let mut solver = smt_to_lra_solver(smt_input).expect("Failed to create LRA solver");
+        let mut solver =
+            smt_to_lra_solver(smt_input, TableauKind::Dense).expect("Failed to create LRA solver");
         let result = solver.solve().expect("Failed to run simplex algorithm");
         match result {
             SolverDecision::FEASIBLE(model) => {
@@ -924,7 +943,8 @@ mod tests {
 (assert (< i j))
 (check-sat)
     "#;
-        let mut solver = smt_to_lra_solver(smt_input).expect("Failed to create LRA solver");
+        let mut solver =
+            smt_to_lra_solver(smt_input, TableauKind::Dense).expect("Failed to create LRA solver");
         let result = solver.solve().expect("Failed to run simplex algorithm");
         assert!(matches!(result, SolverDecision::FEASIBLE(_)));
     }

--- a/src/arithmetic/lia/lira_solver.rs
+++ b/src/arithmetic/lia/lira_solver.rs
@@ -462,6 +462,7 @@ mod tests {
     use crate::arithmetic::lia::lira_solver::LIRASolver;
     use crate::arithmetic::lia::solver_result::SolverDecision;
     use crate::arithmetic::lia::solver_result_api::SolverDecisionApi;
+    use crate::arithmetic::lia::tableau::TableauKind;
 
     /// Execute branch and bound manually on an UNSAT QF_LIA problem
     #[test]
@@ -475,7 +476,8 @@ mod tests {
         (assert (>= x (/ (to_real 1) (to_real 3))))  ; x >= 1/3
         (assert (<= (to_real y) (/ (to_real 2) (to_real 3))))  ; y <= 2/3
             "#;
-        let mut solver = smt_to_lra_solver(smt_input).expect("Failed to create LRA solver");
+        let mut solver =
+            smt_to_lra_solver(smt_input, TableauKind::Dense).expect("Failed to create LRA solver");
         let ass = match solver.solve().unwrap() {
             SolverDecision::FEASIBLE(ass) => ass,
             _ => unreachable!(),
@@ -542,7 +544,8 @@ mod tests {
         (assert (>= x (/ (to_real 1) (to_real 3))))  ; x >= 1/3
         (assert (<= (to_real y) (/ (to_real 2) (to_real 3))))  ; y <= 2/3
             "#;
-        let lra_solver = smt_to_lra_solver(smt_input).expect("Failed to create LRA solver");
+        let lra_solver =
+            smt_to_lra_solver(smt_input, TableauKind::Dense).expect("Failed to create LRA solver");
         let mut lira_solver = LIRASolver::new(lra_solver);
         assert!(matches!(
             lira_solver.solve(),
@@ -571,7 +574,8 @@ mod tests {
         (check-sat)
         "#;
 
-        let lra_solver = smt_to_lra_solver(smt_input).expect("Failed to create LRA solver");
+        let lra_solver =
+            smt_to_lra_solver(smt_input, TableauKind::Dense).expect("Failed to create LRA solver");
         let mut lira_solver = LIRASolver::new(lra_solver);
 
         // Assert that the system is INFEASIBLE
@@ -637,7 +641,8 @@ mod tests {
         (assert (>= (+ (+ 1 (* (- 1) x)) (+ 1 (* (- 1) y)) (+ 1 (* (- 1) z))) 1))
         "#;
 
-        let lra_solver = smt_to_lra_solver(smt_input).expect("Failed to create LRA solver");
+        let lra_solver =
+            smt_to_lra_solver(smt_input, TableauKind::Dense).expect("Failed to create LRA solver");
         let mut lira_solver = LIRASolver::new(lra_solver);
 
         // Assert that the system is INFEASIBLE
@@ -662,12 +667,12 @@ mod tests {
         (check-sat)
         "#;
         // first 3 constraints are sat
-        let result = solve_smtlib(smt1).expect("solver failed");
+        let result = solve_smtlib(smt1, TableauKind::Dense).expect("solver failed");
         assert!(matches!(result, SolverDecisionApi::FEASIBLE(_)));
 
         // all 4 constraints are sat
         let smt2 = smt1.to_string() + "(assert (> (- (* 7 x) (* 9 y)) 4))";
-        let result2 = solve_smtlib(&smt2).expect("solver failed");
+        let result2 = solve_smtlib(&smt2, TableauKind::Dense).expect("solver failed");
         assert!(matches!(result2, SolverDecisionApi::FEASIBLE(_)));
 
         // now prove validity
@@ -679,7 +684,7 @@ mod tests {
         // forall (x y: Int) -(C1 and C2 and C3) or C4
         // negate: exists (x y: Int) (C1 and ... and C3) and (-C4)
         let smt3 = smt1.to_string() + "(assert (not (> (- (* 7 x) (* 9 y)) 4)))";
-        let result3 = solve_smtlib(&smt3).expect("solver failed");
+        let result3 = solve_smtlib(&smt3, TableauKind::Dense).expect("solver failed");
         assert!(matches!(result3, SolverDecisionApi::INFEASIBLE(_)));
     }
 
@@ -694,7 +699,7 @@ mod tests {
         (assert (not (>= (+ (* 2 a) b) (+ b a a))))
         (check-sat)
         "#;
-        let result = solve_smtlib(smt).expect("solver failed");
+        let result = solve_smtlib(smt, TableauKind::Dense).expect("solver failed");
         assert!(matches!(result, SolverDecisionApi::INFEASIBLE(_)),);
         if let SolverDecisionApi::INFEASIBLE(conflict) = result {
             assert_eq!(conflict.len(), 1);
@@ -715,7 +720,7 @@ mod tests {
         (assert (not (<= (* 2 a) (* 3 c))))
         (check-sat)
         "#;
-        let result = solve_smtlib(smt).expect("solver failed");
+        let result = solve_smtlib(smt, TableauKind::Dense).expect("solver failed");
         assert!(matches!(result, SolverDecisionApi::INFEASIBLE(_)),);
         if let SolverDecisionApi::INFEASIBLE(conflict) = result {
             assert_eq!(conflict.len(), 3); // every subset of 2 assertions is feasible
@@ -748,7 +753,7 @@ mod tests {
         (assert (< (+ a b (* 3.0 c) d (* 2.0 e)) 0.0))  ; x
         (check-sat)
         "#;
-        let result = solve_smtlib(smt).expect("solver failed");
+        let result = solve_smtlib(smt, TableauKind::Dense).expect("solver failed");
         assert!(matches!(result, SolverDecisionApi::INFEASIBLE(_)),);
         if let SolverDecisionApi::INFEASIBLE(conflict) = result {
             assert_eq!(conflict.len(), 6);
@@ -772,7 +777,7 @@ mod tests {
         (assert (< (+ a b (* 3.0 c) d (* 2.0 e)) 0.0))  ; x
         (check-sat)
         "#;
-        let result = solve_smtlib(smt_conflict).expect("solver failed");
+        let result = solve_smtlib(smt_conflict, TableauKind::Dense).expect("solver failed");
         assert!(matches!(result, SolverDecisionApi::INFEASIBLE(_)),);
 
         // Sanity check that the conflict is minimal; not a proof of such, just
@@ -792,7 +797,7 @@ mod tests {
         (assert (< (+ a b (* 3.0 c) d (* 2.0 e)) 0.0))  ; x
         (check-sat)
         "#;
-        let result = solve_smtlib(smt_conflict).expect("solver failed");
+        let result = solve_smtlib(smt_conflict, TableauKind::Dense).expect("solver failed");
         assert!(matches!(result, SolverDecisionApi::FEASIBLE(_)),);
     }
 
@@ -812,7 +817,7 @@ mod tests {
         (assert (< (- b) 1))
         (check-sat)
         "#;
-        let result = solve_smtlib(smt).expect("solver failed");
+        let result = solve_smtlib(smt, TableauKind::Dense).expect("solver failed");
         assert!(matches!(result, SolverDecisionApi::INFEASIBLE(_)),);
         if let SolverDecisionApi::INFEASIBLE(conflict) = result {
             assert_eq!(conflict.len(), 2);
@@ -829,7 +834,7 @@ mod tests {
         (assert (= (* 2 x) 3))
         (check-sat)
         "#;
-        let result = solve_smtlib(smt).expect("solver failed");
+        let result = solve_smtlib(smt, TableauKind::Dense).expect("solver failed");
         assert!(matches!(result, SolverDecisionApi::FEASIBLE(_)),);
         if let SolverDecisionApi::FEASIBLE(assg) = result {
             let (_, val) = assg.iter().next().unwrap();

--- a/src/arithmetic/lialp.rs
+++ b/src/arithmetic/lialp.rs
@@ -7,6 +7,7 @@ use crate::arithmetic::lia::context::ConvContext;
 use crate::arithmetic::lia::frontend;
 use crate::arithmetic::lia::linear_system::{Mon, Rel};
 use crate::arithmetic::lia::solver_result::SolverDecision;
+use crate::arithmetic::lia::tableau::TableauKind;
 use crate::arithmetic::lia::variables::{Var, VarType};
 use crate::arithmetic::lp::{
     ArithResult, Coefficient, FunctionType::*, extract_linear_constraints,
@@ -93,7 +94,7 @@ pub fn check_integer_constraints_satisfiable_lia(
         slack_to_lits.insert(slack, lits);
     }
 
-    match frontend::solve_ctx_raw(&mut ctx) {
+    match frontend::solve_ctx_raw(&mut ctx, TableauKind::Dense) {
         Ok(SolverDecision::FEASIBLE(assignment)) => {
             let mut model_hashmap: DeterministicHashMap<i64, DeterministicHashSet<u64>> =
                 DeterministicHashMap::new();


### PR DESCRIPTION
*Description of changes:*

The `TableauKind` parameter is threaded all the way from the public API down through `solve_with_context → solve_ctx_raw → LinearSystem::to_lra_solver → LRASolver::from_eqs → TableauImpl::new`
. Callers can now request either `TableauKind::Dense` or `TableauKind::Sparse`.


All five public/internal functions now accept an argument `tableau_kind: TableauKind`:

- smt_to_lra_solver(smt_input, tableau_kind) — builds an LRASolver from SMT text
- solve_smtlib(smt_input, tableau_kind) — top-level SMT solving
- solve(arith_literals, tableau_kind) — top-level from Terms                                                                                                                             
- solve_with_context(ctx, tableau_kind) — internal helper                                                                                                                                
- solve_ctx_raw(ctx, tableau_kind) — public raw solver entry point                                                                                                                 
- All test call sites that previously used the default are now updated to pass `TableauKind::Dense`.



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
