### PR TITLE
Implements better datastructures and faster implementation of union_predecessors

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ serde_json = "1.0"
 slotmap = "^1.0"
 z3 = { version = "0.19.8", optional = true }
 num = "0.4.3"
+rustc-hash = "2.0"
 
 [dev-dependencies]
 serde_json = "1.0"

--- a/src/egraphs/congruence_closure.rs
+++ b/src/egraphs/congruence_closure.rs
@@ -14,9 +14,7 @@ use yaspar_ir::ast::{
 };
 
 use crate::debug_println;
-use crate::egraphs::datastructures::{
-    Assertion, CanonicalOp, ConstructorType::*, DisequalTerm, Predecessor,
-};
+use crate::egraphs::datastructures::{Assertion, ConstructorType::*, DisequalTerm, Predecessor};
 use crate::egraphs::egraph::Egraph;
 use crate::egraphs::unionfind::ProofTracker;
 use crate::log::is_important;
@@ -1110,19 +1108,6 @@ fn union_predecessors(
     // you fix it, but then you compare to a for loop iterating through all terms in v and iteratively
     // computing the canonical_term_v, but this could change as you are iterating through the loop
     // so we want to precompute the canonical terms of v.
-    // Owned tuples here so we can restore predecessors_v before union_process_assignment
-    // runs (which can re-enter and read egraph.predecessors[v]).
-    // Precompute canonical forms for v's predecessors. Only store the key
-    // and the canonical form — predecessor data is looked up from the egraph
-    // later (after predecessors_v is restored), avoiding a Predecessor clone
-    // per entry.
-    let mut predecessor_v_canonical_forms: Vec<(u64, Option<(Vec<u64>, CanonicalOp, Vec<u64>)>)> =
-        Vec::with_capacity(predecessors_v.len());
-    for (pred_v_key, predecessor_v) in predecessors_v.iter() {
-        let canonical_form = egraph.get_canonical_form(predecessor_v.predecessor, level);
-        predecessor_v_canonical_forms.push((*pred_v_key, canonical_form));
-    }
-
     // moving predecessors from v to u
     for (pred_key, pred_val) in predecessors_v.iter() {
         debug_println!(
@@ -1144,26 +1129,33 @@ fn union_predecessors(
         egraph.add_predecessor(u, *pred_key, new_pred);
     }
 
-    // Restore v before the recursive union_process_assignment calls below.
+    // Restore v before the consuming loop — union_process_assignment can
+    // re-enter and read/write egraph.predecessors[v].
     egraph.predecessors[v as usize] = predecessors_v;
 
-    for (pred_v_key, canonical_form_v) in predecessor_v_canonical_forms {
-        // Look up the predecessor from the restored v slot instead of cloning earlier.
-        let predecessor_v = match egraph.predecessors[v as usize].get(&pred_v_key) {
-            Some(p) => p.clone(),
-            None => continue, // removed by a prior iteration
-        };
-        if !egraph.valid_hash(predecessor_v.hash, predecessor_v.level) {
+    // Collect just the keys (Vec<u64>) so we can iterate without holding a
+    // borrow on egraph. Predecessor data and canonical forms are looked up
+    // inline — get_canonical_form is &self so no precomputation needed.
+    let predecessor_v_keys: Vec<u64> = egraph.predecessors[v as usize].keys().copied().collect();
+
+    for pred_v_key in predecessor_v_keys {
+        // Extract only the scalar fields we need — no Predecessor clone.
+        let (pred_hash, pred_level, pred_predecessor, pred_inner_term) =
+            match egraph.predecessors[v as usize].get(&pred_v_key) {
+                Some(p) => (p.hash, p.level, p.predecessor, p.inner_term),
+                None => continue, // removed by a prior iteration
+            };
+        if !egraph.valid_hash(pred_hash, pred_level) {
             debug_println!(
                 11,
                 5,
                 "Skipping predecessor {} of {} [original: {}] as it has hash {} at level {} and correct hash is {}",
-                egraph.get_term(predecessor_v.predecessor),
+                egraph.get_term(pred_predecessor),
                 egraph.get_term(v),
-                egraph.get_term(predecessor_v.inner_term),
-                predecessor_v.hash,
-                predecessor_v.level,
-                egraph.predecessor_level[predecessor_v.level]
+                egraph.get_term(pred_inner_term),
+                pred_hash,
+                pred_level,
+                egraph.predecessor_level[pred_level]
             );
             debug_println!(
                 11,
@@ -1179,23 +1171,12 @@ fn union_predecessors(
             11,
             3,
             "L. We are in union_predecessors trying to get term for {}",
-            egraph.get_term(predecessor_v.predecessor)
+            egraph.get_term(pred_predecessor)
         );
 
-        // checking if the ite leads to a contradiction
-        // if let Some(negated_model) =
-        //     union_process_ite(&egraph.get_term(predecessor_v.predecessor), egraph, level, from_quantifier)
-        // {
-        //      debug_println!(
-        //         11,
-        //         4,
-        //         "N. [exiting union_pred] of {} andn {} Contradiction found in union_predecessors, we have the following negated_model: {:?}",
-        //         egraph.get_term(u),
-        //         egraph.get_term(v),
-        //         negated_model
-        //     );
-        //     return Some(negated_model);
-        // }
+        // Compute canonical form inline — no precomputation needed since
+        // get_canonical_form is &self.
+        let canonical_form_v = egraph.get_canonical_form(pred_predecessor, level);
 
         if let Some((original_subterms, func, roots)) = canonical_form_v {
             let canonical_form = (func, roots);
@@ -1204,7 +1185,7 @@ fn union_predecessors(
                 6,
                 "3. We are in union_predecessors for v and have canonical form {:?} for {}",
                 canonical_form,
-                egraph.get_term(predecessor_v.predecessor)
+                egraph.get_term(pred_predecessor)
             );
             if let Some(u_forms) = canonical_forms_u.get(&canonical_form) {
                 debug_println!(5, 0, "We have the following u_forms {:?}", u_forms);
@@ -1214,7 +1195,7 @@ fn union_predecessors(
                         0,
                         "We are actually merging the two predecessors {} and {}",
                         egraph.get_term(*canonical_form_u),
-                        egraph.get_term(predecessor_v.predecessor)
+                        egraph.get_term(pred_predecessor)
                     );
                     if is_important(16) {
                         debug_println!(16, 0, "We have u_original_subterms: ");
@@ -1248,7 +1229,7 @@ fn union_predecessors(
                         // u_original,
                         // v_original,
                         *canonical_form_u,
-                        predecessor_v.predecessor,
+                        pred_predecessor,
                         egraph,
                         proof_parent,
                         level,

--- a/src/egraphs/congruence_closure.rs
+++ b/src/egraphs/congruence_closure.rs
@@ -5,7 +5,9 @@
 
 use crate::datatypes::axioms::{learn_ctor_selector_clauses, learn_or_not_term_tester_term};
 use crate::egraphs::proofforest::ProofForestEdge;
-use crate::utils::{DeterministicHashMap, DeterministicHashSet, fmt_termlist};
+use crate::utils::{
+    DeterministicHashMap, DeterministicHashSet, FastDeterministicHashMap, fmt_termlist,
+};
 use yaspar_ir::ast::alg::CheckIdentifier;
 use yaspar_ir::ast::{
     FetchSort, HasArena, IdentifierKind, Monomorphization, Repr, Term, TermAllocator,
@@ -1022,29 +1024,35 @@ fn union_predecessors(
         )
     );
 
-    let predecessors_u = egraph.predecessors[u as usize].clone();
-    let predecessors_v = egraph.predecessors[v as usize].clone();
+    // Move u's and v's predecessor maps out of the egraph so we can iterate
+    // without cloning. Both slots are restored before any re-entrant call
+    // (add_predecessor / union_process_assignment) can observe them.
+    let mut predecessors_u = std::mem::take(&mut egraph.predecessors[u as usize]);
+    let predecessors_v = std::mem::take(&mut egraph.predecessors[v as usize]);
 
-    let mut canonical_forms_u: DeterministicHashMap<_, Vec<(Vec<u64>, u64)>> =
-        DeterministicHashMap::default();
+    let mut canonical_forms_u: FastDeterministicHashMap<_, Vec<(Vec<u64>, u64)>> =
+        FastDeterministicHashMap::default();
 
-    // BTreeMap already provides deterministic iteration order
-    for (pred_u_key, predecessor_u) in predecessors_u.iter() {
-        if !egraph.valid_hash(predecessor_u.hash, predecessor_u.level) {
+    // Stale entries are dropped in-place via retain before iterating.
+    predecessors_u.retain(|_, p| {
+        let keep = egraph.valid_hash(p.hash, p.level);
+        if !keep {
             debug_println!(
                 11,
                 2,
                 "CANONICAL_FORMS_U: Skipping predecessor {} of {} [original: {}] as it has hash {} at level {} and correct hash is {}",
-                egraph.get_term(predecessor_u.predecessor),
+                egraph.get_term(p.predecessor),
                 egraph.get_term(u),
-                egraph.get_term(predecessor_u.inner_term),
-                predecessor_u.hash,
-                predecessor_u.level,
-                egraph.predecessor_level[predecessor_u.level]
+                egraph.get_term(p.inner_term),
+                p.hash,
+                p.level,
+                egraph.predecessor_level[p.level]
             );
-            egraph.predecessors[u as usize].remove(pred_u_key);
-            continue;
         }
+        keep
+    });
+
+    for (_pred_u_key, predecessor_u) in predecessors_u.iter() {
         debug_println!(
             11,
             2,
@@ -1093,28 +1101,28 @@ fn union_predecessors(
         canonical_forms_u
     );
 
+    // Restore u's slot before calling add_predecessor below, which writes to it.
+    egraph.predecessors[u as usize] = predecessors_u;
+
     // basically the issue was that in `union_predecessors` when you create a `canonical_term_u`,
     // you fix it, but then you compare to a for loop iterating through all terms in v and iteratively
     // computing the canonical_term_v, but this could change as you are iterating through the loop
-    // so we want to precompute the canonical terms of v
-    let predecessor_v_canonical_forms = predecessors_v
-        .iter()
-        .map(|(pred_v_key, predecessor_v)| {
-            (
-                pred_v_key,
-                predecessor_v,
-                egraph.get_canonical_form(predecessor_v.predecessor, level),
-            )
-        })
-        .collect::<Vec<_>>();
+    // so we want to precompute the canonical terms of v.
+    // Owned tuples here so we can restore predecessors_v before union_process_assignment
+    // runs (which can re-enter and read egraph.predecessors[v]).
+    let mut predecessor_v_canonical_forms = Vec::with_capacity(predecessors_v.len());
+    for (pred_v_key, predecessor_v) in predecessors_v.iter() {
+        let canonical_form = egraph.get_canonical_form(predecessor_v.predecessor, level);
+        predecessor_v_canonical_forms.push((*pred_v_key, predecessor_v.clone(), canonical_form));
+    }
 
     // moving predecessors from v to u
-    for (pred_key, pred_val) in predecessors_v.clone() {
+    for (pred_key, pred_val) in predecessors_v.iter() {
         debug_println!(
             11,
             0,
             "We are are adding predecessor {} (of  {}) to {} [level: {}, hash: {}]",
-            egraph.get_term(pred_key),
+            egraph.get_term(*pred_key),
             egraph.get_term(pred_val.inner_term),
             egraph.get_term(u),
             level,
@@ -1123,11 +1131,14 @@ fn union_predecessors(
         let new_pred = Predecessor {
             level,
             hash: egraph.predecessor_hash,
-            predecessor: pred_key,
+            predecessor: *pred_key,
             inner_term: pred_val.inner_term,
         };
-        egraph.add_predecessor(u, pred_key, new_pred);
+        egraph.add_predecessor(u, *pred_key, new_pred);
     }
+
+    // Restore v before the recursive union_process_assignment calls below.
+    egraph.predecessors[v as usize] = predecessors_v;
 
     for (pred_v_key, predecessor_v, canonical_form_v) in predecessor_v_canonical_forms {
         if !egraph.valid_hash(predecessor_v.hash, predecessor_v.level) {
@@ -1149,7 +1160,7 @@ fn union_predecessors(
                 level,
                 egraph.predecessor_hash
             );
-            egraph.predecessors[v as usize].remove(pred_v_key);
+            egraph.predecessors[v as usize].remove(&pred_v_key);
             continue;
         }
         debug_println!(

--- a/src/egraphs/congruence_closure.rs
+++ b/src/egraphs/congruence_closure.rs
@@ -14,7 +14,9 @@ use yaspar_ir::ast::{
 };
 
 use crate::debug_println;
-use crate::egraphs::datastructures::{Assertion, ConstructorType::*, DisequalTerm, Predecessor};
+use crate::egraphs::datastructures::{
+    Assertion, CanonicalOp, ConstructorType::*, DisequalTerm, Predecessor,
+};
 use crate::egraphs::egraph::Egraph;
 use crate::egraphs::unionfind::ProofTracker;
 use crate::log::is_important;
@@ -1110,10 +1112,15 @@ fn union_predecessors(
     // so we want to precompute the canonical terms of v.
     // Owned tuples here so we can restore predecessors_v before union_process_assignment
     // runs (which can re-enter and read egraph.predecessors[v]).
-    let mut predecessor_v_canonical_forms = Vec::with_capacity(predecessors_v.len());
+    // Precompute canonical forms for v's predecessors. Only store the key
+    // and the canonical form — predecessor data is looked up from the egraph
+    // later (after predecessors_v is restored), avoiding a Predecessor clone
+    // per entry.
+    let mut predecessor_v_canonical_forms: Vec<(u64, Option<(Vec<u64>, CanonicalOp, Vec<u64>)>)> =
+        Vec::with_capacity(predecessors_v.len());
     for (pred_v_key, predecessor_v) in predecessors_v.iter() {
         let canonical_form = egraph.get_canonical_form(predecessor_v.predecessor, level);
-        predecessor_v_canonical_forms.push((*pred_v_key, predecessor_v.clone(), canonical_form));
+        predecessor_v_canonical_forms.push((*pred_v_key, canonical_form));
     }
 
     // moving predecessors from v to u
@@ -1140,7 +1147,12 @@ fn union_predecessors(
     // Restore v before the recursive union_process_assignment calls below.
     egraph.predecessors[v as usize] = predecessors_v;
 
-    for (pred_v_key, predecessor_v, canonical_form_v) in predecessor_v_canonical_forms {
+    for (pred_v_key, canonical_form_v) in predecessor_v_canonical_forms {
+        // Look up the predecessor from the restored v slot instead of cloning earlier.
+        let predecessor_v = match egraph.predecessors[v as usize].get(&pred_v_key) {
+            Some(p) => p.clone(),
+            None => continue, // removed by a prior iteration
+        };
         if !egraph.valid_hash(predecessor_v.hash, predecessor_v.level) {
             debug_println!(
                 11,

--- a/src/egraphs/congruence_closure.rs
+++ b/src/egraphs/congruence_closure.rs
@@ -1113,11 +1113,18 @@ fn union_predecessors(
     //
     // Precompute: store (key, predecessor_id, canonical_form) per entry.
     // No Predecessor clone — just the scalar `predecessor` field needed downstream.
-    let mut predecessor_v_canonical_forms: Vec<(u64, u64, Option<(Vec<u64>, CanonicalOp, Vec<u64>)>)> =
-        Vec::with_capacity(predecessors_v.len());
+    let mut predecessor_v_canonical_forms: Vec<(
+        u64,
+        u64,
+        Option<(Vec<u64>, CanonicalOp, Vec<u64>)>,
+    )> = Vec::with_capacity(predecessors_v.len());
     for (pred_v_key, predecessor_v) in predecessors_v.iter() {
         let canonical_form = egraph.get_canonical_form(predecessor_v.predecessor, level);
-        predecessor_v_canonical_forms.push((*pred_v_key, predecessor_v.predecessor, canonical_form));
+        predecessor_v_canonical_forms.push((
+            *pred_v_key,
+            predecessor_v.predecessor,
+            canonical_form,
+        ));
     }
 
     // moving predecessors from v to u

--- a/src/egraphs/congruence_closure.rs
+++ b/src/egraphs/congruence_closure.rs
@@ -459,7 +459,7 @@ fn leastcommonancestor_helper(
     let mut path_from_u = vec![];
     let mut curr = u;
 
-    if indent > 100 {
+    if indent > 1000 {
         debug_println!(11, 0, "We have the proof forest :{}", egraph);
         panic!("Should not have this many recusive calls to LCH");
     }

--- a/src/egraphs/congruence_closure.rs
+++ b/src/egraphs/congruence_closure.rs
@@ -17,7 +17,7 @@ use crate::debug_println;
 use crate::egraphs::datastructures::{
     Assertion, CanonicalOp, ConstructorType::*, DisequalTerm, Predecessor,
 };
-use crate::egraphs::egraph::Egraph;
+use crate::egraphs::egraph::{Egraph, valid_hash};
 use crate::egraphs::unionfind::ProofTracker;
 use crate::log::is_important;
 use yaspar_ir::ast::ATerm::*;
@@ -131,7 +131,7 @@ pub fn process_assignment(
                     tester_term,
                     hash,
                     level,
-                } if egraph.valid_hash(*hash, *level) => {
+                } if valid_hash(*hash, *level, &egraph.predecessor_level) => {
                     debug_println!(
                         11,
                         2,
@@ -461,7 +461,8 @@ fn leastcommonancestor_helper(
     let mut path_from_u = vec![];
     let mut curr = u;
 
-    if indent > 1000 {
+    let max_recursion_depth = 100;
+    if indent > max_recursion_depth {
         debug_println!(11, 0, "We have the proof forest :{}", egraph);
         panic!("Should not have this many recusive calls to LCH");
     }
@@ -1026,6 +1027,10 @@ fn union_predecessors(
         )
     );
 
+    debug_assert!(u != v);
+    debug_assert!(egraph.find(u) == u);
+    debug_assert!(egraph.find(v) == v);
+
     // Move u's and v's predecessor maps out of the egraph so we can iterate
     // without cloning. Both slots are restored before any re-entrant call
     // (add_predecessor / union_process_assignment) can observe them.
@@ -1037,7 +1042,7 @@ fn union_predecessors(
 
     // Stale entries are dropped in-place via retain before iterating.
     predecessors_u.retain(|_, p| {
-        let keep = egraph.valid_hash(p.hash, p.level);
+        let keep = valid_hash(p.hash, p.level, &egraph.predecessor_level);
         if !keep {
             debug_println!(
                 11,
@@ -1160,7 +1165,7 @@ fn union_predecessors(
                 Some(p) => (p.hash, p.level, p.inner_term),
                 None => continue, // removed by a prior iteration
             };
-        if !egraph.valid_hash(pred_hash, pred_level) {
+        if !valid_hash(pred_hash, pred_level, &egraph.predecessor_level) {
             debug_println!(
                 11,
                 5,
@@ -1416,7 +1421,7 @@ pub fn proof_forest_backtrack(
     // we are adding disequalities from the "parent" edge to the child
     let mut new_disequalities = DeterministicHashMap::new();
     for (k, v) in child_edge.disequalities().iter() {
-        if egraph.valid_hash(v.hash, v.level) {
+        if valid_hash(v.hash, v.level, &egraph.predecessor_level) {
             debug_println!(11, 0, "Keeping disequality {}: {} in {}", k, v, child);
             new_disequalities.insert(*k, v.clone());
         } else {

--- a/src/egraphs/congruence_closure.rs
+++ b/src/egraphs/congruence_closure.rs
@@ -14,7 +14,9 @@ use yaspar_ir::ast::{
 };
 
 use crate::debug_println;
-use crate::egraphs::datastructures::{Assertion, ConstructorType::*, DisequalTerm, Predecessor};
+use crate::egraphs::datastructures::{
+    Assertion, CanonicalOp, ConstructorType::*, DisequalTerm, Predecessor,
+};
 use crate::egraphs::egraph::Egraph;
 use crate::egraphs::unionfind::ProofTracker;
 use crate::log::is_important;
@@ -1108,6 +1110,16 @@ fn union_predecessors(
     // you fix it, but then you compare to a for loop iterating through all terms in v and iteratively
     // computing the canonical_term_v, but this could change as you are iterating through the loop
     // so we want to precompute the canonical terms of v.
+    //
+    // Precompute: store (key, predecessor_id, canonical_form) per entry.
+    // No Predecessor clone — just the scalar `predecessor` field needed downstream.
+    let mut predecessor_v_canonical_forms: Vec<(u64, u64, Option<(Vec<u64>, CanonicalOp, Vec<u64>)>)> =
+        Vec::with_capacity(predecessors_v.len());
+    for (pred_v_key, predecessor_v) in predecessors_v.iter() {
+        let canonical_form = egraph.get_canonical_form(predecessor_v.predecessor, level);
+        predecessor_v_canonical_forms.push((*pred_v_key, predecessor_v.predecessor, canonical_form));
+    }
+
     // moving predecessors from v to u
     for (pred_key, pred_val) in predecessors_v.iter() {
         debug_println!(
@@ -1133,16 +1145,12 @@ fn union_predecessors(
     // re-enter and read/write egraph.predecessors[v].
     egraph.predecessors[v as usize] = predecessors_v;
 
-    // Collect just the keys (Vec<u64>) so we can iterate without holding a
-    // borrow on egraph. Predecessor data and canonical forms are looked up
-    // inline — get_canonical_form is &self so no precomputation needed.
-    let predecessor_v_keys: Vec<u64> = egraph.predecessors[v as usize].keys().copied().collect();
-
-    for pred_v_key in predecessor_v_keys {
-        // Extract only the scalar fields we need — no Predecessor clone.
-        let (pred_hash, pred_level, pred_predecessor, pred_inner_term) =
+    for (pred_v_key, pred_predecessor, canonical_form_v) in predecessor_v_canonical_forms {
+        // Look up the predecessor's validity from the restored v slot.
+        // Extract only scalar fields — no Predecessor clone.
+        let (pred_hash, pred_level, pred_inner_term) =
             match egraph.predecessors[v as usize].get(&pred_v_key) {
-                Some(p) => (p.hash, p.level, p.predecessor, p.inner_term),
+                Some(p) => (p.hash, p.level, p.inner_term),
                 None => continue, // removed by a prior iteration
             };
         if !egraph.valid_hash(pred_hash, pred_level) {
@@ -1173,10 +1181,6 @@ fn union_predecessors(
             "L. We are in union_predecessors trying to get term for {}",
             egraph.get_term(pred_predecessor)
         );
-
-        // Compute canonical form inline — no precomputation needed since
-        // get_canonical_form is &self.
-        let canonical_form_v = egraph.get_canonical_form(pred_predecessor, level);
 
         if let Some((original_subterms, func, roots)) = canonical_form_v {
             let canonical_form = (func, roots);

--- a/src/egraphs/congruence_closure.rs
+++ b/src/egraphs/congruence_closure.rs
@@ -15,7 +15,7 @@ use yaspar_ir::ast::{
 
 use crate::debug_println;
 use crate::egraphs::datastructures::{
-    Assertion, CanonicalOp, ConstructorType::*, DisequalTerm, Predecessor,
+    Assertion, CanonicalForm, ConstructorType::*, DisequalTerm, Predecessor,
 };
 use crate::egraphs::egraph::{Egraph, valid_hash};
 use crate::egraphs::unionfind::ProofTracker;
@@ -1080,10 +1080,13 @@ fn union_predecessors(
         //     return Some(negated_model);
         // }
 
-        if let Some((original_subterms, func, roots)) =
-            egraph.get_canonical_form(predecessor_u.predecessor, level)
+        if let Some(CanonicalForm {
+            original_subterms,
+            op,
+            canonical_subterms,
+        }) = egraph.get_canonical_form(predecessor_u.predecessor, level)
         {
-            let canonical_form = (func, roots);
+            let canonical_form = (op, canonical_subterms);
             debug_println!(
                 11,
                 4,
@@ -1118,11 +1121,8 @@ fn union_predecessors(
     //
     // Precompute: store (key, predecessor_id, canonical_form) per entry.
     // No Predecessor clone — just the scalar `predecessor` field needed downstream.
-    let mut predecessor_v_canonical_forms: Vec<(
-        u64,
-        u64,
-        Option<(Vec<u64>, CanonicalOp, Vec<u64>)>,
-    )> = Vec::with_capacity(predecessors_v.len());
+    let mut predecessor_v_canonical_forms: Vec<(u64, u64, Option<CanonicalForm>)> =
+        Vec::with_capacity(predecessors_v.len());
     for (pred_v_key, predecessor_v) in predecessors_v.iter() {
         let canonical_form = egraph.get_canonical_form(predecessor_v.predecessor, level);
         predecessor_v_canonical_forms.push((
@@ -1194,8 +1194,13 @@ fn union_predecessors(
             egraph.get_term(pred_predecessor)
         );
 
-        if let Some((original_subterms, func, roots)) = canonical_form_v {
-            let canonical_form = (func, roots);
+        if let Some(CanonicalForm {
+            original_subterms,
+            op,
+            canonical_subterms,
+        }) = canonical_form_v
+        {
+            let canonical_form = (op, canonical_subterms);
             debug_println!(
                 11,
                 6,

--- a/src/egraphs/datastructures.rs
+++ b/src/egraphs/datastructures.rs
@@ -4,7 +4,7 @@
 //! Important datastructures that are used elsewhere
 use std::{cmp::Ordering, fmt};
 
-use yaspar_ir::ast::{Str, Term};
+use yaspar_ir::ast::{QualifiedIdentifier, Str, Term};
 
 /// Keeps track of disequalities used between multiple terms
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -24,6 +24,21 @@ impl fmt::Display for DisequalTerm {
             self.term, self.level, self.hash, self.original_disequality
         )
     }
+}
+
+/// Identifies the "operator" of a canonical term form for the purposes of
+/// congruence-closure lookup. Replaces a previous `String`-based encoding.
+///
+/// For App terms, carries the full `QualifiedIdentifier` (symbol + indices +
+/// optional sort), which is required to distinguish polymorphic constructor
+/// instances like `(as nil (List Int))` vs `(as nil (List Bool))`. Hashing
+/// and equality are cheap because the inner `Str` and `Sort` types are
+/// hash-consed and hash/compare by uid.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub enum CanonicalOp {
+    App(QualifiedIdentifier),
+    Eq,
+    Ite,
 }
 
 /// Represents a predecessor of a term

--- a/src/egraphs/datastructures.rs
+++ b/src/egraphs/datastructures.rs
@@ -41,6 +41,24 @@ pub enum CanonicalOp {
     Ite,
 }
 
+/// The canonical form of a term, produced by `Egraph::get_canonical_form`.
+///
+/// Represents how the term looks after walking each subterm's union-find root,
+/// which is what congruence closure uses to detect "same operator, same
+/// equivalent arguments" matches between two terms.
+#[derive(Debug, Clone)]
+pub struct CanonicalForm {
+    /// Raw uids of the term's subterms (not canonicalized). Used to build
+    /// pairwise term equalities for the congruence proof.
+    pub original_subterms: Vec<u64>,
+    /// The operator (function name / Eq / Ite).
+    pub op: CanonicalOp,
+    /// The union-find roots of each subterm. Together with `op` these form
+    /// the congruence key — two terms with the same `op` and `canonical_subterms`
+    /// must be equal by congruence.
+    pub canonical_subterms: Vec<u64>,
+}
+
 /// Represents a predecessor of a term
 #[derive(Debug, PartialEq, Eq, Hash, Clone)]
 pub struct Predecessor {

--- a/src/egraphs/egraph.rs
+++ b/src/egraphs/egraph.rs
@@ -352,7 +352,6 @@ impl Egraph {
             TermOption::None => panic!("called `get_term_ref` on a None value"),
         }
     }
-    
 
     pub fn get_term_safe(&self, num: u64) -> TermOption {
         if self.terms_list.len() <= num as usize {
@@ -442,8 +441,10 @@ impl Egraph {
                     children: DeterministicHashSet::new(),
                 },
             );
-            self.predecessors
-                .resize(self.predecessors.len() * 2, FastDeterministicHashMap::default());
+            self.predecessors.resize(
+                self.predecessors.len() * 2,
+                FastDeterministicHashMap::default(),
+            );
         }
 
         // if this has already been inserted, then we don't need to do anything
@@ -613,8 +614,10 @@ impl Egraph {
                     children: DeterministicHashSet::new(),
                 },
             );
-            self.predecessors
-                .resize(self.predecessors.len() * 2, FastDeterministicHashMap::default());
+            self.predecessors.resize(
+                self.predecessors.len() * 2,
+                FastDeterministicHashMap::default(),
+            );
         }
 
         // if this has already been inserted, then we don't need to do anything
@@ -1310,15 +1313,12 @@ impl Egraph {
                     (uids, CanonicalOp::App(func.clone()))
                 }
                 Eq(left, right) => (vec![left.uid(), right.uid()], CanonicalOp::Eq),
-                Ite(b, t1, t2) => {
-                    (vec![b.uid(), t1.uid(), t2.uid()], CanonicalOp::Ite)
-                }
+                Ite(b, t1, t2) => (vec![b.uid(), t1.uid(), t2.uid()], CanonicalOp::Ite),
                 _ => return None,
             }
         };
 
-        let canonical_subterms: Vec<u64> =
-            subterms_u64.iter().map(|&t| self.find(t)).collect();
+        let canonical_subterms: Vec<u64> = subterms_u64.iter().map(|&t| self.find(t)).collect();
         Some((subterms_u64, op, canonical_subterms))
     }
 
@@ -1379,8 +1379,7 @@ impl Egraph {
                 let orig_level = original.level;
                 let orig_hash = original.hash;
                 let orig_predecessor = original.predecessor;
-                let should_replace =
-                    (!orig_valid || new_pred_level <= orig_level) && new_valid;
+                let should_replace = (!orig_valid || new_pred_level <= orig_level) && new_valid;
                 if should_replace {
                     slot.insert(new_pred);
                     debug_println!(

--- a/src/egraphs/egraph.rs
+++ b/src/egraphs/egraph.rs
@@ -10,7 +10,7 @@ use crate::egraphs::datastructures::{
 };
 use crate::egraphs::proofforest::*;
 use crate::egraphs::utils::get_subterms;
-use crate::utils::{DeterministicHashMap, DeterministicHashSet};
+use crate::utils::{DeterministicHashMap, DeterministicHashSet, FastDeterministicHashMap};
 use sat_interface::Formula;
 use std::collections::{HashMap, HashSet};
 use std::default::Default;
@@ -216,7 +216,7 @@ pub struct Egraph {
     /// keeps track of a stack of "edges" to backtrack on
     pub proof_forest_backtrack_stack: Vec<(usize, ProofForestEdge, u64, ProofForestEdge)>,
     /// this is a map from terms (u64) -> (term in the same egraph, predecesssor of term in same egraph)
-    pub predecessors: Vec<DeterministicHashMap<u64, Predecessor>>, // u64 -> Vec<Predecessor> TODO: there might be a better way to do this
+    pub predecessors: Vec<FastDeterministicHashMap<u64, Predecessor>>, // u64 -> Vec<Predecessor> TODO: there might be a better way to do this
     /// number to keep track of the current hash
     pub predecessor_hash: u64,
     /// mapping from levels -> corresponding hash
@@ -278,7 +278,7 @@ impl Egraph {
             }], // think about whether using a vector or hashmap is better here
             // note: this is an option because if you are a subterm of a quantifier, you are not in the proof forest. TODO: maybe there is a better way to think about this
             proof_forest_backtrack_stack: Vec::new(),
-            predecessors: vec![DeterministicHashMap::new()],
+            predecessors: vec![FastDeterministicHashMap::default()],
             predecessor_hash: 1,
             predecessor_level: vec![1, 1],
             assertions: vec![],
@@ -341,8 +341,11 @@ impl Egraph {
     }
 
     pub fn get_term(&self, num: u64) -> Term {
-        debug_println!(6, 0, "here3 with {}", num);
         self.terms_list[num as usize].clone().unwrap()
+    }
+
+    pub fn get_term_reference(&self, num: u64) -> &Term {
+        &self.terms_list[num as usize].unwrap()
     }
 
     pub fn get_term_safe(&self, num: u64) -> TermOption {
@@ -434,7 +437,7 @@ impl Egraph {
                 },
             );
             self.predecessors
-                .resize(self.predecessors.len() * 2, DeterministicHashMap::new());
+                .resize(self.predecessors.len() * 2, FastDeterministicHashMap::default());
         }
 
         // if this has already been inserted, then we don't need to do anything
@@ -605,7 +608,7 @@ impl Egraph {
                 },
             );
             self.predecessors
-                .resize(self.predecessors.len() * 2, DeterministicHashMap::new());
+                .resize(self.predecessors.len() * 2, FastDeterministicHashMap::default());
         }
 
         // if this has already been inserted, then we don't need to do anything

--- a/src/egraphs/egraph.rs
+++ b/src/egraphs/egraph.rs
@@ -341,12 +341,10 @@ impl Egraph {
     }
 
     pub fn get_term(&self, num: u64) -> Term {
+        debug_println!(6, 0, "here3 with {}", num);
         self.terms_list[num as usize].clone().unwrap()
     }
-
-    pub fn get_term_reference(&self, num: u64) -> &Term {
-        &self.terms_list[num as usize].unwrap()
-    }
+    
 
     pub fn get_term_safe(&self, num: u64) -> TermOption {
         if self.terms_list.len() <= num as usize {

--- a/src/egraphs/egraph.rs
+++ b/src/egraphs/egraph.rs
@@ -1341,71 +1341,57 @@ impl Egraph {
             self.get_term(new_pred_key),
             new_pred
         );
-        // if let Some(original_pred) = self.predecessors[term as usize].get(&new_pred_key) {
-        //     if (!self.valid_hash(original_pred.hash, original_pred.level)
-        //         || new_pred.level <= original_pred.level)
-        //         && self.valid_hash(new_pred.hash, new_pred.level)
-        //     {
-        //          debug_println!(
-        //             11,
-        //             0,
-        //             "For term {}, we are replacing the predecessor {} [level {}, hash {}] with predecessor {} [level {}, hash {}]",
-        //             self.get_term(term),
-        //             self.get_term(original_pred.predecessor),
-        //             original_pred.level,
-        //             original_pred.hash,
-        //             self.get_term(new_pred_key),
-        //             new_pred.level,
-        //             new_pred.hash
-        //         );
-        //         self.predecessors[term as usize].insert(new_pred_key, new_pred);
-        //     }
-        // } else {
-        //      debug_println!(
-        //         11,
-        //         0,
-        //         "For term {}, we are adding the predecessor {} [level {}, hash {}]",
-        //         self.get_term(term),
-        //         self.get_term(new_pred_key),
-        //         new_pred.level,
-        //         new_pred.hash
-        //     );
-        //     self.predecessors[term as usize].insert(new_pred_key, new_pred);
-        // }
-        // debug_println!(20, 0, "We have predecessor list size {}", self.predecessors[term as usize].len());
-        let (new_pred_hash, new_pred_level) = (new_pred.hash, new_pred.level);
-        if let Some(original_pred) = self.predecessors[term as usize].insert(new_pred_key, new_pred)
-        {
-            if !((!self.valid_hash(original_pred.hash, original_pred.level)
-                || new_pred_level <= original_pred.level)
-                && self.valid_hash(new_pred_hash, new_pred_level))
-            {
-                // if the old predecessor was valid, we want to keep it
-                self.predecessors[term as usize].insert(new_pred_key, original_pred);
-            } else {
+
+        // Compute new_pred validity before entering the Entry so we don't
+        // re-borrow self while holding an occupied slot.
+        let new_valid = self.valid_hash(new_pred.hash, new_pred.level);
+        let new_pred_level = new_pred.level;
+        let new_pred_hash = new_pred.hash;
+
+        use std::collections::hash_map::Entry;
+        match self.predecessors[term as usize].entry(new_pred_key) {
+            Entry::Vacant(slot) => {
+                slot.insert(new_pred);
                 debug_println!(
                     11,
                     0,
-                    "For term {}, we are replacing the predecessor {} [level {}, hash {}] with predecessor {} [level {}, hash {}]",
+                    "For term {}, we are adding the predecessor {} [level {}, hash {}]",
                     self.get_term(term),
-                    self.get_term(original_pred.predecessor),
-                    original_pred.level,
-                    original_pred.hash,
                     self.get_term(new_pred_key),
                     new_pred_level,
                     new_pred_hash
                 );
             }
-        } else {
-            debug_println!(
-                11,
-                0,
-                "For term {}, we are adding the predecessor {} [level {}, hash {}]",
-                self.get_term(term),
-                self.get_term(new_pred_key),
-                new_pred_level,
-                new_pred_hash
-            );
+            Entry::Occupied(mut slot) => {
+                // Inline valid_hash for the original so we don't need &self inside
+                // the occupied borrow. Matches valid_hash's body exactly (minus
+                // its debug_println at level 5, which has no functional effect).
+                let original = slot.get();
+                let orig_valid = original.hash >= self.predecessor_level[original.level]
+                    || original.hash == 0
+                    || original.level == 0;
+                let orig_level = original.level;
+                let orig_hash = original.hash;
+                let orig_predecessor = original.predecessor;
+                let should_replace =
+                    (!orig_valid || new_pred_level <= orig_level) && new_valid;
+                if should_replace {
+                    slot.insert(new_pred);
+                    debug_println!(
+                        11,
+                        0,
+                        "For term {}, we are replacing the predecessor {} [level {}, hash {}] with predecessor {} [level {}, hash {}]",
+                        self.get_term(term),
+                        self.get_term(orig_predecessor),
+                        orig_level,
+                        orig_hash,
+                        self.get_term(new_pred_key),
+                        new_pred_level,
+                        new_pred_hash
+                    );
+                }
+                // Keep-old case: zero inserts, no debug output (matches original).
+            }
         }
     }
 

--- a/src/egraphs/egraph.rs
+++ b/src/egraphs/egraph.rs
@@ -6,8 +6,8 @@ use crate::datatypes::process::DatatypeInfo;
 use crate::debug_println;
 use crate::egraphs::congruence_closure::union;
 use crate::egraphs::datastructures::{
-    Assertion, CanonicalOp, ConstructorType, DisequalTerm, Polarity::*, Predecessor, Quantifier,
-    TermOption,
+    Assertion, CanonicalForm, CanonicalOp, ConstructorType, DisequalTerm, Polarity::*, Predecessor,
+    Quantifier, TermOption,
 };
 use crate::egraphs::proofforest::*;
 use crate::egraphs::utils::get_subterms;
@@ -1280,11 +1280,7 @@ impl Egraph {
     /// Get the canonical form for some term
     /// For example the canoncial form for f(x, y) is (f, root(x), root(y))  
     /// TODO: I don't support canonical forms for non-app, non-eq terms, non-ite terms, but will have to do that eventually
-    pub fn get_canonical_form(
-        &self,
-        term_num: u64,
-        _level: usize,
-    ) -> Option<(Vec<u64>, CanonicalOp, Vec<u64>)> {
+    pub fn get_canonical_form(&self, term_num: u64, _level: usize) -> Option<CanonicalForm> {
         debug_println!(
             5,
             0,
@@ -1296,12 +1292,12 @@ impl Egraph {
 
         // Extract subterm uids and the operation identifier without cloning the Term.
         // The inner block holds a borrow of self.terms_list via get_term_ref;
-        // it ends before we need &mut self for self.find(...).
+        // it ends before we need &self for self.find(...).
         //
         // CanonicalOp replaces the old String-based identifier so that HashMap keys
         // compare/hash as u64 (via hash-consed uids) instead of allocating and
         // hashing String bytes per call.
-        let (subterms_u64, op) = {
+        let (original_subterms, op) = {
             let term = self.get_term_ref(term_num);
             match term.repr() {
                 App(func, subterms, ..) => {
@@ -1318,8 +1314,13 @@ impl Egraph {
             }
         };
 
-        let canonical_subterms: Vec<u64> = subterms_u64.iter().map(|&t| self.find(t)).collect();
-        Some((subterms_u64, op, canonical_subterms))
+        let canonical_subterms: Vec<u64> =
+            original_subterms.iter().map(|&t| self.find(t)).collect();
+        Some(CanonicalForm {
+            original_subterms,
+            op,
+            canonical_subterms,
+        })
     }
 
     /// Adds a predecessor to a term (for example f(x) to x)
@@ -1416,7 +1417,7 @@ where
 }
 
 /// Checks if the hash is still valid at the given level
-pub fn valid_hash(hash: u64, level: usize, predecessor_level: &Vec<u64>) -> bool {
+pub fn valid_hash(hash: u64, level: usize, predecessor_level: &[u64]) -> bool {
     debug_println!(
         5,
         0,

--- a/src/egraphs/egraph.rs
+++ b/src/egraphs/egraph.rs
@@ -6,7 +6,8 @@ use crate::datatypes::process::DatatypeInfo;
 use crate::debug_println;
 use crate::egraphs::congruence_closure::union;
 use crate::egraphs::datastructures::{
-    Assertion, ConstructorType, DisequalTerm, Polarity::*, Predecessor, Quantifier, TermOption,
+    Assertion, CanonicalOp, ConstructorType, DisequalTerm, Polarity::*, Predecessor, Quantifier,
+    TermOption,
 };
 use crate::egraphs::proofforest::*;
 use crate::egraphs::utils::get_subterms;
@@ -343,6 +344,13 @@ impl Egraph {
     pub fn get_term(&self, num: u64) -> Term {
         debug_println!(6, 0, "here3 with {}", num);
         self.terms_list[num as usize].clone().unwrap()
+    }
+
+    pub fn get_term_ref(&self, num: u64) -> &Term {
+        match &self.terms_list[num as usize] {
+            TermOption::Some(term) | TermOption::Uninitialized(term) => term,
+            TermOption::None => panic!("called `get_term_ref` on a None value"),
+        }
     }
     
 
@@ -1273,7 +1281,7 @@ impl Egraph {
         &mut self,
         term_num: u64,
         _level: usize,
-    ) -> Option<(Vec<u64>, String, Vec<u64>)> {
+    ) -> Option<(Vec<u64>, CanonicalOp, Vec<u64>)> {
         debug_println!(
             5,
             0,
@@ -1282,38 +1290,36 @@ impl Egraph {
             self.get_term(term_num)
         );
         debug_println!(6, 0, "before11");
-        let term = self.get_term(term_num);
-        match term.repr() {
-            App(func, subterms, ..) => {
-                let subterms_u64 = subterms.iter().map(|t| t.uid()).collect::<Vec<_>>();
-                let canonical_subterms = subterms_u64
-                    .clone()
-                    .into_iter()
-                    .map(|t| self.find(t))
-                    .collect::<Vec<_>>();
-                Some((subterms_u64, func.to_string(), canonical_subterms))
+
+        // Extract subterm uids and the operation identifier without cloning the Term.
+        // The inner block holds a borrow of self.terms_list via get_term_ref;
+        // it ends before we need &mut self for self.find(...).
+        //
+        // CanonicalOp replaces the old String-based identifier so that HashMap keys
+        // compare/hash as u64 (via hash-consed uids) instead of allocating and
+        // hashing String bytes per call.
+        let (subterms_u64, op) = {
+            let term = self.get_term_ref(term_num);
+            match term.repr() {
+                App(func, subterms, ..) => {
+                    let uids: Vec<u64> = subterms.iter().map(|t| t.uid()).collect();
+                    // Clone the full QualifiedIdentifier so we preserve both
+                    // the symbol AND any sort/index annotations — without them
+                    // polymorphic constructor instances collide in the
+                    // canonical-form HashMap.
+                    (uids, CanonicalOp::App(func.clone()))
+                }
+                Eq(left, right) => (vec![left.uid(), right.uid()], CanonicalOp::Eq),
+                Ite(b, t1, t2) => {
+                    (vec![b.uid(), t1.uid(), t2.uid()], CanonicalOp::Ite)
+                }
+                _ => return None,
             }
-            Eq(left, right) => {
-                let canonical_left = self.find(left.uid());
-                let canonical_right = self.find(right.uid());
-                Some((
-                    vec![left.uid(), right.uid()],
-                    "=".to_string(),
-                    vec![canonical_left, canonical_right],
-                ))
-            }
-            Ite(b, t1, t2) => {
-                let canonical_b = self.find(b.uid());
-                let canonical_left = self.find(t1.uid());
-                let canonical_right = self.find(t2.uid());
-                Some((
-                    vec![b.uid(), t1.uid(), t2.uid()],
-                    "ite".to_string(),
-                    vec![canonical_b, canonical_left, canonical_right],
-                ))
-            }
-            _ => None,
-        }
+        };
+
+        let canonical_subterms: Vec<u64> =
+            subterms_u64.iter().map(|&t| self.find(t)).collect();
+        Some((subterms_u64, op, canonical_subterms))
     }
 
     /// Checks if the hash is still valid at the given level

--- a/src/egraphs/egraph.rs
+++ b/src/egraphs/egraph.rs
@@ -1281,7 +1281,7 @@ impl Egraph {
     /// For example the canoncial form for f(x, y) is (f, root(x), root(y))  
     /// TODO: I don't support canonical forms for non-app, non-eq terms, non-ite terms, but will have to do that eventually
     pub fn get_canonical_form(
-        &mut self,
+        &self,
         term_num: u64,
         _level: usize,
     ) -> Option<(Vec<u64>, CanonicalOp, Vec<u64>)> {
@@ -1290,7 +1290,7 @@ impl Egraph {
             0,
             "We are in get_canonical_form with term_num {} and term {}",
             term_num,
-            self.get_term(term_num)
+            self.get_term_ref(term_num)
         );
         debug_println!(6, 0, "before11");
 

--- a/src/egraphs/egraph.rs
+++ b/src/egraphs/egraph.rs
@@ -675,7 +675,7 @@ impl Egraph {
         for (pred_key, pred) in subterm_root_predecessor {
             debug_println!(6, 0, "before9");
             // if the predecessor is not valid, then we can remove it from the predecessors list (this can happen because of backtracking) and continue
-            if !self.valid_hash(pred.hash, pred.level) {
+            if !valid_hash(pred.hash, pred.level, &self.predecessor_level) {
                 self.predecessors[subterm_root as usize].remove(pred_key);
                 debug_println!(
                     16,
@@ -1184,7 +1184,7 @@ impl Egraph {
         // sorted_disequalities.sort_by_key(|(key, _)| **key);
 
         for (key, disequality) in sorted_disequalities {
-            if !self.valid_hash(disequality.hash, disequality.level) {
+            if !valid_hash(disequality.hash, disequality.level, &self.predecessor_level) {
                 debug_println!(
                     19,
                     0,
@@ -1322,18 +1322,6 @@ impl Egraph {
         Some((subterms_u64, op, canonical_subterms))
     }
 
-    /// Checks if the hash is still valid at the given level
-    pub fn valid_hash(&self, hash: u64, level: usize) -> bool {
-        debug_println!(
-            5,
-            0,
-            "We are in valid_hash with hash {} and level {}",
-            hash,
-            level
-        );
-        hash >= self.predecessor_level[level] || hash == 0 || level == 0 // todo: I added this level ==0 ~> I think this is correct but need to double check to be sure
-    }
-
     /// Adds a predecessor to a term (for example f(x) to x)
     ///
     /// TODO: right now this is preferring the smallest level, but this might not always be
@@ -1350,7 +1338,7 @@ impl Egraph {
 
         // Compute new_pred validity before entering the Entry so we don't
         // re-borrow self while holding an occupied slot.
-        let new_valid = self.valid_hash(new_pred.hash, new_pred.level);
+        let new_valid = valid_hash(new_pred.hash, new_pred.level, &self.predecessor_level);
         let new_pred_level = new_pred.level;
         let new_pred_hash = new_pred.hash;
 
@@ -1373,9 +1361,10 @@ impl Egraph {
                 // the occupied borrow. Matches valid_hash's body exactly (minus
                 // its debug_println at level 5, which has no functional effect).
                 let original = slot.get();
-                let orig_valid = original.hash >= self.predecessor_level[original.level]
-                    || original.hash == 0
-                    || original.level == 0;
+                let orig_valid = valid_hash(original.hash, original.level, &self.predecessor_level);
+                // original.hash >= self.predecessor_level[original.level]
+                //     || original.hash == 0
+                //     || original.level == 0;
                 let orig_level = original.level;
                 let orig_hash = original.hash;
                 let orig_predecessor = original.predecessor;
@@ -1424,6 +1413,18 @@ where
     fn nnf(&self, env: &mut Egraph) -> Self {
         self.nnf(&mut env.cnf_env())
     }
+}
+
+/// Checks if the hash is still valid at the given level
+pub fn valid_hash(hash: u64, level: usize, predecessor_level: &Vec<u64>) -> bool {
+    debug_println!(
+        5,
+        0,
+        "We are in valid_hash with hash {} and level {}",
+        hash,
+        level
+    );
+    hash >= predecessor_level[level] || hash == 0 || level == 0 // todo: I added this level ==0 ~> I think this is correct but need to double check to be sure
 }
 
 // check that every variable occurs in each multipattern

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -3,13 +3,23 @@
 
 //! A file containting functions that may be useful elswhere
 
-use std::collections::{BTreeMap, BTreeSet};
+use rustc_hash::FxHasher;
+use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
+use std::hash::BuildHasherDefault;
 use yaspar_ir::ast::Term;
 
-// For collections that need deterministic iteration, we use BTreeMap/BTreeSet
-// These maintain sorted order naturally, so iteration is always deterministic
+// Sorted-order deterministic map. Iteration order is canonical (sorted by key),
+// so these also implement Hash and can be used as keys in other hash-based
+// containers. Use this when you need canonical equality or sorted iteration.
 pub type DeterministicHashMap<K, V> = BTreeMap<K, V>;
 pub type DeterministicHashSet<T> = BTreeSet<T>;
+
+// Hash-based deterministic map using a fixed-seed FxHash. O(1) average ops
+// and deterministic across runs (unlike std's RandomState), but iteration
+// order depends on insertion sequence and these do not implement Hash.
+// Prefer this on hot paths where sorted iteration is not required.
+pub type FastDeterministicHashMap<K, V> = HashMap<K, V, BuildHasherDefault<FxHasher>>;
+pub type FastDeterministicHashSet<T> = HashSet<T, BuildHasherDefault<FxHasher>>;
 
 // Takes in a List of terms and returns a String (useful for debugging)
 pub fn fmt_termlist(terms: Vec<Term>) -> String {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* Switching predecessors to use a HashMap instead of BTreeMap. Also reducing the amount of cloning done in union_predecessors. This a major hot spot for the solver and these changes get us from solving 63.0% to 66.0% on Verus benchmarks. The datastructure changes are similar to those in #68 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
