### PR TITLE
Add basic statistics to the LIA solver modules

### DIFF
--- a/src/arithmetic/lia/frontend.rs
+++ b/src/arithmetic/lia/frontend.rs
@@ -7,6 +7,7 @@
 use std::collections;
 use std::fmt::{self, Display};
 use std::ops;
+use std::time::Instant;
 
 use yaspar_ir::ast::{self as smt_ast, FetchSort};
 use yaspar_ir::ast::{AConstant, ATerm};
@@ -21,8 +22,11 @@ use crate::arithmetic::lia::linear_system::{
 use crate::arithmetic::lia::lira_solver::LIRASolver;
 use crate::arithmetic::lia::lra_solver::LRASolver;
 use crate::arithmetic::lia::preprocess::{PreprocessResult, preprocess};
-use crate::arithmetic::lia::solver_result::{Conflict, SolverDecision, SolverError, default_model};
+use crate::arithmetic::lia::solver_result::{
+    Conflict, SolverDecision, SolverError, SolverReturn, default_model,
+};
 use crate::arithmetic::lia::solver_result_api::SolverDecisionApi;
+use crate::arithmetic::lia::stats::Stats;
 use crate::arithmetic::lia::tableau::TableauKind;
 use crate::arithmetic::lia::types::{FBig, Integer, Rational, UBig};
 use crate::arithmetic::lia::variables::VarType;
@@ -519,9 +523,10 @@ fn solve_with_context(
 ) -> FrontendResult<SolverDecisionApi> {
     let (_, var_term_map) = ctx.get_term_var_maps(); // this is a clone
     let decision = solve_ctx_raw(&mut ctx, tableau_kind)?;
+    // TODO: frontend::solve_with_context: return stats through SolverDecisionApi
     Ok(SolverDecisionApi::from_solver_decision(
         &var_term_map,
-        decision,
+        decision.decision,
     )?)
 }
 
@@ -529,7 +534,7 @@ fn solve_with_context(
 pub fn solve_ctx_raw(
     ctx: &mut ConvContext,
     tableau_kind: TableauKind,
-) -> FrontendResult<SolverDecision> {
+) -> FrontendResult<SolverReturn> {
     // preprocess the input relations, detect trivial cases, and otherwise return a [LinearSystem]
     // from which to build a solver.
     let result = preprocess(ctx);
@@ -542,12 +547,18 @@ pub fn solve_ctx_raw(
     );
     let sys = match result {
         PreprocessResult::TriviallySat => {
-            return Ok(SolverDecision::FEASIBLE(default_model(ctx.get_all_vars())));
+            return Ok(SolverReturn::new(
+                SolverDecision::FEASIBLE(default_model(ctx.get_all_vars())),
+                Stats::new(),
+            ));
         }
         PreprocessResult::TriviallyUnsat(v) => {
             let mut conflict = collections::BTreeSet::new();
             conflict.insert(v);
-            return Ok(SolverDecision::INFEASIBLE(Conflict::from_set(conflict)));
+            return Ok(SolverReturn::new(
+                SolverDecision::INFEASIBLE(Conflict::from_set(conflict)),
+                Stats::new(),
+            ));
         }
         PreprocessResult::Unknown => LinearSystem::new(ctx.clone()),
     };
@@ -555,9 +566,18 @@ pub fn solve_ctx_raw(
         .to_lra_solver(true, tableau_kind)
         .map_err(|e| FrontendError(format!("error building lra_solver: {}", e)))?;
     let mut lira_solver = LIRASolver::new(lra_solver);
-    lira_solver
+    debug_println!(25, 0, "lia::frontend::solve_ctx_raw: Starting LIRA solver");
+    let start = Instant::now();
+    let ret = lira_solver
         .solve()
-        .map_err(|e| FrontendError(format!("error solving: {}", e)))
+        .map_err(|e| FrontendError(format!("error solving: {}", e)));
+    let duration = start.elapsed();
+    debug_println!(
+        25,
+        4,
+        "lia::frontend::solve_ctx_raw: LIRA solver finished, duration: {duration:?}"
+    );
+    ret
 }
 
 #[cfg(test)]
@@ -838,7 +858,10 @@ mod tests {
 
         let mut solver =
             smt_to_lra_solver(smt_input, TableauKind::Dense).expect("Failed to create LRA solver");
-        let result = solver.solve().expect("Failed to run simplex algorithm");
+        let result = solver
+            .solve()
+            .expect("Failed to run simplex algorithm")
+            .decision;
         assert!(matches!(result, SolverDecision::FEASIBLE(_)));
     }
 
@@ -855,7 +878,10 @@ mod tests {
     "#;
         let mut solver =
             smt_to_lra_solver(smt_input, TableauKind::Dense).expect("Failed to create LRA solver");
-        let result = solver.solve().expect("Failed to run simplex algorithm");
+        let result = solver
+            .solve()
+            .expect("Failed to run simplex algorithm")
+            .decision;
         assert!(matches!(result, SolverDecision::INFEASIBLE(_)));
     }
 
@@ -873,7 +899,10 @@ mod tests {
     "#;
         let mut solver =
             smt_to_lra_solver(smt_input, TableauKind::Dense).expect("Failed to create LRA solver");
-        let result = solver.solve().expect("Failed to run simplex algorithm");
+        let result = solver
+            .solve()
+            .expect("Failed to run simplex algorithm")
+            .decision;
         assert!(matches!(result, SolverDecision::FEASIBLE(_)));
     }
 
@@ -887,7 +916,10 @@ mod tests {
     "#;
         let mut solver =
             smt_to_lra_solver(smt_input, TableauKind::Dense).expect("Failed to create LRA solver");
-        let result = solver.solve().expect("Failed to run simplex algorithm");
+        let result = solver
+            .solve()
+            .expect("Failed to run simplex algorithm")
+            .decision;
         assert!(matches!(result, SolverDecision::FEASIBLE(_)));
     }
 
@@ -901,7 +933,10 @@ mod tests {
     "#;
         let mut solver =
             smt_to_lra_solver(smt_input, TableauKind::Dense).expect("Failed to create LRA solver");
-        let result = solver.solve().expect("Failed to run simplex algorithm");
+        let result = solver
+            .solve()
+            .expect("Failed to run simplex algorithm")
+            .decision;
         match result {
             SolverDecision::FEASIBLE(model) => {
                 let x_var = solver.get_var("x").unwrap();
@@ -922,7 +957,10 @@ mod tests {
     "#;
         let mut solver =
             smt_to_lra_solver(smt_input, TableauKind::Dense).expect("Failed to create LRA solver");
-        let result = solver.solve().expect("Failed to run simplex algorithm");
+        let result = solver
+            .solve()
+            .expect("Failed to run simplex algorithm")
+            .decision;
         match result {
             SolverDecision::FEASIBLE(model) => {
                 let x_var = solver.get_var("x").unwrap();
@@ -945,7 +983,10 @@ mod tests {
     "#;
         let mut solver =
             smt_to_lra_solver(smt_input, TableauKind::Dense).expect("Failed to create LRA solver");
-        let result = solver.solve().expect("Failed to run simplex algorithm");
+        let result = solver
+            .solve()
+            .expect("Failed to run simplex algorithm")
+            .decision;
         assert!(matches!(result, SolverDecision::FEASIBLE(_)));
     }
 }

--- a/src/arithmetic/lia/linear_system.rs
+++ b/src/arithmetic/lia/linear_system.rs
@@ -1101,7 +1101,7 @@ mod tests {
             .expect("failed to build solver");
 
         assert!(solver.is_valid());
-        let result = solver.solve().expect("simplex failed");
+        let result = solver.solve().expect("simplex failed").decision;
         assert!(matches!(result, SolverDecision::FEASIBLE(_)));
 
         // Same test but with sparse tableau
@@ -1111,7 +1111,7 @@ mod tests {
             .expect("failed to build solver");
 
         assert!(solver.is_valid());
-        let result = solver.solve().expect("simplex failed");
+        let result = solver.solve().expect("simplex failed").decision;
         assert!(matches!(result, SolverDecision::FEASIBLE(_)));
     }
 
@@ -1141,7 +1141,7 @@ mod tests {
             .expect("failed to build solver");
 
         assert!(solver.is_valid());
-        let result = solver.solve().expect("simplex failed");
+        let result = solver.solve().expect("simplex failed").decision;
         // TODO: check all assignments are ZERO
         assert!(matches!(result, SolverDecision::FEASIBLE(_)));
         if let SolverDecision::FEASIBLE(assg) = result {
@@ -1158,7 +1158,7 @@ mod tests {
                 .expect("bound assertion failed"),
             Some(true)
         );
-        let result = solver.solve().expect("simplex failed");
+        let result = solver.solve().expect("simplex failed").decision;
         assert!(matches!(result, SolverDecision::FEASIBLE(_)));
         if let SolverDecision::FEASIBLE(assg) = result {
             assert!(assg.iter().all(|(_, val)| val.is_zero()));
@@ -1204,7 +1204,7 @@ mod tests {
             .expect("failed to build solver");
         assert!(solver.is_valid());
         assert!(matches!(
-            solver.solve().expect("simplex failed"),
+            solver.solve().expect("simplex failed").decision,
             SolverDecision::INFEASIBLE(_)
         ));
     }
@@ -1275,7 +1275,7 @@ mod tests {
             .to_lra_solver(true, TableauKind::Dense)
             .expect("failed to build solver");
         assert!(solver.is_valid());
-        let result = solver.solve().expect("simplex failed");
+        let result = solver.solve().expect("simplex failed").decision;
         // validate the assignment
         if let SolverDecision::FEASIBLE(assg) = result {
             // Find the value of x_59 and assert it is strictly positive
@@ -1292,7 +1292,7 @@ mod tests {
             .to_lra_solver(true, TableauKind::Sparse)
             .expect("failed to build solver");
         assert!(solver.is_valid());
-        let result = solver.solve().expect("simplex failed");
+        let result = solver.solve().expect("simplex failed").decision;
         // validate the assignment
         assert!(matches!(result, SolverDecision::FEASIBLE(_)));
     }
@@ -1359,7 +1359,7 @@ mod tests {
             .to_lra_solver(true, TableauKind::Dense)
             .expect("failed to build solver");
         assert!(solver.is_valid());
-        let result = solver.solve().expect("simplex failed");
+        let result = solver.solve().expect("simplex failed").decision;
         // validate the assignment
         if let SolverDecision::FEASIBLE(assg) = result {
             // the system is feasible, but only via some values being non-integral. For example:
@@ -1379,7 +1379,7 @@ mod tests {
             .to_lra_solver(true, TableauKind::Sparse)
             .expect("failed to build solver");
         assert!(solver.is_valid());
-        let result = solver.solve().expect("simplex failed");
+        let result = solver.solve().expect("simplex failed").decision;
         // validate the assignment
         assert!(matches!(result, SolverDecision::FEASIBLE(_)));
     }
@@ -1402,7 +1402,7 @@ mod tests {
             .expect("failed to build solver");
 
         assert!(solver.is_valid());
-        let result = solver.solve().expect("simplex failed");
+        let result = solver.solve().expect("simplex failed").decision;
         assert!(matches!(result, SolverDecision::INFEASIBLE(_)));
     }
 
@@ -1443,7 +1443,7 @@ mod tests {
     #[test]
     fn solve_strict_system_strictly_in_unit_cube() {
         let (mut solver, _x, _y) = open_polytope_in_unit_cube();
-        let result = solver.solve().expect("simplex failed");
+        let result = solver.solve().expect("simplex failed").decision;
         if let SolverDecision::FEASIBLE(assg) = result {
             // the system is feasible, but only via *all* variables being non-integral
             assert!(assg.iter().all(|(_, val)| !val.is_int()));
@@ -1457,7 +1457,7 @@ mod tests {
     fn solve_strict_system_strictly_in_unit_cube_then_assert_lower() {
         let (mut solver, x, _y) = open_polytope_in_unit_cube();
         assert!(matches!(
-            solver.solve().expect("simplex failed"),
+            solver.solve().expect("simplex failed").decision,
             SolverDecision::FEASIBLE(_)
         ));
 
@@ -1467,7 +1467,7 @@ mod tests {
             solver.assert_lower(&x, &rbig!(1 / 10).into()).unwrap(),
             Some(true)
         );
-        if let SolverDecision::FEASIBLE(ass) = solver.solve().expect("simplex failed") {
+        if let SolverDecision::FEASIBLE(ass) = solver.solve().expect("simplex failed").decision {
             assert_eq!(ass.get(&x).unwrap(), &rbig!(7 / 18));
         } else {
             unreachable!()
@@ -1481,7 +1481,7 @@ mod tests {
             None, // feasibility is now unknown
         );
         // the new lower bound pushed x up to its lower bound
-        if let SolverDecision::FEASIBLE(ass) = solver.solve().expect("simplex failed") {
+        if let SolverDecision::FEASIBLE(ass) = solver.solve().expect("simplex failed").decision {
             assert_eq!(ass.get(&x).unwrap(), &rbig!(5 / 9));
         } else {
             unreachable!()
@@ -1494,7 +1494,7 @@ mod tests {
         );
         // system is now infeasible
         assert!(matches!(
-            solver.solve().expect("simplex failed"),
+            solver.solve().expect("simplex failed").decision,
             SolverDecision::INFEASIBLE(_)
         ));
     }
@@ -1502,7 +1502,7 @@ mod tests {
     #[test]
     fn solve_strict_system_strictly_in_unit_cube_then_assert_upper() {
         let (mut solver, x, y) = open_polytope_in_unit_cube();
-        if let SolverDecision::FEASIBLE(ass) = solver.solve().expect("simplex failed") {
+        if let SolverDecision::FEASIBLE(ass) = solver.solve().expect("simplex failed").decision {
             // test x and y's values
             assert!(rbig!(1 / 3) <= *ass.get(&x).unwrap() && *ass.get(&x).unwrap() <= rbig!(2 / 3));
             assert!(rbig!(1 / 3) <= *ass.get(&y).unwrap() && *ass.get(&y).unwrap() <= rbig!(2 / 3));
@@ -1516,7 +1516,7 @@ mod tests {
             solver.assert_upper(&y, &rbig!(199 / 300).into()).unwrap(),
             Some(true)
         );
-        if let SolverDecision::FEASIBLE(ass) = solver.solve().expect("simplex failed") {
+        if let SolverDecision::FEASIBLE(ass) = solver.solve().expect("simplex failed").decision {
             assert!(
                 rbig!(1 / 3) <= *ass.get(&y).unwrap() && *ass.get(&y).unwrap() <= rbig!(199 / 300)
             );
@@ -1534,7 +1534,7 @@ mod tests {
         let assert_upper_2_result = solver.assert_upper(&y, &rbig!(1001 / 3000).into()).unwrap();
         assert_ne!(assert_upper_2_result, Some(false)); // either None or Some(true)
 
-        if let SolverDecision::FEASIBLE(ass) = solver.solve().expect("simplex failed") {
+        if let SolverDecision::FEASIBLE(ass) = solver.solve().expect("simplex failed").decision {
             assert!(
                 rbig!(1 / 3) <= *ass.get(&y).unwrap()
                     && *ass.get(&y).unwrap() <= rbig!(1001 / 3000)
@@ -1550,7 +1550,7 @@ mod tests {
         );
         // system is now infeasible
         assert!(matches!(
-            solver.solve().expect("simplex failed"),
+            solver.solve().expect("simplex failed").decision,
             SolverDecision::INFEASIBLE(_)
         ));
     }
@@ -1572,7 +1572,7 @@ mod tests {
         let sys = LinearSystem::new(ctx);
         let mut solver = sys.to_lra_solver(true, TableauKind::Dense).unwrap();
 
-        let result = solver.solve().unwrap();
+        let result = solver.solve().unwrap().decision;
         if let SolverDecision::FEASIBLE(assg) = result {
             // the system is feasible, but only via *all* original variables being non-integral
             assert!(!assg.get(&x).unwrap().is_int() && !assg.get(&y).unwrap().is_int());
@@ -1599,7 +1599,7 @@ mod tests {
         let sys = LinearSystem::new(ctx);
         let mut solver = sys.to_lra_solver(true, TableauKind::Dense).unwrap();
         assert!(matches!(
-            solver.solve().unwrap(),
+            solver.solve().unwrap().decision,
             SolverDecision::INFEASIBLE(_)
         ));
 
@@ -1615,7 +1615,7 @@ mod tests {
         let sys = LinearSystem::new(ctx);
         let mut solver = sys.to_lra_solver(true, TableauKind::Dense).unwrap();
         assert!(matches!(
-            solver.solve().unwrap(),
+            solver.solve().unwrap().decision,
             SolverDecision::INFEASIBLE(_)
         ));
     }
@@ -1653,7 +1653,7 @@ mod tests {
             .to_lra_solver(true, TableauKind::Dense)
             .expect("failed to build tableau");
         assert!(solver.is_valid());
-        let result = solver.solve().expect("simplex failed");
+        let result = solver.solve().expect("simplex failed").decision;
         assert!(matches!(result, SolverDecision::FEASIBLE(_)));
     }
 
@@ -1681,7 +1681,7 @@ mod tests {
         let mut solver = sys
             .to_lra_solver(true, TableauKind::Dense)
             .expect("failed to build solver");
-        let result = solver.solve().expect("solver failed");
+        let result = solver.solve().expect("solver failed").decision;
         assert!(matches!(result, SolverDecision::INFEASIBLE(_)));
     }
 }

--- a/src/arithmetic/lia/lira_solver.rs
+++ b/src/arithmetic/lia/lira_solver.rs
@@ -12,7 +12,8 @@ use slotmap;
 use crate::arithmetic::lia::bounds::Bounds;
 use crate::arithmetic::lia::lra_solver::LRASolver;
 use crate::arithmetic::lia::qdelta::QDelta;
-use crate::arithmetic::lia::solver_result::{Conflict, SolverDecision, SolverResult};
+use crate::arithmetic::lia::solver_result::{Conflict, SolverDecision, SolverResult, SolverReturn};
+use crate::arithmetic::lia::stats::Stats;
 use crate::arithmetic::lia::variables::{Var, VarType};
 use crate::debug_println;
 
@@ -179,6 +180,8 @@ pub struct LIRASolver {
     lra_solver: LRASolver,
     /// Stack of variable bounds for tracking during solving
     explorer: BrtExplorer,
+    /// Runtime statistics
+    stats: Stats,
 }
 
 impl LIRASolver {
@@ -192,6 +195,7 @@ impl LIRASolver {
         Self {
             lra_solver,
             explorer: BrtExplorer::new(root),
+            stats: Stats::new(),
         }
     }
 
@@ -289,17 +293,12 @@ impl LIRASolver {
     ///
     /// TODO: lira_solver::solve: document branch-and-bound algorithm using incremental simplex
     /// TODO: lira_solver::solve: clean up debug statements
-    pub fn solve(&mut self) -> SolverResult<SolverDecision> {
-        debug_println!(
-            21,
-            0,
-            "lia::lira_solver: starting LIRASolver with lra_solver: {:?}",
-            self.lra_solver
-        );
+    pub fn solve(&mut self) -> SolverResult<SolverReturn> {
+        debug_println!(21, 0, "lia::lira_solver: starting LIRASolver");
 
         while let Some(current_k) = self.explorer.active.pop() {
             debug_println!(
-                15,
+                21,
                 0,
                 "lia::lira_solver::solve: pop & setup node {:?}",
                 self.explorer.arena[current_k]
@@ -316,7 +315,10 @@ impl LIRASolver {
 
             // setup done, now solve and update state and active
             debug_println!(21, 0, "lia::lira_solver: solving over Q");
-            match self.lra_solver.solve()? {
+            let ret = self.lra_solver.solve()?;
+            // this also bumps num_lra_solve by 1
+            self.stats.combine(&ret.stats);
+            match ret.decision {
                 SolverDecision::INFEASIBLE(cs) => {
                     debug_println!(
                         15,
@@ -342,7 +344,12 @@ impl LIRASolver {
                     );
                     // identify the first integer type variable whose assigned value is not integral
                     let (x, val) = match self.find_next_int_var() {
-                        None => return Ok(SolverDecision::FEASIBLE(assg)), // rational solution meets all type constraints
+                        None => {
+                            return Ok(SolverReturn::new(
+                                SolverDecision::FEASIBLE(assg),
+                                self.stats.clone(),
+                            ));
+                        } // rational solution meets all type constraints
                         Some((x, val)) => {
                             debug_println!(
                                 15,
@@ -412,7 +419,10 @@ impl LIRASolver {
             .get(root_k)
             .unwrap_or_else(|| panic!("invalid root key {root_k:?}"));
         match &root.state {
-            BrtNodeState::Pruned(conflict) => Ok(SolverDecision::INFEASIBLE(conflict.clone())),
+            BrtNodeState::Pruned(conflict) => Ok(SolverReturn::new(
+                SolverDecision::INFEASIBLE(conflict.clone()),
+                self.stats.clone(),
+            )),
             state => unreachable!("invalid final root node state {state:?}"),
         }
     }
@@ -478,7 +488,7 @@ mod tests {
             "#;
         let mut solver =
             smt_to_lra_solver(smt_input, TableauKind::Dense).expect("Failed to create LRA solver");
-        let ass = match solver.solve().unwrap() {
+        let ass = match solver.solve().unwrap().decision {
             SolverDecision::FEASIBLE(ass) => ass,
             _ => unreachable!(),
         };
@@ -508,7 +518,7 @@ mod tests {
         );
         // lower branch is infeasible
         assert!(matches!(
-            solver.solve().unwrap(),
+            solver.solve().unwrap().decision,
             SolverDecision::INFEASIBLE(_)
         ));
 
@@ -523,7 +533,7 @@ mod tests {
         );
         // upper branch is infeasible
         assert!(matches!(
-            solver.solve().unwrap(),
+            solver.solve().unwrap().decision,
             SolverDecision::INFEASIBLE(_)
         ));
 
@@ -548,8 +558,8 @@ mod tests {
             smt_to_lra_solver(smt_input, TableauKind::Dense).expect("Failed to create LRA solver");
         let mut lira_solver = LIRASolver::new(lra_solver);
         assert!(matches!(
-            lira_solver.solve(),
-            Ok(SolverDecision::INFEASIBLE(_))
+            lira_solver.solve().unwrap().decision,
+            SolverDecision::INFEASIBLE(_)
         ));
     }
 
@@ -580,8 +590,8 @@ mod tests {
 
         // Assert that the system is INFEASIBLE
         assert!(matches!(
-            lira_solver.solve(),
-            Ok(SolverDecision::INFEASIBLE(_))
+            lira_solver.solve().unwrap().decision,
+            SolverDecision::INFEASIBLE(_)
         ));
     }
 
@@ -647,8 +657,8 @@ mod tests {
 
         // Assert that the system is INFEASIBLE
         assert!(matches!(
-            lira_solver.solve(),
-            Ok(SolverDecision::INFEASIBLE(_))
+            lira_solver.solve().unwrap().decision,
+            SolverDecision::INFEASIBLE(_)
         ));
     }
 

--- a/src/arithmetic/lia/lra_solver.rs
+++ b/src/arithmetic/lia/lra_solver.rs
@@ -15,8 +15,9 @@ use crate::arithmetic::lia::bounds::Bounds;
 use crate::arithmetic::lia::context::ConvContext;
 use crate::arithmetic::lia::qdelta::QDelta;
 use crate::arithmetic::lia::solver_result::{
-    Assignment, Conflict, SolverDecision, SolverError, SolverResult,
+    Assignment, Conflict, SolverDecision, SolverError, SolverResult, SolverReturn,
 };
+use crate::arithmetic::lia::stats::Stats;
 use crate::arithmetic::lia::tableau::{Tableau, TableauImpl, TableauKind};
 use crate::arithmetic::lia::types::Rational;
 use crate::arithmetic::lia::variables::{Owner, Var, VarInfo};
@@ -628,7 +629,7 @@ impl LRASolver {
     /// Perform the general simplex algorithm to find a feasible solution.
     ///
     /// TODO: add configuration options for termination
-    pub fn solve(&mut self) -> SolverResult<SolverDecision> {
+    pub fn solve(&mut self) -> SolverResult<SolverReturn> {
         let mut i: usize = 0;
         loop {
             debug_println!(21, 0, "lia::lra_solver: Stepping simplex, iteration {}", i);
@@ -644,7 +645,11 @@ impl LRASolver {
                         "lia::lra_solver::solve: simplex complete, num iterations = {}",
                         i
                     );
-                    return Ok(SolverDecision::FEASIBLE(assg));
+                    let stats = Stats {
+                        num_lra_solve: 1,
+                        num_simplex_steps: i,
+                    };
+                    return Ok(SolverReturn::new(SolverDecision::FEASIBLE(assg), stats));
                 }
                 Ok(SimplexStepResult::Infeasible(v)) => {
                     let conflict = self.compute_conflict(v)?;
@@ -654,7 +659,14 @@ impl LRASolver {
                         "lia::lra_solver::solve: simplex complete, num iterations = {}",
                         i
                     );
-                    return Ok(SolverDecision::INFEASIBLE(conflict));
+                    let stats = Stats {
+                        num_lra_solve: 1,
+                        num_simplex_steps: i,
+                    };
+                    return Ok(SolverReturn::new(
+                        SolverDecision::INFEASIBLE(conflict),
+                        stats,
+                    ));
                 }
                 Err(e) => return Err(e), // error
             }
@@ -1151,7 +1163,7 @@ mod tests {
         // s2 | 2 -1    0 <= s2
         // s3 |-1  2    1 <= s3
         let mut solver = ex_5_6_tableau();
-        let result = solver.solve().expect("Failed to run simplex");
+        let result = solver.solve().expect("Failed to run simplex").decision;
         assert!(matches!(result, SolverDecision::FEASIBLE(_)));
         if let SolverDecision::FEASIBLE(ass) = result {
             assert_eq!(ass.nvars(), 5);
@@ -1184,14 +1196,14 @@ mod tests {
     #[test]
     fn ex_triangle_hole_run_simplex() {
         let mut tableau = ex_triangle_hole_infeasible();
-        let result = tableau.solve().expect("Failed to run simplex");
+        let result = tableau.solve().expect("Failed to run simplex").decision;
         assert!(matches!(result, SolverDecision::INFEASIBLE(_)));
     }
 
     #[test]
     fn ex_triangle_hole_run_simplex_conflict() {
         let mut tableau = ex_triangle_hole_infeasible();
-        match tableau.solve().expect("Failed to run simplex") {
+        match tableau.solve().expect("Failed to run simplex").decision {
             SolverDecision::INFEASIBLE(conflict) => {
                 assert_eq!(conflict.len(), 3);
             }
@@ -1202,7 +1214,10 @@ mod tests {
     #[test]
     fn ex_5_6_assert_lower() {
         let mut solver = ex_5_6_tableau();
-        let result = solver.solve().expect("Failed to run simplex, first run");
+        let result = solver
+            .solve()
+            .expect("Failed to run simplex, first run")
+            .decision;
         assert!(matches!(result, SolverDecision::FEASIBLE(_)));
         // x (Var(4, Real)) is assigned 1, so we expect asserting lower bound zero to satisfy the current
         // assignment
@@ -1211,7 +1226,7 @@ mod tests {
             Some(true)
         );
 
-        let result = solver.solve().expect("Failed to run simplex");
+        let result = solver.solve().expect("Failed to run simplex").decision;
         assert!(
             matches!(result, SolverDecision::FEASIBLE(_)),
             "unexpected result when x >= 0 is asserted"
@@ -1224,7 +1239,7 @@ mod tests {
         );
 
         // still feasible: system has solutions where x is unbounded
-        let result = solver.solve().expect("Failed to run simplex");
+        let result = solver.solve().expect("Failed to run simplex").decision;
         assert!(
             matches!(result, SolverDecision::FEASIBLE(_)),
             "unexpected result when x >= 100 is asserted"
@@ -1236,7 +1251,7 @@ mod tests {
             solver.assert_lower(&Var::real(2), &2i32.into()).unwrap(),
             Some(true)
         );
-        let result = solver.solve().expect("Failed to run simplex");
+        let result = solver.solve().expect("Failed to run simplex").decision;
         assert!(
             matches!(result, SolverDecision::FEASIBLE(_)),
             "unexpected result when y >= 100 is asserted"
@@ -1246,7 +1261,7 @@ mod tests {
     #[test]
     fn ex_5_6_backtrack_from_unsat() {
         let mut solver = ex_5_6_tableau();
-        let result = solver.solve().unwrap();
+        let result = solver.solve().unwrap().decision;
         assert!(matches!(result, SolverDecision::FEASIBLE(_)));
 
         // set a backtrack point and assert x <= 0 which makes the system infeasible
@@ -1257,12 +1272,12 @@ mod tests {
             solver.assert_upper(&Var::real(4), &0i32.into()).unwrap(),
             None
         );
-        let result = solver.solve().unwrap();
+        let result = solver.solve().unwrap().decision;
         assert!(matches!(result, SolverDecision::INFEASIBLE(_)));
 
         // backtrack to level 0 and assert that the system is feasible again
         solver.backtrack(level);
-        let result = solver.solve().unwrap();
+        let result = solver.solve().unwrap().decision;
         assert!(matches!(result, SolverDecision::FEASIBLE(_)));
     }
 }

--- a/src/arithmetic/lia/mod.rs
+++ b/src/arithmetic/lia/mod.rs
@@ -17,6 +17,7 @@ pub mod qdelta;
 pub mod solver_result;
 pub mod solver_result_api;
 pub mod sparse;
+pub mod stats;
 pub mod tableau;
 pub mod tableau_dense;
 pub mod tableau_sparse;

--- a/src/arithmetic/lia/solver_result.rs
+++ b/src/arithmetic/lia/solver_result.rs
@@ -9,6 +9,7 @@ use std::fmt;
 
 use dashu::Rational;
 
+use crate::arithmetic::lia::stats::Stats;
 use crate::arithmetic::lia::tableau::TableauError;
 use crate::arithmetic::lia::variables::{Var, VarInfo};
 
@@ -198,6 +199,22 @@ pub enum SolverDecision {
     FEASIBLE(Assignment<Var>),
     /// The original linear real arithmetic problem is UNSAT
     INFEASIBLE(Conflict<Var>),
+}
+
+/// Result returned from the LRA or LIRA solvers
+#[derive(Debug)]
+pub struct SolverReturn {
+    /// Solver decision, FEASIBLE, INFEASIBLE, or UNKNOWN along with supporting data
+    pub decision: SolverDecision,
+    /// Runtime statistics
+    pub stats: Stats,
+}
+
+impl SolverReturn {
+    /// Construct a new solver return result
+    pub fn new(decision: SolverDecision, stats: Stats) -> Self {
+        Self { decision, stats }
+    }
 }
 
 /// Return a default model for a set of variable id's

--- a/src/arithmetic/lia/stats.rs
+++ b/src/arithmetic/lia/stats.rs
@@ -1,0 +1,35 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Statistics for the LRA/LIRA solvers
+
+/// Statistics for the LRA/LIRA solvers
+#[derive(Debug, Clone)]
+pub struct Stats {
+    /// Number of simplex steps (pivots) in total across multiple LRASolver solve() calls
+    pub num_simplex_steps: usize,
+    /// Number of LRASolver solve() calls
+    pub num_lra_solve: usize,
+}
+
+impl Stats {
+    /// Construct a new [`Stats`] object
+    pub fn new() -> Self {
+        Self {
+            num_simplex_steps: 0,
+            num_lra_solve: 0,
+        }
+    }
+
+    /// Combine stats objects, adding the totals in `other` to `self`.
+    pub fn combine(&mut self, other: &Stats) {
+        self.num_simplex_steps += other.num_simplex_steps;
+        self.num_lra_solve += other.num_lra_solve;
+    }
+}
+
+impl Default for Stats {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/src/arithmetic/lialp.rs
+++ b/src/arithmetic/lialp.rs
@@ -95,26 +95,32 @@ pub fn check_integer_constraints_satisfiable_lia(
     }
 
     match frontend::solve_ctx_raw(&mut ctx, TableauKind::Dense) {
-        Ok(SolverDecision::FEASIBLE(assignment)) => {
-            let mut model_hashmap: DeterministicHashMap<i64, DeterministicHashSet<u64>> =
-                DeterministicHashMap::new();
-            for (term_id, root_var) in &roots {
-                if let Some(value) = assignment.get(root_var) {
-                    let val_i64: i64 = value.to_int().value().try_into().unwrap_or(i64::MAX);
-                    model_hashmap.entry(val_i64).or_default().insert(*term_id);
+        Ok(ret) => {
+            debug_println!(25, 4, "lia::frontend: stats: {:?}", ret.stats);
+            match ret.decision {
+                SolverDecision::FEASIBLE(assignment) => {
+                    let mut model_hashmap: DeterministicHashMap<i64, DeterministicHashSet<u64>> =
+                        DeterministicHashMap::new();
+                    for (term_id, root_var) in &roots {
+                        if let Some(value) = assignment.get(root_var) {
+                            let val_i64: i64 =
+                                value.to_int().value().try_into().unwrap_or(i64::MAX);
+                            model_hashmap.entry(val_i64).or_default().insert(*term_id);
+                        }
+                    }
+                    ArithResult::Sat(model_hashmap)
                 }
+                SolverDecision::INFEASIBLE(conflict) => {
+                    let unsat_core_literals: Vec<i32> = conflict
+                        .iter()
+                        .flat_map(|var| slack_to_lits.get(var).into_iter().flatten().copied())
+                        .collect();
+                    debug_println!(21, 4, "LIA: Unsat core literals: {:?}", unsat_core_literals);
+                    ArithResult::Unsat(unsat_core_literals)
+                }
+                SolverDecision::UNKNOWN => ArithResult::None,
             }
-            ArithResult::Sat(model_hashmap)
         }
-        Ok(SolverDecision::INFEASIBLE(conflict)) => {
-            let unsat_core_literals: Vec<i32> = conflict
-                .iter()
-                .flat_map(|var| slack_to_lits.get(var).into_iter().flatten().copied())
-                .collect();
-            debug_println!(21, 4, "LIA: Unsat core literals: {:?}", unsat_core_literals);
-            ArithResult::Unsat(unsat_core_literals)
-        }
-        Ok(SolverDecision::UNKNOWN) => ArithResult::None,
         Err(e) => panic!("lialp: unexpected error: {e:?}"),
     }
 }


### PR DESCRIPTION

*Description of changes:*

Thread a new `Stats` object through the LIA solver. For now it tracks number of LRA solver calls (corresponds to the number of branch and bound steps) and the number of LRA solver pivots (corresponds to the complexity of individual rational solver calls).

The stats object is logged; this is currently the only way to get the information out of Sundance. For example:

```
./target/debug/sundance-smt --arithmetic internal --debug 25 \
    tests/regression/smt_files/arithmetic/subtraction4.smt2 2>&1 \
    | grep "lia::front\|lia::lira"
```

Shows branch and bound step statistics, durations for each LRA solver call, and shows how the solver ultimately gets stuck in branch and bound in this specific query.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
