### PR TITLE
Add SolverConfig and a default limit on branch-and-bound steps

### DIFF
--- a/src/arithmetic/lia/config.rs
+++ b/src/arithmetic/lia/config.rs
@@ -1,0 +1,28 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Solver configuration for the LIA arithmetic solver.
+
+use crate::arithmetic::lia::tableau::TableauKind;
+
+/// Configuration parameters for the LIA solver pipeline.
+#[derive(Debug, Clone)]
+pub struct SolverConfig {
+    /// Which tableau implementation to use (dense or sparse).
+    pub tableau_kind: TableauKind,
+    /// Upper bound on the number of LRA solve calls in branch-and-bound.
+    /// `None` means unlimited.
+    pub max_lra_solve_calls: Option<usize>,
+}
+
+impl Default for SolverConfig {
+    fn default() -> Self {
+        Self {
+            tableau_kind: TableauKind::Dense,
+            // 2^17; high enough that regression tests pass as expected
+            // i.e. they are either SAT/UNSAT or TIMEOUT. If this is lowered
+            // significantly, some will return UNKNOWN instead.
+            max_lra_solve_calls: Some(131_072),
+        }
+    }
+}

--- a/src/arithmetic/lia/frontend.rs
+++ b/src/arithmetic/lia/frontend.rs
@@ -15,6 +15,7 @@ use yaspar_ir::ast::{Context, LetElim, Term, Typecheck};
 use yaspar_ir::traits::Repr;
 use yaspar_ir::untyped::{Command, UntypedAst};
 
+use crate::arithmetic::lia::config::SolverConfig;
 use crate::arithmetic::lia::context::ConvContext;
 use crate::arithmetic::lia::linear_system::{
     Addend, Constraint, LinearSystem, LinearSystemError, Rel, combine_terms_helper,
@@ -27,7 +28,6 @@ use crate::arithmetic::lia::solver_result::{
 };
 use crate::arithmetic::lia::solver_result_api::SolverDecisionApi;
 use crate::arithmetic::lia::stats::Stats;
-use crate::arithmetic::lia::tableau::TableauKind;
 use crate::arithmetic::lia::types::{FBig, Integer, Rational, UBig};
 use crate::arithmetic::lia::variables::VarType;
 use crate::debug_println;
@@ -484,21 +484,18 @@ fn convert_terms(terms: &[Term]) -> FrontendResult<ConvContext> {
 }
 
 /// Parse an SMT script and build a QF_LRA solver without preprocessing
-pub fn smt_to_lra_solver(smt_input: &str, tableau_kind: TableauKind) -> FrontendResult<LRASolver> {
+pub fn smt_to_lra_solver(smt_input: &str, config: &SolverConfig) -> FrontendResult<LRASolver> {
     let ctx = convert_smt(smt_input)?;
-    Ok(LinearSystem::new(ctx).to_lra_solver(true, tableau_kind)?)
+    Ok(LinearSystem::new(ctx).to_lra_solver(true, config)?)
 }
 
 /// Top-level arithmetic solving function
 ///
 /// This provides solving a system of linear (in)equalities over the rationals as a single function
 /// call from SMT-LIB text as input.
-pub fn solve_smtlib(
-    smt_input: &str,
-    tableau_kind: TableauKind,
-) -> FrontendResult<SolverDecisionApi> {
+pub fn solve_smtlib(smt_input: &str, config: &SolverConfig) -> FrontendResult<SolverDecisionApi> {
     let ctx = convert_smt(smt_input)?;
-    solve_with_context(ctx, tableau_kind)
+    solve_with_context(ctx, config)
 }
 
 /// Top-level mixed-integer arithmetic solver
@@ -506,23 +503,20 @@ pub fn solve_smtlib(
 /// This version accepts a list of arithmetic literals and returns SAT/UNSAT/UNKNOW
 /// as usual. SAT comes with a satisfying assignment and UNSAT comes with a conflict
 /// set which is guaranteed to be a subset of the input literals.
-pub fn solve(
-    arith_literals: &[Term],
-    tableau_kind: TableauKind,
-) -> FrontendResult<SolverDecisionApi> {
+pub fn solve(arith_literals: &[Term], config: &SolverConfig) -> FrontendResult<SolverDecisionApi> {
     // The context is used to construct a solver below, but also to report conflicts
     // and assignments to the outside in terms of [Term]s rather than internal variables.
     // This value is consumed below, but some of the mappings are cloned for reporting.
     let ctx = convert_terms(arith_literals)?;
-    solve_with_context(ctx, tableau_kind)
+    solve_with_context(ctx, config)
 }
 
 fn solve_with_context(
     mut ctx: ConvContext,
-    tableau_kind: TableauKind,
+    config: &SolverConfig,
 ) -> FrontendResult<SolverDecisionApi> {
     let (_, var_term_map) = ctx.get_term_var_maps(); // this is a clone
-    let decision = solve_ctx_raw(&mut ctx, tableau_kind)?;
+    let decision = solve_ctx_raw(&mut ctx, config)?;
     // TODO: frontend::solve_with_context: return stats through SolverDecisionApi
     Ok(SolverDecisionApi::from_solver_decision(
         &var_term_map,
@@ -531,10 +525,7 @@ fn solve_with_context(
 }
 
 /// Run the solver given the provided context and return the resulting SolverDecision.
-pub fn solve_ctx_raw(
-    ctx: &mut ConvContext,
-    tableau_kind: TableauKind,
-) -> FrontendResult<SolverReturn> {
+pub fn solve_ctx_raw(ctx: &mut ConvContext, config: &SolverConfig) -> FrontendResult<SolverReturn> {
     // preprocess the input relations, detect trivial cases, and otherwise return a [LinearSystem]
     // from which to build a solver.
     let result = preprocess(ctx);
@@ -563,9 +554,9 @@ pub fn solve_ctx_raw(
         PreprocessResult::Unknown => LinearSystem::new(ctx.clone()),
     };
     let lra_solver = sys
-        .to_lra_solver(true, tableau_kind)
+        .to_lra_solver(true, config)
         .map_err(|e| FrontendError(format!("error building lra_solver: {}", e)))?;
-    let mut lira_solver = LIRASolver::new(lra_solver);
+    let mut lira_solver = LIRASolver::new(lra_solver, config.clone());
     debug_println!(25, 0, "lia::frontend::solve_ctx_raw: Starting LIRA solver");
     let start = Instant::now();
     let ret = lira_solver
@@ -583,11 +574,11 @@ pub fn solve_ctx_raw(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::arithmetic::lia::config::SolverConfig;
     use crate::arithmetic::lia::frontend::{convert_smt, smt_to_lra_solver, solve_smtlib};
     use crate::arithmetic::lia::preprocess::{PreprocessResult, preprocess};
     use crate::arithmetic::lia::solver_result::SolverDecision;
     use crate::arithmetic::lia::solver_result_api::SolverDecisionApi;
-    use crate::arithmetic::lia::tableau::TableauKind;
     use crate::arithmetic::lia::types::{DBig, rbig};
     use crate::arithmetic::lia::variables::Var;
     use std::str::FromStr;
@@ -742,7 +733,7 @@ mod tests {
 (check-sat)
     "#;
         assert!(matches!(
-            solve_smtlib(smt, TableauKind::Dense).unwrap(),
+            solve_smtlib(smt, &SolverConfig::default()).unwrap(),
             SolverDecisionApi::FEASIBLE(_)
         ));
     }
@@ -776,7 +767,7 @@ mod tests {
             unreachable!()
         }
 
-        let result = solve_smtlib(smt_input, TableauKind::Dense).expect("solver failed");
+        let result = solve_smtlib(smt_input, &SolverConfig::default()).expect("solver failed");
         assert!(matches!(result, SolverDecisionApi::FEASIBLE(_)));
     }
 
@@ -802,7 +793,7 @@ mod tests {
             preprocess(&mut ctx),
             PreprocessResult::TriviallySat
         ));
-        let result = solve_smtlib(smt_input, TableauKind::Dense).expect("solver failed");
+        let result = solve_smtlib(smt_input, &SolverConfig::default()).expect("solver failed");
         assert!(matches!(result, SolverDecisionApi::FEASIBLE(_)));
     }
 
@@ -827,7 +818,7 @@ mod tests {
             preprocess(&mut ctx),
             PreprocessResult::TriviallyUnsat(_)
         ));
-        let result = solve_smtlib(smt_input, TableauKind::Dense).expect("solver failed");
+        let result = solve_smtlib(smt_input, &SolverConfig::default()).expect("solver failed");
         assert!(matches!(result, SolverDecisionApi::INFEASIBLE(_)));
     }
 
@@ -856,8 +847,8 @@ mod tests {
 (check-sat)
     "#;
 
-        let mut solver =
-            smt_to_lra_solver(smt_input, TableauKind::Dense).expect("Failed to create LRA solver");
+        let mut solver = smt_to_lra_solver(smt_input, &SolverConfig::default())
+            .expect("Failed to create LRA solver");
         let result = solver
             .solve()
             .expect("Failed to run simplex algorithm")
@@ -876,8 +867,8 @@ mod tests {
 (assert (>= (+ x0 x1) 1))
 (check-sat)
     "#;
-        let mut solver =
-            smt_to_lra_solver(smt_input, TableauKind::Dense).expect("Failed to create LRA solver");
+        let mut solver = smt_to_lra_solver(smt_input, &SolverConfig::default())
+            .expect("Failed to create LRA solver");
         let result = solver
             .solve()
             .expect("Failed to run simplex algorithm")
@@ -897,8 +888,8 @@ mod tests {
 (assert (not b))
 (check-sat)
     "#;
-        let mut solver =
-            smt_to_lra_solver(smt_input, TableauKind::Dense).expect("Failed to create LRA solver");
+        let mut solver = smt_to_lra_solver(smt_input, &SolverConfig::default())
+            .expect("Failed to create LRA solver");
         let result = solver
             .solve()
             .expect("Failed to run simplex algorithm")
@@ -914,8 +905,8 @@ mod tests {
 (assert (<= (/ x0 2) 0))
 (check-sat)
     "#;
-        let mut solver =
-            smt_to_lra_solver(smt_input, TableauKind::Dense).expect("Failed to create LRA solver");
+        let mut solver = smt_to_lra_solver(smt_input, &SolverConfig::default())
+            .expect("Failed to create LRA solver");
         let result = solver
             .solve()
             .expect("Failed to run simplex algorithm")
@@ -931,8 +922,8 @@ mod tests {
 (assert (= x (- 1 2 3)))  ; x = (1 - 2) - 3 = -4
 (check-sat)
     "#;
-        let mut solver =
-            smt_to_lra_solver(smt_input, TableauKind::Dense).expect("Failed to create LRA solver");
+        let mut solver = smt_to_lra_solver(smt_input, &SolverConfig::default())
+            .expect("Failed to create LRA solver");
         let result = solver
             .solve()
             .expect("Failed to run simplex algorithm")
@@ -955,8 +946,8 @@ mod tests {
 (assert (= x (f x)))
 (check-sat)
     "#;
-        let mut solver =
-            smt_to_lra_solver(smt_input, TableauKind::Dense).expect("Failed to create LRA solver");
+        let mut solver = smt_to_lra_solver(smt_input, &SolverConfig::default())
+            .expect("Failed to create LRA solver");
         let result = solver
             .solve()
             .expect("Failed to run simplex algorithm")
@@ -981,8 +972,8 @@ mod tests {
 (assert (< i j))
 (check-sat)
     "#;
-        let mut solver =
-            smt_to_lra_solver(smt_input, TableauKind::Dense).expect("Failed to create LRA solver");
+        let mut solver = smt_to_lra_solver(smt_input, &SolverConfig::default())
+            .expect("Failed to create LRA solver");
         let result = solver
             .solve()
             .expect("Failed to run simplex algorithm")

--- a/src/arithmetic/lia/linear_system.rs
+++ b/src/arithmetic/lia/linear_system.rs
@@ -20,10 +20,10 @@ use std::hash::{Hash, Hasher};
 use std::ops;
 
 use crate::arithmetic::lia::bounds::Bounds;
+use crate::arithmetic::lia::config::SolverConfig;
 use crate::arithmetic::lia::context::ConvContext;
 use crate::arithmetic::lia::lra_solver::LRASolver;
 use crate::arithmetic::lia::qdelta::QDelta;
-use crate::arithmetic::lia::tableau::TableauKind;
 use crate::arithmetic::lia::utils;
 use crate::arithmetic::lia::variables::{Owner, Var, VarInfo};
 use crate::debug_println;
@@ -661,7 +661,7 @@ impl LinearSystem {
     pub fn to_lra_solver(
         self,
         relation_bounds: bool,
-        tableau_kind: TableauKind,
+        config: &SolverConfig,
     ) -> LinearSystemResult<LRASolver> {
         // original variable id's
         let var_set = self.var_id_set();
@@ -742,7 +742,7 @@ impl LinearSystem {
             equations.len(),
             num_non_zero
         );
-        LRASolver::from_eqs(basic, non_basic, equations, self.ctx, tableau_kind)
+        LRASolver::from_eqs(basic, non_basic, equations, self.ctx, config.tableau_kind)
             .map_err(|e| LinearSystemError(format!("error building tableau: {}", e)))
     }
 }
@@ -752,6 +752,7 @@ mod tests {
     use super::*;
 
     use crate::arithmetic::lia::{
+        config::SolverConfig,
         context::ConvContext,
         linear_system::{LinearSystem, Mon, Rel},
         lra_solver::LRASolver,
@@ -1097,7 +1098,7 @@ mod tests {
 
         let sys = LinearSystem::new(ctx.clone());
         let mut solver = sys
-            .to_lra_solver(true, TableauKind::Dense)
+            .to_lra_solver(true, &SolverConfig::default())
             .expect("failed to build solver");
 
         assert!(solver.is_valid());
@@ -1107,7 +1108,13 @@ mod tests {
         // Same test but with sparse tableau
         let sys = LinearSystem::new(ctx);
         let mut solver = sys
-            .to_lra_solver(true, TableauKind::Sparse)
+            .to_lra_solver(
+                true,
+                &SolverConfig {
+                    tableau_kind: TableauKind::Sparse,
+                    ..SolverConfig::default()
+                },
+            )
             .expect("failed to build solver");
 
         assert!(solver.is_valid());
@@ -1137,7 +1144,7 @@ mod tests {
 
         let sys = LinearSystem::new(ctx);
         let mut solver = sys
-            .to_lra_solver(false, TableauKind::Dense)
+            .to_lra_solver(false, &SolverConfig::default())
             .expect("failed to build solver");
 
         assert!(solver.is_valid());
@@ -1200,7 +1207,7 @@ mod tests {
 
         let sys = LinearSystem::new(ctx);
         let mut solver = sys
-            .to_lra_solver(true, TableauKind::Dense)
+            .to_lra_solver(true, &SolverConfig::default())
             .expect("failed to build solver");
         assert!(solver.is_valid());
         assert!(matches!(
@@ -1272,7 +1279,7 @@ mod tests {
 
         let sys = LinearSystem::new(ctx.clone());
         let mut solver = sys
-            .to_lra_solver(true, TableauKind::Dense)
+            .to_lra_solver(true, &SolverConfig::default())
             .expect("failed to build solver");
         assert!(solver.is_valid());
         let result = solver.solve().expect("simplex failed").decision;
@@ -1289,7 +1296,13 @@ mod tests {
         // same test but with sparse tableau
         let sys = LinearSystem::new(ctx);
         let mut solver = sys
-            .to_lra_solver(true, TableauKind::Sparse)
+            .to_lra_solver(
+                true,
+                &SolverConfig {
+                    tableau_kind: TableauKind::Sparse,
+                    ..SolverConfig::default()
+                },
+            )
             .expect("failed to build solver");
         assert!(solver.is_valid());
         let result = solver.solve().expect("simplex failed").decision;
@@ -1356,7 +1369,7 @@ mod tests {
 
         let sys = LinearSystem::new(ctx.clone());
         let mut solver = sys
-            .to_lra_solver(true, TableauKind::Dense)
+            .to_lra_solver(true, &SolverConfig::default())
             .expect("failed to build solver");
         assert!(solver.is_valid());
         let result = solver.solve().expect("simplex failed").decision;
@@ -1376,7 +1389,13 @@ mod tests {
         // same test but with sparse tableau
         let sys = LinearSystem::new(ctx);
         let mut solver = sys
-            .to_lra_solver(true, TableauKind::Sparse)
+            .to_lra_solver(
+                true,
+                &SolverConfig {
+                    tableau_kind: TableauKind::Sparse,
+                    ..SolverConfig::default()
+                },
+            )
             .expect("failed to build solver");
         assert!(solver.is_valid());
         let result = solver.solve().expect("simplex failed").decision;
@@ -1398,7 +1417,7 @@ mod tests {
 
         let sys = LinearSystem::new(ctx);
         let mut solver = sys
-            .to_lra_solver(true, TableauKind::Dense)
+            .to_lra_solver(true, &SolverConfig::default())
             .expect("failed to build solver");
 
         assert!(solver.is_valid());
@@ -1427,7 +1446,7 @@ mod tests {
 
         let sys = LinearSystem::new(ctx);
         let solver = sys
-            .to_lra_solver(true, TableauKind::Dense)
+            .to_lra_solver(true, &SolverConfig::default())
             .expect("failed to build solver");
         assert!(solver.is_valid());
         (solver, x, y)
@@ -1570,7 +1589,7 @@ mod tests {
         let _r3 = ctx.allocate_relation(Rel::mk_ge(vec![Mon::new(1, x)], rbig!(1 / 3)));
 
         let sys = LinearSystem::new(ctx);
-        let mut solver = sys.to_lra_solver(true, TableauKind::Dense).unwrap();
+        let mut solver = sys.to_lra_solver(true, &SolverConfig::default()).unwrap();
 
         let result = solver.solve().unwrap().decision;
         if let SolverDecision::FEASIBLE(assg) = result {
@@ -1597,7 +1616,7 @@ mod tests {
         let _r4 = ctx.allocate_relation(Rel::mk_le(vec![Mon::new(1, x)], rbig!(0))); // new bound x <= 0
 
         let sys = LinearSystem::new(ctx);
-        let mut solver = sys.to_lra_solver(true, TableauKind::Dense).unwrap();
+        let mut solver = sys.to_lra_solver(true, &SolverConfig::default()).unwrap();
         assert!(matches!(
             solver.solve().unwrap().decision,
             SolverDecision::INFEASIBLE(_)
@@ -1613,7 +1632,7 @@ mod tests {
         let _r4 = ctx.allocate_relation(Rel::mk_ge(vec![Mon::new(1, y)], rbig!(1))); // new bound y >= 1
 
         let sys = LinearSystem::new(ctx);
-        let mut solver = sys.to_lra_solver(true, TableauKind::Dense).unwrap();
+        let mut solver = sys.to_lra_solver(true, &SolverConfig::default()).unwrap();
         assert!(matches!(
             solver.solve().unwrap().decision,
             SolverDecision::INFEASIBLE(_)
@@ -1650,7 +1669,7 @@ mod tests {
 
         // Verify that the system is still solvable
         let mut solver = sys
-            .to_lra_solver(true, TableauKind::Dense)
+            .to_lra_solver(true, &SolverConfig::default())
             .expect("failed to build tableau");
         assert!(solver.is_valid());
         let result = solver.solve().expect("simplex failed").decision;
@@ -1679,7 +1698,7 @@ mod tests {
 
         // Verify that the system is infeasible
         let mut solver = sys
-            .to_lra_solver(true, TableauKind::Dense)
+            .to_lra_solver(true, &SolverConfig::default())
             .expect("failed to build solver");
         let result = solver.solve().expect("solver failed").decision;
         assert!(matches!(result, SolverDecision::INFEASIBLE(_)));

--- a/src/arithmetic/lia/lira_solver.rs
+++ b/src/arithmetic/lia/lira_solver.rs
@@ -10,6 +10,7 @@ use dashu::{Integer, Rational};
 use slotmap;
 
 use crate::arithmetic::lia::bounds::Bounds;
+use crate::arithmetic::lia::config::SolverConfig;
 use crate::arithmetic::lia::lra_solver::LRASolver;
 use crate::arithmetic::lia::qdelta::QDelta;
 use crate::arithmetic::lia::solver_result::{Conflict, SolverDecision, SolverResult, SolverReturn};
@@ -180,13 +181,15 @@ pub struct LIRASolver {
     lra_solver: LRASolver,
     /// Stack of variable bounds for tracking during solving
     explorer: BrtExplorer,
+    /// Solver configuration
+    config: SolverConfig,
     /// Runtime statistics
     stats: Stats,
 }
 
 impl LIRASolver {
     /// Create a new LIRASolver with the given LRASolver
-    pub fn new(lra_solver: LRASolver) -> Self {
+    pub fn new(lra_solver: LRASolver, config: SolverConfig) -> Self {
         let root = BrtNode {
             level: Some(0usize),
             state: BrtNodeState::Active(BrtAction::NoOp),
@@ -195,6 +198,7 @@ impl LIRASolver {
         Self {
             lra_solver,
             explorer: BrtExplorer::new(root),
+            config,
             stats: Stats::new(),
         }
     }
@@ -318,6 +322,14 @@ impl LIRASolver {
             let ret = self.lra_solver.solve()?;
             // this also bumps num_lra_solve by 1
             self.stats.combine(&ret.stats);
+            if let Some(max) = self.config.max_lra_solve_calls
+                && self.stats.num_lra_solve > max
+            {
+                return Ok(SolverReturn::new(
+                    SolverDecision::UNKNOWN,
+                    self.stats.clone(),
+                ));
+            }
             match ret.decision {
                 SolverDecision::INFEASIBLE(cs) => {
                     debug_println!(
@@ -468,11 +480,11 @@ impl LIRASolver {
 mod tests {
     use dashu::{Rational, rbig};
 
+    use crate::arithmetic::lia::config::SolverConfig;
     use crate::arithmetic::lia::frontend::{smt_to_lra_solver, solve_smtlib};
     use crate::arithmetic::lia::lira_solver::LIRASolver;
     use crate::arithmetic::lia::solver_result::SolverDecision;
     use crate::arithmetic::lia::solver_result_api::SolverDecisionApi;
-    use crate::arithmetic::lia::tableau::TableauKind;
 
     /// Execute branch and bound manually on an UNSAT QF_LIA problem
     #[test]
@@ -486,8 +498,8 @@ mod tests {
         (assert (>= x (/ (to_real 1) (to_real 3))))  ; x >= 1/3
         (assert (<= (to_real y) (/ (to_real 2) (to_real 3))))  ; y <= 2/3
             "#;
-        let mut solver =
-            smt_to_lra_solver(smt_input, TableauKind::Dense).expect("Failed to create LRA solver");
+        let mut solver = smt_to_lra_solver(smt_input, &SolverConfig::default())
+            .expect("Failed to create LRA solver");
         let ass = match solver.solve().unwrap().decision {
             SolverDecision::FEASIBLE(ass) => ass,
             _ => unreachable!(),
@@ -554,9 +566,9 @@ mod tests {
         (assert (>= x (/ (to_real 1) (to_real 3))))  ; x >= 1/3
         (assert (<= (to_real y) (/ (to_real 2) (to_real 3))))  ; y <= 2/3
             "#;
-        let lra_solver =
-            smt_to_lra_solver(smt_input, TableauKind::Dense).expect("Failed to create LRA solver");
-        let mut lira_solver = LIRASolver::new(lra_solver);
+        let lra_solver = smt_to_lra_solver(smt_input, &SolverConfig::default())
+            .expect("Failed to create LRA solver");
+        let mut lira_solver = LIRASolver::new(lra_solver, SolverConfig::default());
         assert!(matches!(
             lira_solver.solve().unwrap().decision,
             SolverDecision::INFEASIBLE(_)
@@ -584,9 +596,9 @@ mod tests {
         (check-sat)
         "#;
 
-        let lra_solver =
-            smt_to_lra_solver(smt_input, TableauKind::Dense).expect("Failed to create LRA solver");
-        let mut lira_solver = LIRASolver::new(lra_solver);
+        let lra_solver = smt_to_lra_solver(smt_input, &SolverConfig::default())
+            .expect("Failed to create LRA solver");
+        let mut lira_solver = LIRASolver::new(lra_solver, SolverConfig::default());
 
         // Assert that the system is INFEASIBLE
         assert!(matches!(
@@ -651,9 +663,9 @@ mod tests {
         (assert (>= (+ (+ 1 (* (- 1) x)) (+ 1 (* (- 1) y)) (+ 1 (* (- 1) z))) 1))
         "#;
 
-        let lra_solver =
-            smt_to_lra_solver(smt_input, TableauKind::Dense).expect("Failed to create LRA solver");
-        let mut lira_solver = LIRASolver::new(lra_solver);
+        let lra_solver = smt_to_lra_solver(smt_input, &SolverConfig::default())
+            .expect("Failed to create LRA solver");
+        let mut lira_solver = LIRASolver::new(lra_solver, SolverConfig::default());
 
         // Assert that the system is INFEASIBLE
         assert!(matches!(
@@ -677,12 +689,12 @@ mod tests {
         (check-sat)
         "#;
         // first 3 constraints are sat
-        let result = solve_smtlib(smt1, TableauKind::Dense).expect("solver failed");
+        let result = solve_smtlib(smt1, &SolverConfig::default()).expect("solver failed");
         assert!(matches!(result, SolverDecisionApi::FEASIBLE(_)));
 
         // all 4 constraints are sat
         let smt2 = smt1.to_string() + "(assert (> (- (* 7 x) (* 9 y)) 4))";
-        let result2 = solve_smtlib(&smt2, TableauKind::Dense).expect("solver failed");
+        let result2 = solve_smtlib(&smt2, &SolverConfig::default()).expect("solver failed");
         assert!(matches!(result2, SolverDecisionApi::FEASIBLE(_)));
 
         // now prove validity
@@ -694,7 +706,7 @@ mod tests {
         // forall (x y: Int) -(C1 and C2 and C3) or C4
         // negate: exists (x y: Int) (C1 and ... and C3) and (-C4)
         let smt3 = smt1.to_string() + "(assert (not (> (- (* 7 x) (* 9 y)) 4)))";
-        let result3 = solve_smtlib(&smt3, TableauKind::Dense).expect("solver failed");
+        let result3 = solve_smtlib(&smt3, &SolverConfig::default()).expect("solver failed");
         assert!(matches!(result3, SolverDecisionApi::INFEASIBLE(_)));
     }
 
@@ -709,7 +721,7 @@ mod tests {
         (assert (not (>= (+ (* 2 a) b) (+ b a a))))
         (check-sat)
         "#;
-        let result = solve_smtlib(smt, TableauKind::Dense).expect("solver failed");
+        let result = solve_smtlib(smt, &SolverConfig::default()).expect("solver failed");
         assert!(matches!(result, SolverDecisionApi::INFEASIBLE(_)),);
         if let SolverDecisionApi::INFEASIBLE(conflict) = result {
             assert_eq!(conflict.len(), 1);
@@ -730,7 +742,7 @@ mod tests {
         (assert (not (<= (* 2 a) (* 3 c))))
         (check-sat)
         "#;
-        let result = solve_smtlib(smt, TableauKind::Dense).expect("solver failed");
+        let result = solve_smtlib(smt, &SolverConfig::default()).expect("solver failed");
         assert!(matches!(result, SolverDecisionApi::INFEASIBLE(_)),);
         if let SolverDecisionApi::INFEASIBLE(conflict) = result {
             assert_eq!(conflict.len(), 3); // every subset of 2 assertions is feasible
@@ -763,7 +775,7 @@ mod tests {
         (assert (< (+ a b (* 3.0 c) d (* 2.0 e)) 0.0))  ; x
         (check-sat)
         "#;
-        let result = solve_smtlib(smt, TableauKind::Dense).expect("solver failed");
+        let result = solve_smtlib(smt, &SolverConfig::default()).expect("solver failed");
         assert!(matches!(result, SolverDecisionApi::INFEASIBLE(_)),);
         if let SolverDecisionApi::INFEASIBLE(conflict) = result {
             assert_eq!(conflict.len(), 6);
@@ -787,7 +799,7 @@ mod tests {
         (assert (< (+ a b (* 3.0 c) d (* 2.0 e)) 0.0))  ; x
         (check-sat)
         "#;
-        let result = solve_smtlib(smt_conflict, TableauKind::Dense).expect("solver failed");
+        let result = solve_smtlib(smt_conflict, &SolverConfig::default()).expect("solver failed");
         assert!(matches!(result, SolverDecisionApi::INFEASIBLE(_)),);
 
         // Sanity check that the conflict is minimal; not a proof of such, just
@@ -807,7 +819,7 @@ mod tests {
         (assert (< (+ a b (* 3.0 c) d (* 2.0 e)) 0.0))  ; x
         (check-sat)
         "#;
-        let result = solve_smtlib(smt_conflict, TableauKind::Dense).expect("solver failed");
+        let result = solve_smtlib(smt_conflict, &SolverConfig::default()).expect("solver failed");
         assert!(matches!(result, SolverDecisionApi::FEASIBLE(_)),);
     }
 
@@ -827,7 +839,7 @@ mod tests {
         (assert (< (- b) 1))
         (check-sat)
         "#;
-        let result = solve_smtlib(smt, TableauKind::Dense).expect("solver failed");
+        let result = solve_smtlib(smt, &SolverConfig::default()).expect("solver failed");
         assert!(matches!(result, SolverDecisionApi::INFEASIBLE(_)),);
         if let SolverDecisionApi::INFEASIBLE(conflict) = result {
             assert_eq!(conflict.len(), 2);
@@ -844,7 +856,7 @@ mod tests {
         (assert (= (* 2 x) 3))
         (check-sat)
         "#;
-        let result = solve_smtlib(smt, TableauKind::Dense).expect("solver failed");
+        let result = solve_smtlib(smt, &SolverConfig::default()).expect("solver failed");
         assert!(matches!(result, SolverDecisionApi::FEASIBLE(_)),);
         if let SolverDecisionApi::FEASIBLE(assg) = result {
             let (_, val) = assg.iter().next().unwrap();

--- a/src/arithmetic/lia/mod.rs
+++ b/src/arithmetic/lia/mod.rs
@@ -7,6 +7,7 @@
 #![warn(missing_docs, missing_debug_implementations, rust_2018_idioms)]
 
 pub mod bounds;
+pub mod config;
 pub mod context;
 pub mod frontend;
 pub mod linear_system;

--- a/src/arithmetic/lialp.rs
+++ b/src/arithmetic/lialp.rs
@@ -3,11 +3,11 @@
 
 //! Entry point for the LIA mixed integer arithmetic solver
 
+use crate::arithmetic::lia::config::SolverConfig;
 use crate::arithmetic::lia::context::ConvContext;
 use crate::arithmetic::lia::frontend;
 use crate::arithmetic::lia::linear_system::{Mon, Rel};
 use crate::arithmetic::lia::solver_result::SolverDecision;
-use crate::arithmetic::lia::tableau::TableauKind;
 use crate::arithmetic::lia::variables::{Var, VarType};
 use crate::arithmetic::lp::{
     ArithResult, Coefficient, FunctionType::*, extract_linear_constraints,
@@ -94,7 +94,7 @@ pub fn check_integer_constraints_satisfiable_lia(
         slack_to_lits.insert(slack, lits);
     }
 
-    match frontend::solve_ctx_raw(&mut ctx, TableauKind::Dense) {
+    match frontend::solve_ctx_raw(&mut ctx, &SolverConfig::default()) {
         Ok(ret) => {
             debug_println!(25, 4, "lia::frontend: stats: {:?}", ret.stats);
             match ret.decision {


### PR DESCRIPTION
*Description of changes:*

This change adds arithmetic solver configuration. The configuration currently consists of the tableau kind (dense or sparse) and a new option to limit the number of branch-and-bound steps. Limiting branch-and-bound prevents it from diverging. When the limit is hit, the arithmetic solver returns UNKNOWN.

The default limit is chosen to be large enough so that all regression tests pass, i.e. either return the correct answer or timeout. Setting a much lower limit has the effect of turning some TIMEOUT  and UNSAT queries into UNKNOWNs.

Regression test results show one less timeout than before the change:

```
Test Summary:
Total tests: 365
Correct:     348
Incorrect:   0
Timeout:     17
test regression_test ... ok
```

On the Verus benchmarks, limiting branch-and-bound has the effect of raising the number of queries solved UNSAT from 56.3% to 58.8%.

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
