### PR TITLE
Implement the SPASS-SATT heuristic for pivot variable selection

### DIFF
--- a/src/arithmetic/lia/lra_solver.rs
+++ b/src/arithmetic/lia/lra_solver.rs
@@ -54,6 +54,15 @@ enum PivotDirection {
     Decrease,
 }
 
+/// Current pivot selection heuristic
+#[derive(Debug)]
+enum PivotHeuristic {
+    /// prefers basic variables by order and non-basic variables that are unbounded
+    Greedy,
+    /// prefers both basic and non-basic variables by order
+    Bland,
+}
+
 /// Linear real arithmetic solver
 pub struct LRASolver {
     /// Variable info for all original and slack variables. The vector itself should be immutable,
@@ -90,14 +99,16 @@ pub struct LRASolver {
     backtrack_level: usize,
     /// backup copy of the solver's assignment at some backtracking point
     old_assignment: Option<BTreeMap<Var, QDelta>>,
+    /// Current pivot selection heuristic
+    pivot_heuristic: PivotHeuristic,
+    /// During `solve()`, the current number of simplex steps that have been performed
+    num_simplex_steps: usize,
 
     // -- Mappings for bookkeeping --
     /// mapping from Var to index in `self.variables`
     var_to_idx: BTreeMap<Var, usize>,
     /// Conversion context from the frontend including the name <-> Var mapping
     ctx: ConvContext,
-    /// During `solve()`, the current number of simplex steps that have been performed
-    num_simplex_steps: usize,
 }
 
 impl fmt::Debug for LRASolver {
@@ -113,6 +124,7 @@ impl fmt::Debug for LRASolver {
         s.push_str(&format!("Non-Basic pointers:\n  {0:?}\n", self.non_basic));
         s.push_str(&format!("Tableau:\n  {0:?}\n", self.tableau));
         s.push_str(&format!("State: {:?}\n", self.state));
+        s.push_str(&format!("Pivot heuristic: {:?}\n", self.pivot_heuristic));
         s.push_str(&format!("Num simplex steps: {}\n", self.num_simplex_steps));
         // TODO: add the rest of the solver state, including backtracking info
         write!(f, "{}", s)
@@ -532,6 +544,22 @@ impl LRASolver {
         d0
     }
 
+    /// Implements the SPASS-SATT pivot hueristic: start with Greedy non-basic variable selection
+    /// (see [`LRASolver::find_pivot_and_update`]) and switch to Bland's rule after a fixed number of pivot
+    /// steps.
+    fn update_pivot_heuristic(&mut self) {
+        if let PivotHeuristic::Greedy = self.pivot_heuristic
+            && self.num_simplex_steps > self.basic.len()
+        {
+            debug_println!(
+                25,
+                0,
+                "lia::lra_solver: switching pivot heuristic to Bland's Rule"
+            );
+            self.pivot_heuristic = PivotHeuristic::Bland;
+        }
+    }
+
     /// Helper function for `step_simplex` that finds a non-basic variable to pivot on.
     fn find_pivot_and_update(
         &mut self,
@@ -554,8 +582,84 @@ impl LRASolver {
                 .clone(),
         };
 
-        // iterate over non_basic (col) variables in the fixed variable ordering
-        for var in self.variables.iter() {
+        let non_basics: Vec<_> = self
+            .variables
+            .iter()
+            .filter(|v| v.is_non_basic().is_some())
+            .collect();
+
+        if let PivotHeuristic::Greedy = self.pivot_heuristic {
+            let unbounded_non_basics: Vec<_> = non_basics
+                .iter()
+                .filter(|v| v.is_totally_unbounded())
+                .collect();
+            if !unbounded_non_basics.is_empty() {
+                let col = unbounded_non_basics[0].is_non_basic().unwrap();
+                let a_i_j = self.tableau.get(row, col).unwrap();
+                // as long as a_i_j is non-zero, the non-basic variable is eligible
+                if !a_i_j.is_zero() {
+                    debug_println!(
+                        15,
+                        0,
+                        "lia::lra_solver: (greedy) pivot basic (row {}) {} and non-basic (col {}) {}, update non-basic val to {}",
+                        row,
+                        self.variables[row_var_idx],
+                        col,
+                        self.variables[self.non_basic[col]],
+                        target_bound
+                    );
+                    self.pivot_and_update(row, col, &target_bound)?;
+                    // Invariant: in `step_simplex` or `find_pivot_and_update` => `self.state ==
+                    // LRASolverState::Unknown`
+                    return Ok(SimplexStepResult::Unknown);
+                }
+            }
+            // No unbounded non-basic variable found. Select the eligible variable with the
+            // smallest number of non-zero entries in its tableau column. Ties are broken by
+            // the fixed self.variables ordering (iteration order).
+            let mut best: Option<(usize, usize)> = None; // (col, nnz)
+            for var in non_basics.iter() {
+                let col = var.is_non_basic().unwrap();
+                let a_i_j = self.tableau.get(row, col).unwrap();
+
+                let eligible = match direction {
+                    PivotDirection::Increase => {
+                        (a_i_j > &Rational::ZERO && !var.at_upper())
+                            || (a_i_j < &Rational::ZERO && !var.at_lower())
+                    }
+                    PivotDirection::Decrease => {
+                        (a_i_j > &Rational::ZERO && !var.at_lower())
+                            || (a_i_j < &Rational::ZERO && !var.at_upper())
+                    }
+                };
+
+                if eligible {
+                    let nnz = self.tableau.col_nnz(col);
+                    if best.is_none_or(|(_, best_nnz)| nnz < best_nnz) {
+                        best = Some((col, nnz));
+                    }
+                }
+            }
+
+            if let Some((col, _)) = best {
+                debug_println!(
+                    15,
+                    0,
+                    "lia::lra_solver: (greedy/col_nnz) pivot basic (row {}) {} and non-basic (col {}) {}, update non-basic val to {}",
+                    row,
+                    self.variables[row_var_idx],
+                    col,
+                    self.variables[self.non_basic[col]],
+                    target_bound
+                );
+                self.pivot_and_update(row, col, &target_bound)?;
+                return Ok(SimplexStepResult::Unknown);
+            }
+        }
+
+        // Bland's rule fallback: iterate over non_basic (col) variables in the fixed variable
+        // ordering and select the first eligible one.
+        for var in non_basics.iter() {
             let col = match var.is_non_basic() {
                 Some(c) => c,
                 None => continue,
@@ -657,6 +761,8 @@ impl LRASolver {
                 "lia::lra_solver: Stepping simplex, iteration {}",
                 self.num_simplex_steps
             );
+
+            self.update_pivot_heuristic(); // possibly switch heuristics based on the current solver state.
             match self.step_simplex() {
                 Ok(SimplexStepResult::Unknown) => {
                     self.num_simplex_steps += 1;
@@ -881,9 +987,10 @@ impl LRASolver {
             old_upper_bounds: vec![],
             backtrack_level: 0,
             old_assignment: None,
+            pivot_heuristic: PivotHeuristic::Greedy,
+            num_simplex_steps: 0,
             var_to_idx,
             ctx,
-            num_simplex_steps: 0,
         })
     }
 }

--- a/src/arithmetic/lia/tableau.rs
+++ b/src/arithmetic/lia/tableau.rs
@@ -71,6 +71,13 @@ where
 
     /// Return the number of columns in the tableau
     fn ncols(&self) -> usize;
+
+    /// Return the number of non-zero entries in the given column
+    fn col_nnz(&self, col: usize) -> usize {
+        (0..self.nrows())
+            .filter(|r| self.get(*r, col).is_ok_and(|v| !v.is_zero()))
+            .count()
+    }
 }
 
 /// Enum-dispatched tableau that selects between dense and sparse at runtime.
@@ -135,6 +142,13 @@ impl Tableau for TableauImpl {
         match self {
             TableauImpl::Dense(t) => t.ncols(),
             TableauImpl::Sparse(t) => t.ncols(),
+        }
+    }
+
+    fn col_nnz(&self, col: usize) -> usize {
+        match self {
+            TableauImpl::Dense(t) => t.col_nnz(col),
+            TableauImpl::Sparse(t) => t.col_nnz(col),
         }
     }
 }

--- a/src/arithmetic/lia/variables.rs
+++ b/src/arithmetic/lia/variables.rs
@@ -272,6 +272,11 @@ impl<T: Ord> VarInfo<T> {
         self.bounds.upper.as_ref().is_some_and(|u| &self.val > u)
     }
 
+    /// Check if the variable is totally unbounded, i.e. ∞ < x < ∞
+    pub fn is_totally_unbounded(&self) -> bool {
+        self.bounds.lower.is_none() && self.bounds.upper.is_none()
+    }
+
     /// Update the current assignment
     pub fn update_assignment(&mut self, val: impl Into<T>) {
         self.val = val.into()
@@ -308,12 +313,14 @@ mod tests {
         assert!(v.in_bounds());
         v.update_lower(10);
         assert!(!v.in_bounds());
+        assert!(!v.is_totally_unbounded());
     }
 
     #[test]
     fn update_val() {
         let mut v = VarInfo::<Rational>::new(Var::real(0), Owner::Basic(0));
         assert!(v.in_bounds());
+        assert!(v.is_totally_unbounded());
         v.update_assignment(10);
         assert!(v.in_bounds());
         v.update_upper(-10);


### PR DESCRIPTION
*Description of changes:*

SPASS-SATT is an SMT solver that implements a dynamic pivot variable selection algorithm that accelerates the simplex procedure. See https://dx.doi.org/10.22028/D291-30636 section 7.1.1. It won the QF_LIA and QF_LRA divisions in SMT-Comp in 2018/2019.

Regression tests: one additional regression test is solved compared with `origin/main`. Results for the full verus benchmark set will be posted once they complete.

```
Test Summary:
Total tests: 367
Correct:     349
Incorrect:   0
Timeout:     16
test regression_test ... ok
```

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
