### PR TITLE
Refactor LIRASolver::solve() and LRASolver::solve()

### DIFF
--- a/src/arithmetic/lia/lira_solver.rs
+++ b/src/arithmetic/lia/lira_solver.rs
@@ -13,7 +13,9 @@ use crate::arithmetic::lia::bounds::Bounds;
 use crate::arithmetic::lia::config::SolverConfig;
 use crate::arithmetic::lia::lra_solver::LRASolver;
 use crate::arithmetic::lia::qdelta::QDelta;
-use crate::arithmetic::lia::solver_result::{Conflict, SolverDecision, SolverResult, SolverReturn};
+use crate::arithmetic::lia::solver_result::{
+    Assignment, Conflict, SolverDecision, SolverResult, SolverReturn,
+};
 use crate::arithmetic::lia::stats::Stats;
 use crate::arithmetic::lia::variables::{Var, VarType};
 use crate::debug_println;
@@ -293,12 +295,60 @@ impl LIRASolver {
         Ok(())
     }
 
-    /// Solve a mixed-integer system using branch-and-bound
+    /// Solve a mixed-integer system.
     ///
-    /// TODO: lira_solver::solve: document branch-and-bound algorithm using incremental simplex
-    /// TODO: lira_solver::solve: clean up debug statements
+    /// First solves the relaxed rational system. If feasible with all integer variables
+    /// assigned integer values, returns immediately. Otherwise attempts heuristics
+    /// (rounding, unit cube test) before falling back to branch-and-bound.
     pub fn solve(&mut self) -> SolverResult<SolverReturn> {
         debug_println!(21, 0, "lia::lira_solver: starting LIRASolver");
+
+        // Solve the rational relaxation
+        let ret = self.lra_solver.solve()?;
+        self.stats.combine(&ret.stats);
+
+        match ret.decision {
+            SolverDecision::INFEASIBLE(cs) => Ok(SolverReturn::new(
+                SolverDecision::INFEASIBLE(cs),
+                self.stats.clone(),
+            )),
+            SolverDecision::UNKNOWN => Ok(SolverReturn::new(
+                SolverDecision::UNKNOWN,
+                self.stats.clone(),
+            )),
+            SolverDecision::FEASIBLE(assg) => {
+                // Check if all integer variables already have integer assignments
+                if self.find_next_int_var().is_none() {
+                    return Ok(SolverReturn::new(
+                        SolverDecision::FEASIBLE(assg),
+                        self.stats.clone(),
+                    ));
+                }
+
+                // Try rounding heuristic
+                if let Some(rounded_assg) = self.try_rounding_heuristic() {
+                    debug_println!(
+                        21,
+                        0,
+                        "lia::lira_solver::solve: rounding heuristic succeeded"
+                    );
+                    return Ok(SolverReturn::new(
+                        SolverDecision::FEASIBLE(rounded_assg),
+                        self.stats.clone(),
+                    ));
+                }
+
+                // TODO: try unit cube test
+
+                // Fall back to branch-and-bound
+                self.branch_and_bound()
+            }
+        }
+    }
+
+    /// Solve a mixed-integer system using branch-and-bound
+    fn branch_and_bound(&mut self) -> SolverResult<SolverReturn> {
+        debug_println!(21, 0, "lia::lira_solver: starting branch-and-bound");
 
         while let Some(current_k) = self.explorer.active.pop() {
             debug_println!(
@@ -475,6 +525,12 @@ impl LIRASolver {
 
         // No integer variables with non-integer values found
         None
+    }
+
+    /// Attempt to round non-basic integer variables to the nearest integer value.
+    /// Delegates to the underlying LRASolver.
+    fn try_rounding_heuristic(&mut self) -> Option<Assignment<Var>> {
+        self.lra_solver.try_rounding_heuristic()
     }
 }
 

--- a/src/arithmetic/lia/lra_solver.rs
+++ b/src/arithmetic/lia/lra_solver.rs
@@ -766,25 +766,6 @@ impl LRASolver {
                     self.num_simplex_steps += 1;
                 }
                 Ok(SimplexStepResult::Feasible) => {
-                    if let Some(rounded_assg) = self.try_rounding_heuristic() {
-                        debug_println!(
-                            21,
-                            0,
-                            "lia::lra_solver::solve: rounding heuristic succeeded"
-                        );
-                        let stats = Stats {
-                            num_lra_solve: 1,
-                            num_simplex_steps: self.num_simplex_steps,
-                        };
-                        return Ok(SolverReturn::new(
-                            SolverDecision::FEASIBLE(rounded_assg),
-                            stats,
-                        ));
-                    }
-
-                    // TODO: implement the "unit cube test" in order to find integer values for the
-                    // integer type variables.
-
                     let assg = self.compute_assignment();
                     debug_println!(
                         21,
@@ -855,7 +836,7 @@ impl LRASolver {
     /// whether the resulting assignment (propagated through the tableau) is still feasible.
     ///
     /// Returns `Some(assignment)` if rounding succeeds, `None` otherwise (original state restored).
-    fn try_rounding_heuristic(&mut self) -> Option<Assignment<Var>> {
+    pub fn try_rounding_heuristic(&mut self) -> Option<Assignment<Var>> {
         let d0 = self.calculate_d0();
 
         // Identify non-basic integer variables with non-integer values and their rounded targets


### PR DESCRIPTION

*Description of changes:*

Refactor the top-level LIRASolver::solve() method. The main goal is that LRASolver::solve() no longer considers integer variables, it just solves the rational relaxation and returns the result directly.

1. `LIRASolver::solve()` now starts by calling `LRASolver::solve()` and dispatches:
    - UNSAT → returns UNSAT immediately
    - UNKNOWN → returns UNKNOWN immediately
    - SAT → checks for non-integer assignments to integer variables:
        - If all integer vars have integer values → returns SAT immediately
      - Tries `try_rounding_heuristic()` (now on `LIRASolver`)
      - TODO placeholder for unit cube test
      - Falls back to `branch_and_bound()` (extracted to its own method)
2. `try_rounding_heuristic` was moved conceptually to LIRASolver; delegates to `LRASolver::try_rounding_heuristic()` which was made pub

----

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
