### PR TITLE
Implement AddAssign/SubAssign for QDelta

### DIFF
--- a/src/arithmetic/lia/lra_solver.rs
+++ b/src/arithmetic/lia/lra_solver.rs
@@ -927,7 +927,7 @@ impl LRASolver {
         let mut rhs = QDelta::ZERO;
         for (col, non_basic_idx) in self.non_basic.iter().enumerate() {
             // TODO: getting the whole row at once may be faster here
-            rhs = rhs + &self.variables[*non_basic_idx].val * self.tableau.get(row, col).unwrap();
+            rhs += &self.variables[*non_basic_idx].val * self.tableau.get(row, col).unwrap();
         }
         rhs
     }

--- a/src/arithmetic/lia/qdelta.rs
+++ b/src/arithmetic/lia/qdelta.rs
@@ -263,6 +263,34 @@ impl ops::Sub for QDelta {
     }
 }
 
+impl ops::AddAssign<&QDelta> for QDelta {
+    fn add_assign(&mut self, rhs: &QDelta) {
+        self.rat += &rhs.rat;
+        self.inf += &rhs.inf;
+    }
+}
+
+impl ops::AddAssign for QDelta {
+    fn add_assign(&mut self, rhs: QDelta) {
+        self.rat += rhs.rat;
+        self.inf += rhs.inf;
+    }
+}
+
+impl ops::SubAssign<&QDelta> for QDelta {
+    fn sub_assign(&mut self, rhs: &QDelta) {
+        self.rat -= &rhs.rat;
+        self.inf -= &rhs.inf;
+    }
+}
+
+impl ops::SubAssign for QDelta {
+    fn sub_assign(&mut self, rhs: QDelta) {
+        self.rat -= rhs.rat;
+        self.inf -= rhs.inf;
+    }
+}
+
 /// Multiply a Q_δ on the left by a rational: a * d for a in Q, d in Q_δ
 ///
 /// ```rust


### PR DESCRIPTION

*Description of changes:*

Improves the efficiency of the hot loop in `calculate_assignment` because the rat and inf parts can be mutated in place.

----
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
