### PR TITLE
Add some basic stats

### DIFF
--- a/src/cadical_propagator.rs
+++ b/src/cadical_propagator.rs
@@ -15,6 +15,7 @@ use crate::log::is_important;
 use crate::proof::proof_tracer::SMTProofTracker;
 use crate::quantifiers::quantifier::QuantifierInstance::{Instantiation, Skolemization};
 use crate::quantifiers::quantifier::instantiate_quantifiers;
+use crate::stats::SolverStats;
 use crate::utils::{DeterministicHashMap, DeterministicHashSet};
 use cadical_sys::{CaDiCal, ExternalPropagator};
 use std::cell::RefCell;
@@ -46,6 +47,7 @@ pub struct CustomExternalPropagator<'a> {
     pub assignments: Vec<i32>, // maps abs(literal) -> (decision level assigned + 1) * sgn(literal)
     pub solver: *mut CaDiCal,
     pub arithmetic: ArithSolver, // whether we are doing arithmetic solving or not
+    pub stats: SolverStats,
 }
 
 impl<'a> CustomExternalPropagator<'a> {
@@ -212,6 +214,7 @@ impl<'a> ExternalPropagator for CustomExternalPropagator<'a> {
                     //     .add_theory_clause(shrunk_constraint.clone(), theory_reason);
 
                     self.disequalities.borrow_mut().push(shrunk_constraint);
+                    self.stats.theory_lemmas += 1;
                     debug_println!(
                         14 - 3,
                         0,
@@ -224,6 +227,7 @@ impl<'a> ExternalPropagator for CustomExternalPropagator<'a> {
     }
 
     fn notify_new_decision_level(&mut self) {
+        self.stats.decisions += 1;
         debug_println!(
             11,
             0,
@@ -255,6 +259,7 @@ impl<'a> ExternalPropagator for CustomExternalPropagator<'a> {
     }
 
     fn notify_backtrack(&mut self, level: usize) {
+        self.stats.backtracks += 1;
         debug_println!(
             23,
             0,
@@ -455,6 +460,7 @@ impl<'a> ExternalPropagator for CustomExternalPropagator<'a> {
 
         // Check arithmetic consistency before instantiating quantifiers
         debug_println!(21, 0, "Starting arithmetic check",);
+        self.stats.arith_checks += 1;
 
         match check_integer_constraints_satisfiable(&self.arithmetic, model, self.egraph) {
             ArithResult::Unsat(arithmetic_literals) => {

--- a/src/cadical_propagator.rs
+++ b/src/cadical_propagator.rs
@@ -214,7 +214,6 @@ impl<'a> ExternalPropagator for CustomExternalPropagator<'a> {
                     //     .add_theory_clause(shrunk_constraint.clone(), theory_reason);
 
                     self.disequalities.borrow_mut().push(shrunk_constraint);
-                    self.stats.theory_lemmas += 1;
                     debug_println!(
                         14 - 3,
                         0,
@@ -595,6 +594,7 @@ impl<'a> ExternalPropagator for CustomExternalPropagator<'a> {
 
                     // TODO: since I am adding literals, I might have to add them as observed literals
                     self.disequalities.borrow_mut().push(clause.clone());
+                    self.stats.instantiations += 1;
                 }
                 Skolemization { clause } => {
                     for lit in clause {

--- a/src/cdcl.rs
+++ b/src/cdcl.rs
@@ -7,6 +7,7 @@ use crate::cadical_propagator::CustomExternalPropagator;
 use crate::debug_println;
 use crate::egraphs::egraph::Egraph;
 use crate::proof::proof_tracer::SMTProofTracker;
+use crate::stats::SolverStats;
 use crate::utils::DeterministicHashSet;
 use cadical_sys::{CaDiCal, Status};
 use std::cell::RefCell;
@@ -28,7 +29,7 @@ pub fn cdcl_decision_procedure(
     symbol_table: HashMap<Str, Vec<(Sig, FunctionMeta)>>,
     arithmetic: ArithSolver,
     _timeout: u64, // todo: add timeout functionality
-) -> Status {
+) -> (Status, SolverStats) {
     let mut solver = CaDiCal::new();
 
     // Create proof tracker for real-time proof tracking wrapped in Rc<RefCell<>>
@@ -47,6 +48,7 @@ pub fn cdcl_decision_procedure(
         assignments: vec![0, 0],
         solver: &mut solver as *mut CaDiCal,
         arithmetic,
+        stats: SolverStats::new(),
     };
 
     solver.connect_external_propagator(&mut propagator);
@@ -108,7 +110,7 @@ pub fn cdcl_decision_procedure(
             debug_println!(2, 0, "eDRAT proof written to: {}", p.display());
         }
     }
-    result
+    (result, propagator.stats)
 }
 
 fn solve(solver: &mut CaDiCal) -> Status {

--- a/src/config.rs
+++ b/src/config.rs
@@ -41,4 +41,7 @@ pub struct Args {
     /// Set timeout in seconds (0 means no timeout)
     #[arg(long, default_value_t = 0)]
     pub timeout: u64,
+    /// Print solver statistics after solving
+    #[arg(long, default_value_t = false)]
+    pub stats: bool,
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,3 +14,4 @@ pub mod log;
 pub mod preprocess;
 mod proof;
 mod quantifiers;
+pub mod stats;

--- a/src/main.rs
+++ b/src/main.rs
@@ -180,7 +180,7 @@ fn main() -> Result<(), String> {
 
     let quantifiers = !egraph.quantifiers.is_empty();
 
-    let return_value = cdcl_decision_procedure(
+    let (return_value, stats) = cdcl_decision_procedure(
         &mut egraph,
         prop_skeleton,
         boolean_dt_constraints,
@@ -202,5 +202,10 @@ fn main() -> Result<(), String> {
         Status::UNSATISFIABLE => println!("unsat"),
         Status::UNKNOWN => println!("unknown"),
     }
+
+    if args.stats {
+        eprintln!("{stats}");
+    }
+
     Ok(())
 }

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -5,13 +5,14 @@ use std::fmt;
 use std::time::{Duration, Instant};
 
 /// Statistics about the solver run
+#[derive(Debug)]
 pub struct SolverStats {
     start_time: Instant,
 
     pub decisions: u64,
     pub backtracks: u64,
-    pub theory_lemmas: u64,
     pub arith_checks: u64,
+    pub instantiations: u64,
 }
 
 impl SolverStats {
@@ -20,8 +21,8 @@ impl SolverStats {
             start_time: Instant::now(),
             decisions: 0,
             backtracks: 0,
-            theory_lemmas: 0,
             arith_checks: 0,
+            instantiations: 0,
         }
     }
 
@@ -42,9 +43,9 @@ impl fmt::Display for SolverStats {
         write!(f, "{{\n")?;
         writeln!(f, "  \"decisions\": {},", self.decisions)?;
         writeln!(f, "  \"backtracks\": {},", self.backtracks)?;
-        writeln!(f, "  \"theory_lemmas\": {},", self.theory_lemmas)?;
         writeln!(f, "  \"arith_checks\": {},", self.arith_checks)?;
-        writeln!(f, "  \"time\": {:.3}", elapsed.as_secs_f64())?;
+        writeln!(f, "  \"instantiations\": {},", self.instantiations)?;
+        writeln!(f, "  \"solve_time\": {:.3}", elapsed.as_secs_f64())?;
         write!(f, "}}")
     }
 }

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -9,9 +9,13 @@ use std::time::{Duration, Instant};
 pub struct SolverStats {
     start_time: Instant,
 
+    /// Number of new decision levels created by CaDiCaL (notify_new_decision_level calls)
     pub decisions: u64,
+    /// Number of backtrack notifications from CaDiCaL (notify_backtrack calls)
     pub backtracks: u64,
+    /// Number of calls to the arithmetic theory solver (check_integer_constraints_satisfiable)
     pub arith_checks: u64,
+    /// Number of quantifier instantiations added as clauses to CaDiCaL
     pub instantiations: u64,
 }
 

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -1,0 +1,50 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::fmt;
+use std::time::{Duration, Instant};
+
+/// Statistics about the solver run
+pub struct SolverStats {
+    start_time: Instant,
+
+    pub decisions: u64,
+    pub backtracks: u64,
+    pub theory_lemmas: u64,
+    pub arith_checks: u64,
+}
+
+impl SolverStats {
+    pub fn new() -> Self {
+        Self {
+            start_time: Instant::now(),
+            decisions: 0,
+            backtracks: 0,
+            theory_lemmas: 0,
+            arith_checks: 0,
+        }
+    }
+
+    pub fn elapsed(&self) -> Duration {
+        self.start_time.elapsed()
+    }
+}
+
+impl Default for SolverStats {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl fmt::Display for SolverStats {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let elapsed = self.elapsed();
+        write!(f, "{{\n")?;
+        writeln!(f, "  \"decisions\": {},", self.decisions)?;
+        writeln!(f, "  \"backtracks\": {},", self.backtracks)?;
+        writeln!(f, "  \"theory_lemmas\": {},", self.theory_lemmas)?;
+        writeln!(f, "  \"arith_checks\": {},", self.arith_checks)?;
+        writeln!(f, "  \"time\": {:.3}", elapsed.as_secs_f64())?;
+        write!(f, "}}")
+    }
+}

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -40,7 +40,7 @@ impl Default for SolverStats {
 impl fmt::Display for SolverStats {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let elapsed = self.elapsed();
-        write!(f, "{{\n")?;
+        writeln!(f, "{{")?;
         writeln!(f, "  \"decisions\": {},", self.decisions)?;
         writeln!(f, "  \"backtracks\": {},", self.backtracks)?;
         writeln!(f, "  \"arith_checks\": {},", self.arith_checks)?;


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

I was talking with Long and we thought it would be useful to have some way of tracking stats across a run. This is a start at that, with some very basic stats added. The main thing to figure out now is about whether this approach to tracking & reporting stats is what we want, since we can extend this to include more information in future PRs. 

Example:
```
 % ./target/release/sundance-smt tests/hardertests/unknown/unknown_reduced_znew.smt2 --stats
unsat
{
  "decisions": 4604,
  "backtracks": 345,
  "arith_checks": 8,
  "instantiations": 4914,
  "solve_time": 1.279
}
```

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
