### PR TITLE
gitignore chore and filter out tautologies in eDRAT proof.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,8 @@ target/
 .DS_Store
 .z3-trace
 .vscode
+
+# eDRAT proof files
+*.edrat
+*.drat
+*.lrat

--- a/src/cadical_propagator.rs
+++ b/src/cadical_propagator.rs
@@ -146,7 +146,7 @@ impl<'a> ExternalPropagator for CustomExternalPropagator<'a> {
                 negated_model_or_datatype_constraints_opt
             {
                 for constraint in negated_model_or_datatype_constraints {
-                    // todo: deleting this ordering thing -> just for debuggin
+                    // todo: deleting this ordering thing -> just for debugging
                     let mut constraint_ordered = constraint.clone();
                     constraint_ordered.sort();
                     debug_println!(
@@ -176,7 +176,7 @@ impl<'a> ExternalPropagator for CustomExternalPropagator<'a> {
                             already_considered.insert(lit);
                         }
                     }
-                    // todo: deleting this ordering thing -> just for debuggin
+                    // todo: deleting this ordering thing -> just for debugging
                     let mut shrunk_constraint_ordered = shrunk_constraint.clone();
                     shrunk_constraint_ordered.sort();
                     debug_println!(

--- a/src/egraphs/egraph.rs
+++ b/src/egraphs/egraph.rs
@@ -216,7 +216,7 @@ pub struct Egraph {
     pub proof_forest: Vec<ProofForestEdge>, // u64 -> ProofForestEdge [t <- ]
     /// keeps track of a stack of "edges" to backtrack on
     pub proof_forest_backtrack_stack: Vec<(usize, ProofForestEdge, u64, ProofForestEdge)>,
-    /// this is a map from terms (u64) -> (term in the same egraph, predecesssor of term in same egraph)
+    /// this is a map from terms (u64) -> (term in the same egraph, predecessor of term in same egraph)
     pub predecessors: Vec<FastDeterministicHashMap<u64, Predecessor>>, // u64 -> Vec<Predecessor> TODO: there might be a better way to do this
     /// number to keep track of the current hash
     pub predecessor_hash: u64,
@@ -785,7 +785,7 @@ impl Egraph {
                 inner_term: num,
             };
 
-            // this will not insert if something already exists. it should not matter for correctness, but should be slighlty more efficient
+            // this will not insert if something already exists. it should not matter for correctness, but should be slightly more efficient
             self.predecessors[num as usize]
                 .entry(parent_num)
                 .or_insert(predecessor);

--- a/src/proof/proof_tracer.rs
+++ b/src/proof/proof_tracer.rs
@@ -6,7 +6,10 @@
 use crate::debug_println;
 use cadical_sys::ProofTracer;
 use core::panic;
+use std::cmp::Eq;
 use std::collections::{HashMap, HashSet};
+use std::hash::Hash;
+use std::ops::Neg;
 use yaspar_ir::ast::{
     ATerm::*, Context, FunctionMeta, ObjectAllocatorExt, Repr, Sig, Sort, SortDef, Str, Term,
 };
@@ -53,6 +56,23 @@ fn polarize_term(term: &Term, polarity: bool) -> Term {
     }
 }
 
+/// Returns true if the clause contains a literal and its negation (i.e., both `x` and `-x`).
+/// Written for generic iterators, since clauses in this file are both `Vec`s and `&[i32]` arrays.
+fn clause_is_tautology<'a, I, T>(clause: I) -> bool
+where
+    I: IntoIterator<Item = &'a T>,
+    T: 'a + Copy + Eq + Hash + Neg<Output = T>,
+{
+    let mut seen = HashSet::new();
+    for &lit in clause {
+        if seen.contains(&-lit) {
+            return true;
+        }
+        seen.insert(lit);
+    }
+    false
+}
+
 /// Represents a single step in the proof
 #[derive(Debug, Clone)]
 pub enum ProofStepData {
@@ -73,8 +93,10 @@ pub enum ProofStepData {
     //     clause: Vec<i32>,
     //     // skolemized: bool,
     // },
-    /// Clause deletion
-    Deletion { id: u64 },
+    /// DRAT-style clause deletion.
+    /// Despite CaDiCaL returning a clause ID, we store the entire clause.
+    /// TODO: Any way to store an index into `proof_steps`? It'll save on memory
+    Deletion { clause: Vec<i32> },
 }
 
 /// Format a sort definition as a declare-sort command
@@ -284,6 +306,11 @@ impl SMTProofTracker {
                         output.push_str(&format!("{} ", lit));
                     }
                     output.push_str("0\n");
+
+                    // Stop adding proof steps to the output once the empty clause is derived
+                    if clause.is_empty() {
+                        return output;
+                    }
                 }
                 ProofStepData::TheoryClause { clause, .. } => {
                     self.introduce_literals(clause, &mut output);
@@ -312,8 +339,13 @@ impl SMTProofTracker {
                     }
                     output.push_str("0\n");
                 }
-                ProofStepData::Deletion { id } => {
-                    output.push_str(&format!("d {} 0\n", id));
+                ProofStepData::Deletion { clause } => {
+                    // Emit a DRAT-style deletion, which includes all literals in the clause
+                    output.push_str("d ");
+                    for &lit in clause {
+                        output.push_str(&format!("{} ", lit));
+                    }
+                    output.push_str("0\n");
                 }
             }
         }
@@ -324,6 +356,9 @@ impl SMTProofTracker {
 impl ProofTracer for SMTProofTracker {
     fn add_original_clause(&mut self, _id: u64, _redundant: bool, clause: &[i32], _restored: bool) {
         if self.skolemizations.contains(clause) {
+            return;
+        }
+        if clause_is_tautology(clause) {
             return;
         }
         if !self.finished_original_clauses {
@@ -352,13 +387,22 @@ impl ProofTracer for SMTProofTracker {
         debug_println!(6, 0, "Antecedent clause IDs: {:?}", antecedents);
         debug_println!(6, 0, "Clause size: {}", clause.len());
 
+        if clause_is_tautology(clause) {
+            return;
+        }
+
         self.proof_steps.push(ProofStepData::SATClause {
             clause: clause.to_vec(),
         });
     }
 
-    fn delete_clause(&mut self, id: u64, _redundant: bool, _clause: &[i32]) {
-        self.proof_steps.push(ProofStepData::Deletion { id });
+    fn delete_clause(&mut self, _id: u64, _redundant: bool, clause: &[i32]) {
+        if clause_is_tautology(clause) {
+            return;
+        }
+        self.proof_steps.push(ProofStepData::Deletion {
+            clause: clause.to_vec(),
+        });
     }
 
     fn weaken_minus(&mut self, _id: u64, _clause: &[i32]) {

--- a/src/quantifiers/quantifier.rs
+++ b/src/quantifiers/quantifier.rs
@@ -317,7 +317,7 @@ pub fn instantiate_quantifiers(
 
                 // note we do this after nnf
                 // this might lead to weirdness when you have equality of booleans not being represented in egraph
-                // but it should be fine. This is necessary becasue we need to look up lits
+                // but it should be fine. This is necessary because we need to look up lits
                 // todo: also might be less efficient as well because we are losing structure from original formula in the egraph
                 egraph.insert_predecessor(&nnf_term, None, None, true, None);
 

--- a/src/quantifiers/skolem.rs
+++ b/src/quantifiers/skolem.rs
@@ -19,10 +19,7 @@ pub fn skolemize(term: &Term, context: &mut Context, polarity: bool) -> (Term, V
     match term.repr() {
         Forall(var_bindings, body) => {
             if polarity {
-                panic!(
-                    "We can only skolemize an existenial or negated forall or existential term, not {}",
-                    term
-                );
+                panic_not_quant(term);
             } else {
                 // Create a fresh skolem variable for each existentially quantified variable
                 debug_println!(6, 0, "We are skolemizing the term {}", term);
@@ -47,7 +44,7 @@ pub fn skolemize(term: &Term, context: &mut Context, polarity: bool) -> (Term, V
                     skolem_substitutions.insert(var_binding.0.clone(), skolem_term);
                 }
 
-                let denannotated_body = if let Annotated(inner_term, _) = body.repr() {
+                let deannotated_body = if let Annotated(inner_term, _) = body.repr() {
                     inner_term
                 } else {
                     // if no annotation, assuming we have the body
@@ -56,7 +53,7 @@ pub fn skolemize(term: &Term, context: &mut Context, polarity: bool) -> (Term, V
                 // Substitute the skolem variables into the body
                 // todo: substitution needs a builder
                 let substituted_term =
-                    denannotated_body.subst(&Substitution::new_str(skolem_substitutions), context);
+                    deannotated_body.subst(&Substitution::new_str(skolem_substitutions), context);
 
                 let negated_substituted_term = context.not(substituted_term);
                 (negated_substituted_term, skolem_variables)
@@ -69,10 +66,7 @@ pub fn skolemize(term: &Term, context: &mut Context, polarity: bool) -> (Term, V
 
             // Create a fresh skolem variable for each existentially quantified variable
             if !polarity {
-                panic!(
-                    "We can only skolemize a existenial or negated forall or existential term, not {}",
-                    term
-                );
+                panic_not_quant(term);
             } else {
                 // Create a fresh skolem variable for each existentially quantified variable
                 debug_println!(6, 0, "We are skolemizing the term {}", term);
@@ -97,7 +91,7 @@ pub fn skolemize(term: &Term, context: &mut Context, polarity: bool) -> (Term, V
                     skolem_substitutions.insert(var_binding.0.clone(), skolem_term);
                 }
 
-                let denannotated_body = if let Annotated(inner_term, _) = body.repr() {
+                let deannotated_body = if let Annotated(inner_term, _) = body.repr() {
                     inner_term
                 } else {
                     // if no annotation, assuming we have the body
@@ -106,14 +100,19 @@ pub fn skolemize(term: &Term, context: &mut Context, polarity: bool) -> (Term, V
                 // Substitute the skolem variables into the body
                 // todo: substitution needs a builder
                 let substituted_term =
-                    denannotated_body.subst(&Substitution::new_str(skolem_substitutions), context);
+                    deannotated_body.subst(&Substitution::new_str(skolem_substitutions), context);
 
                 (substituted_term, skolem_variables)
             }
         }
-        _ => panic!(
-            "We can only skolemize an existenial or negated forall or existential term, not {}",
-            term
-        ),
+        _ => panic_not_quant(term),
     }
+}
+
+/// Calls `panic!()` with a message that `term` is not a quantifier.
+fn panic_not_quant(term: &Term) -> ! {
+    panic!(
+        "We can only skolemize an existential or a negated forall, not {}",
+        term
+    );
 }


### PR DESCRIPTION
This PR contains two commits. One commit updates the .gitignore file to ignore eDRAT proof objects. The other adds a filtering function `clause_is_tautology()` to `proof_tracer.rs` to filter out added and deleted clauses that are tautologies. Deletions are also re-formatted to be "DRAT-style" where the entire clause is included, rather than referencing a clause ID, which is "LRAT-style."

Regarding the tautologies: For technical reasons due to Sundance's dependence on an outdated version of CaDiCaL/cadical-sys (see [this GitHub issue](https://github.com/arminbiere/cadical/issues/140)), tautologies are given to CaDiCaL during preprocessing of the SMT formula to force a complete model. (See [line 87 of preprocess.rs](https://github.com/yaspar-org/Sundance-SMT/blob/28bf8be05a2b94a767d7846150edb723cfe143a9/src/preprocess.rs#L87).) In my discussion with Amar Shah, we concluded that the easier thing was to filter out tautologies when storing eDRAT proof steps, but in the future, an upgrade to the underlying CaDiCaL version could remove the need to add tautologies, and thus eliminate the need for this kind of filtering.

------------

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
