### PR TITLE
Disable debug log messages in unit tests and micro-benchmarks

### DIFF
--- a/src/log.rs
+++ b/src/log.rs
@@ -4,7 +4,7 @@
 use std::sync::atomic::{AtomicU8, Ordering};
 
 /// Global debug level - controls which debug messages are printed
-static DEBUG_LEVEL: AtomicU8 = AtomicU8::new(0);
+static DEBUG_LEVEL: AtomicU8 = AtomicU8::new(30);
 
 pub fn set_debug_level(level: u8) {
     DEBUG_LEVEL.store(level, Ordering::SeqCst);

--- a/src/main.rs
+++ b/src/main.rs
@@ -27,9 +27,8 @@ fn main() -> Result<(), String> {
             "Debug mode enabled (level {})",
             log::get_debug_level()
         );
-    } else {
-        log::set_debug_level(30);
     }
+    // else the default is set in `crate::log`
 
     // Enable debug output for proof tracking if proof file is specified
     if args.proof.is_some() {


### PR DESCRIPTION

*Description of changes:*

In `log.rs` the debug level was initialized to 0, meaning all log messages are printed. In `src/main.rs` it is explicitly set to 30 (generally meaning no debug output). But in unit tests and benchmarks `main` is not called.

----
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
