### PR TITLE
Rewrite sparse matrix

### DIFF
--- a/src/arithmetic/lia/config.rs
+++ b/src/arithmetic/lia/config.rs
@@ -18,7 +18,11 @@ pub struct SolverConfig {
 impl Default for SolverConfig {
     fn default() -> Self {
         Self {
-            tableau_kind: TableauKind::Dense,
+            tableau_kind: TableauKind::Sparse,
+            // Note: 2^17 is high enough that regression tests pass as expected
+            // i.e. they are either SAT/UNSAT or TIMEOUT. If this is lowered
+            // significantly, some will return UNKNOWN instead since branch-and-bound
+            // will return UNKNOWN when the limit is hit.
             max_lra_solve_calls: None,
         }
     }

--- a/src/arithmetic/lia/sparse.rs
+++ b/src/arithmetic/lia/sparse.rs
@@ -1,14 +1,14 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-//! Sparse matrix implementation using mirrored row/column HashMaps.
+//! Sparse matrix implementation using mirrored row/column FxHashMaps.
 //!
 //! Each entry (i, j, v) is stored in both `rows[i]` and `cols[j]`, enabling
 //! O(1) access by either row or column. This is the pattern used by most SMT
 //! simplex implementations (Yices2, Z3, CVC5).
 
 use num_traits::Zero;
-use std::collections::HashMap;
+use rustc_hash::FxHashMap;
 use std::error;
 use std::fmt;
 
@@ -31,8 +31,8 @@ pub type SparseResult<T> = Result<T, SparseError>;
 /// enabling O(1) access by either row or column during pivot operations.
 #[derive(Clone)]
 pub struct Matrix<V> {
-    rows: Vec<HashMap<usize, V>>, // rows[i]: col -> coefficient
-    cols: Vec<HashMap<usize, V>>, // cols[j]: row -> coefficient
+    rows: Vec<FxHashMap<usize, V>>, // rows[i]: col -> coefficient
+    cols: Vec<FxHashMap<usize, V>>, // cols[j]: row -> coefficient
     zero: V,
 }
 
@@ -59,8 +59,8 @@ impl<V: Zero + Clone + fmt::Debug> Matrix<V> {
             return Err(SparseError("nrows and ncols must be > 0".to_string()));
         }
         Ok(Self {
-            rows: vec![HashMap::new(); nrows],
-            cols: vec![HashMap::new(); ncols],
+            rows: vec![FxHashMap::default(); nrows],
+            cols: vec![FxHashMap::default(); ncols],
             zero: V::zero(),
         })
     }
@@ -161,21 +161,20 @@ impl<V: Zero + Clone + fmt::Debug> Matrix<V> {
 
         // Step 1: Snapshot the original pivot row (before modification)
         // Worst case O(M)
-        let pivot_row_snapshot: HashMap<usize, V> = self.rows[row].clone();
+        let pivot_row_snapshot = std::mem::take(&mut self.rows[row]);
 
         // Step 2: Update the pivot row in-place
         // Collect new values first, then write them
         // Worst case O(M)
-        let new_pivot_row: HashMap<usize, V> = pivot_row_snapshot
-            .iter()
-            .map(|(j, b)| {
-                if *j == col {
-                    (*j, inv_pivot.clone())
-                } else {
-                    (*j, -(b.clone() * inv_pivot.clone()))
-                }
-            })
-            .collect();
+        let mut new_pivot_row: FxHashMap<usize, V> =
+            FxHashMap::with_capacity_and_hasher(pivot_row_snapshot.len(), Default::default());
+        for (j, b) in pivot_row_snapshot.iter() {
+            if *j == col {
+                new_pivot_row.insert(*j, inv_pivot.clone());
+            } else {
+                new_pivot_row.insert(*j, -(b.clone() * inv_pivot.clone()));
+            }
+        }
 
         self.rows[row] = new_pivot_row;
         // Update cols to reflect new pivot row values (same set of columns, just new values)
@@ -194,23 +193,24 @@ impl<V: Zero + Clone + fmt::Debug> Matrix<V> {
 
         // Step 4: Update non-pivot rows
         for (i, c_val) in pivot_col_rows.iter() {
+            // Hoist c/a: same for every column j in this row
+            let c_over_a = c_val.clone() * inv_pivot.clone();
+
             // For each column j in the original pivot row snapshot:
             for (j, b_val) in pivot_row_snapshot.iter() {
                 if *j == col {
                     // Pivot column entry: c -> c/a
-                    let new_val = c_val.clone() / pivot_value.clone();
-                    if new_val.is_zero() {
+                    if c_over_a.is_zero() {
                         self.rows[*i].remove(j);
                         self.cols[*j].remove(i);
                     } else {
-                        self.rows[*i].insert(*j, new_val.clone());
-                        self.cols[*j].insert(*i, new_val);
+                        self.rows[*i].insert(*j, c_over_a.clone());
+                        self.cols[*j].insert(*i, c_over_a.clone());
                     }
                 } else {
                     // General case: d -> d - b*c/a
                     let d_val = self.rows[*i].get(j).cloned().unwrap_or_else(V::zero);
-                    let new_val =
-                        d_val - b_val.clone() * c_val.clone() * inv_pivot.clone();
+                    let new_val = d_val - b_val.clone() * c_over_a.clone();
                     if new_val.is_zero() {
                         self.rows[*i].remove(j);
                         self.cols[*j].remove(i);

--- a/src/arithmetic/lia/sparse.rs
+++ b/src/arithmetic/lia/sparse.rs
@@ -231,7 +231,7 @@ impl<V: Zero + Clone + fmt::Debug> Matrix<V> {
     fn validate_row_col(&self, row: usize, col: usize) -> SparseResult<()> {
         if row >= self.rows.len() || col >= self.cols.len() {
             return Err(SparseError(format!(
-                "pivot position ({}, {}) is out of bounds for matrix with dimensions {} x {}",
+                "position ({}, {}) is out of bounds for matrix with dimensions {} x {}",
                 row,
                 col,
                 self.rows.len(),

--- a/src/arithmetic/lia/sparse.rs
+++ b/src/arithmetic/lia/sparse.rs
@@ -534,11 +534,7 @@ mod tests {
 
     #[test]
     fn test_pivot_0_0_diag_plus_row() {
-        let tuples = vec![
-            (0, 0, rbig!(2)),
-            (1, 1, rbig!(3)),
-            (0, 1, rbig!(4)),
-        ];
+        let tuples = vec![(0, 0, rbig!(2)), (1, 1, rbig!(3)), (0, 1, rbig!(4))];
         let mut m = Matrix::from_tuples(2, 2, tuples).expect("Failed to create matrix");
         m.pivot(0, 0).expect("first pivot failed");
         assert_eq!(m.get(0, 0), Some(&rbig!(1 / 2)));

--- a/src/arithmetic/lia/sparse.rs
+++ b/src/arithmetic/lia/sparse.rs
@@ -1,32 +1,18 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-//! Sparse matrix implementation
+//! Sparse matrix implementation using mirrored row/column HashMaps.
 //!
-//! Matrix representation:
-//!
-//! ```text
-//!                        basecol
-//!                           |
-//!                          ...
-//!                           ^
-//!                           |
-//! baserow  <    [ r | c |  up  ] <-- ...
-//!           \   [ value | left ]
-//!            \______________/
-//!
-//!                      ^
-//!                      |
-//!                     ...
-//! ```
+//! Each entry (i, j, v) is stored in both `rows[i]` and `cols[j]`, enabling
+//! O(1) access by either row or column. This is the pattern used by most SMT
+//! simplex implementations (Yices2, Z3, CVC5).
 
 use num_traits::Zero;
-use slotmap;
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
 use std::error;
 use std::fmt;
 
-/// Generic error type for spare matrix operations
+/// Generic error type for sparse matrix operations
 #[derive(Debug, PartialEq, Eq)]
 pub struct SparseError(pub String);
 impl fmt::Display for SparseError {
@@ -36,554 +22,222 @@ impl fmt::Display for SparseError {
 }
 impl error::Error for SparseError {}
 
-/// Generic result type for tableau operations
+/// Generic result type for sparse matrix operations
 pub type SparseResult<T> = Result<T, SparseError>;
 
-// pointer to a matrix node
-type K = slotmap::DefaultKey;
-
-/// Sparse matrix node
-#[derive(Debug, Clone)]
-struct Node<V> {
-    // Some if the node is not a column header
-    row: Option<usize>,
-    // Some if the node is not a row header
-    col: Option<usize>,
-    value: V,
-    // pointer to the next left entry
-    left: K,
-    // pointer to the next up entry
-    up: K,
-}
-
-/// todo:
+/// Sparse matrix stored as row vectors with a mirrored column index.
+///
+/// Both `rows[i]` and `cols[j]` store the same coefficient for entry (i, j),
+/// enabling O(1) access by either row or column during pivot operations.
 #[derive(Clone)]
 pub struct Matrix<V> {
-    arena: slotmap::SlotMap<K, Node<V>>,
-    baserows: Vec<K>, // length = # rows
-    basecols: Vec<K>, // length = # cols
+    rows: Vec<HashMap<usize, V>>, // rows[i]: col -> coefficient
+    cols: Vec<HashMap<usize, V>>, // cols[j]: row -> coefficient
     zero: V,
 }
 
-impl<V: fmt::Debug> fmt::Debug for Matrix<V> {
+impl<V: fmt::Debug + Zero + Clone> fmt::Debug for Matrix<V> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> Result<(), std::fmt::Error> {
-        writeln!(f, "Matrix: (zero = {:?}", self.zero)?;
-        write!(f, "  baserows: ")?;
-        for k in self.baserows.iter() {
-            write!(f, "{k:?},")?;
-        }
-        writeln!(f)?;
-        write!(f, "  basecols: ")?;
-        for k in self.basecols.iter() {
-            write!(f, "{k:?},")?;
-        }
-        writeln!(f)?;
-        for n in self.arena.iter() {
-            writeln!(f, "    {n:?}")?;
+        writeln!(f, "Matrix {}x{}:", self.nrows(), self.ncols())?;
+        for (i, row) in self.rows.iter().enumerate() {
+            write!(f, "  row {i}: ")?;
+            let mut entries: Vec<_> = row.iter().collect();
+            entries.sort_by_key(|(col, _)| *col);
+            for (col, val) in entries {
+                write!(f, "({col}, {val:?}) ")?;
+            }
+            writeln!(f)?;
         }
         Ok(())
     }
 }
 
-impl<V: Zero + fmt::Debug> Matrix<V> {
+impl<V: Zero + Clone + fmt::Debug> Matrix<V> {
+    /// Create a new sparse zero matrix of nrows x ncols.
+    pub fn new(nrows: usize, ncols: usize) -> SparseResult<Self> {
+        if nrows == 0 || ncols == 0 {
+            return Err(SparseError("nrows and ncols must be > 0".to_string()));
+        }
+        Ok(Self {
+            rows: vec![HashMap::new(); nrows],
+            cols: vec![HashMap::new(); ncols],
+            zero: V::zero(),
+        })
+    }
+
     /// Create a new sparse matrix from a vector of tuples (row, col, value).
     ///
-    /// The matrix dimensions are explicitly specified by nrows and ncols.
     /// Returns an error if any tuple contains row or col indices out of bounds.
+    /// Zero values are not inserted.
     pub fn from_tuples(
         nrows: usize,
         ncols: usize,
         t: Vec<(usize, usize, V)>,
     ) -> SparseResult<Self> {
-        // Create a new matrix with the specified dimensions
         let mut matrix = Self::new(nrows, ncols)?;
-
-        // Insert each tuple into the matrix, validating bounds. Zero values are not
-        // inserted into the matrix.
         for (row, col, value) in t {
             if !value.is_zero() {
                 matrix.update_or_insert(row, col, value)?;
             }
         }
-
         Ok(matrix)
     }
 
-    /// Create a new sparse zero matrix of nrows x ncols, i.e. there are no nodes in the matrix
-    /// representation except for the base rows and columns.
-    ///
-    /// Zero Matrix representation:
-    ///
-    /// ```text
-    /// For a 3x3 matrix (nrows=3, ncols=3):
-    ///
-    ///    basecol[0]  basecol[1]  basecol[2]
-    ///         ↓          ↓          ↓
-    ///    ┌─────────┬─────────┬─────────┐
-    ///    │ r:None  │ r:None  │ r:None  │
-    ///    │ c:0     │ c:1     │ c:2     │
-    ///  ┌─┼─left: ←─┼─left: ←─┼─left:   │←┐
-    ///  │ │ up:─┐   │ up:─┐   │ up:─┐   │ │
-    ///  │ └─────┼───┴─────┼───┴─────┼───┘ │
-    ///  │    │  ↓      │  ↓      │  ↓     │
-    ///  │    │  │      │  │      │  │     │
-    ///  │    └──┘      └──┘      └──┘     │
-    ///  └─────────────────────────────────┘
-    ///
-    /// ```
-    ///
-    ///  and similarly for the baserows but they are arranged in a single column at the left.
-    ///
-    pub fn new(nrows: usize, ncols: usize) -> SparseResult<Self> {
-        if nrows == 0 || ncols == 0 {
-            return Err(SparseError("nrows and ncols must be > 0".to_string()));
-        }
-        let mut arena = slotmap::SlotMap::new();
-        let mut baserows = Vec::with_capacity(nrows);
-        let mut basecols = Vec::with_capacity(ncols);
-
-        for r in 0..nrows {
-            let mk_baserow_node = |k| Node {
-                row: Some(r),
-                col: None,
-                value: V::zero(),
-                left: k,
-                up: k,
-            };
-            // initially every left/up pointer of the baserow nodes points to itself
-            let k = arena.insert_with_key(mk_baserow_node);
-            baserows.push(k);
-        }
-
-        // form a circularly linked list with the baserow nodes
-        let last_baserow_node_k = *baserows.last().unwrap(); // safe b/c nrows > 0 from early return above
-        let first_baserow_node_k = *baserows.first().unwrap();
-        let first_baserow_node = arena.get_mut(first_baserow_node_k).unwrap();
-        first_baserow_node.up = last_baserow_node_k;
-        let mut k = first_baserow_node_k; // key to the previous baserow node
-        for r in baserows[1..].iter() {
-            let node = arena.get_mut(*r).unwrap();
-            node.up = k;
-            k = *r;
-        }
-
-        for c in 0..ncols {
-            let mk_basecol_node = |k| Node {
-                row: None,
-                col: Some(c),
-                value: V::zero(),
-                left: k,
-                up: k,
-            };
-            // initially every left/up pointer of the basecol nodes points to itself
-            let k = arena.insert_with_key(mk_basecol_node);
-            basecols.push(k);
-        }
-
-        // form a circularly linked list with the basecol nodes
-        let last_basecol_node_k = *basecols.last().unwrap(); // safe b/c nrows > 0 from early return above
-        let first_basecol_node_k = *basecols.first().unwrap();
-        let first_basecol_node = arena.get_mut(first_basecol_node_k).unwrap();
-        first_basecol_node.left = last_basecol_node_k;
-        let mut k = first_basecol_node_k; // key to the previous basecol node
-        for c in basecols[1..].iter() {
-            let node = arena.get_mut(*c).unwrap();
-            node.left = k;
-            k = *c;
-        }
-
-        Ok(Self {
-            arena,
-            baserows,
-            basecols,
-            zero: V::zero(),
-        })
-    }
-
-    /// Return the number of rows in the matrix
+    /// Return the number of rows in the matrix.
     pub fn nrows(&self) -> usize {
-        self.baserows.len()
+        self.rows.len()
     }
 
-    /// Return the number of columns in the matrix
+    /// Return the number of columns in the matrix.
     pub fn ncols(&self) -> usize {
-        self.basecols.len()
+        self.cols.len()
     }
 
-    /// Get the value of an element in the matrix
+    /// Get the value of an element in the matrix.
     ///
-    /// Returns Some(&Zero) if the element coordinates are in-bounds but the node
-    /// doesn't exist in the sparse matrix representation. Return None if the indices
-    /// are out of bounds.
+    /// Returns `Some(&zero)` if the element coordinates are in-bounds but no
+    /// entry exists. Returns `None` if the indices are out of bounds.
     pub fn get(&self, row: usize, col: usize) -> Option<&V> {
-        if row >= self.baserows.len() || col >= self.basecols.len() {
+        if row >= self.rows.len() || col >= self.cols.len() {
             return None;
         }
-        // traverse left from the baserow[row] to find the right column to get
-        let baserow_n = self.arena.get(self.baserows[row]).unwrap();
-        let mut p = baserow_n.left; // pointer to the current node in left traversal
-        let mut p_n = self.arena.get(p).unwrap();
-        while let Some(pcol) = p_n.col
-            && pcol > col
-        {
-            p = p_n.left;
-            p_n = self.arena.get(p).unwrap();
-        }
-        if let Some(pcol) = p_n.col
-            && pcol == col
-        {
-            // we arrived at a non baserow node whose row and col match the input; return the value
-            // stored here
-            debug_assert!(p_n.row.is_some() && p_n.row.unwrap() == row);
-            let p_n = self.arena.get(p).unwrap();
-            return Some(&p_n.value);
-        }
-        // we arrived at a baserow node; meaning the node doesn't exist in the sparse
-        // representation
-        Some(&self.zero)
+        Some(self.rows[row].get(&col).unwrap_or(&self.zero))
     }
 
-    /// Insert or update an entry in the matrix
+    /// Insert or update an entry in the matrix.
     ///
-    /// Returns `Ok(false)` if a node was inserted. Otherwise the existing value
-    /// is updated and `Ok(true)` is returned. This is compatible with the convention from
-    /// `delete_node`. Returns Err if `row` or `col` is out of bounds.
+    /// If `val` is zero, the entry is removed (maintaining sparsity).
+    /// Returns `Ok(true)` if an existing entry was updated, `Ok(false)` if a
+    /// new entry was inserted. Returns `Err` if indices are out of bounds.
+    ///
+    /// This is an O(1) operation.
     pub fn update_or_insert(&mut self, row: usize, col: usize, val: V) -> SparseResult<bool> {
-        if row >= self.baserows.len() || col >= self.basecols.len() {
-            return Err(SparseError(format!(
-                "({row}, {col}) are out of bounds for matrix of size {}x{}",
-                self.baserows.len(),
-                self.basecols.len(),
-            )));
-        }
+        self.validate_row_col(row, col)?;
 
         if val.is_zero() {
-            return self.delete_node(row, col);
+            let existed = self.rows[row].remove(&col).is_some();
+            self.cols[col].remove(&row);
+            return Ok(existed);
         }
 
-        // traverse left from the baserow[row] to find the right column to insert or
-        // update at
-        let mut q = self.baserows[row]; // previous node in left traversal
-        let baserow_n = self.arena.get_mut(q).unwrap();
-        let mut p = baserow_n.left;
-        let mut p_n = self.arena.get(p).unwrap();
-        while let Some(pcol) = p_n.col
-            && pcol > col
-        {
-            q = p;
-            p = p_n.left;
-            p_n = self.arena.get(p).unwrap();
-        }
-        if let Some(pcol) = p_n.col
-            && pcol == col
-        {
-            // update value
-            debug_assert!(p_n.row.is_some() && p_n.row.unwrap() == row);
-            let p_n = self.arena.get_mut(p).unwrap();
-            p_n.value = val;
-            Ok(true)
-        } else {
-            // insert node p <- new_node <- q
-            let mk_node = |k| Node {
-                row: Some(row),
-                col: Some(col),
-                value: val,
-                left: p,
-                up: k, // up will be updated later in the column traversal
-            };
-            let k = self.arena.insert_with_key(mk_node);
-            let q_n = self.arena.get_mut(q).unwrap();
-            q_n.left = k;
-
-            // column traverse to fix links in col `col` and update `k`'s up pointer
-            let mut q = self.basecols[col]; // previous node in left traversal
-            let basecol_n = self.arena.get_mut(q).unwrap();
-            let mut p = basecol_n.up;
-            let mut p_n = self.arena.get(p).unwrap();
-            while let Some(prow) = p_n.row
-                && prow > row
-            {
-                q = p;
-                p = p_n.up;
-                p_n = self.arena.get(p).unwrap();
-            }
-            if let Some(prow) = p_n.row
-                && prow == row
-            {
-                // there is no node linked yet in the column with row `row` since
-                // we're in the branch creating that now and column links have not
-                // been setup yet
-                unreachable!("programming error in sparse matrix column traversal");
-            } else {
-                // update links in the column
-                //   p
-                //   ^
-                // new_node
-                //   ^
-                //   q
-                debug_assert!(p_n.col.is_some() && p_n.col.unwrap() == col);
-                let k_n = self.arena.get_mut(k).unwrap();
-                k_n.up = p;
-                let q_n = self.arena.get_mut(q).unwrap();
-                q_n.up = k;
-
-                Ok(false)
-            }
-        }
+        let existed = self.rows[row].contains_key(&col);
+        self.rows[row].insert(col, val.clone());
+        self.cols[col].insert(row, val);
+        Ok(existed)
     }
 
-    /// Delete a node at the specified row and column from the sparse matrix.
-    ///
-    /// Updates the linked list pointers to maintain matrix integrity.
-    /// Returns Ok(true) if an in-bounds node was found and deleted, or Ok(false)
-    /// if no node was present to delete. Return Err if the row, col are out of bounds.
-    /// (row, col) is out of bounds.
-    fn delete_node(&mut self, row: usize, col: usize) -> SparseResult<bool> {
-        if row >= self.baserows.len() || col >= self.basecols.len() {
-            return Err(SparseError(format!(
-                "({row}, {col}) are out of bounds for matrix of size {}x{}",
-                self.baserows.len(),
-                self.basecols.len(),
-            )));
-        }
-
-        // Traverse left from baserow to find the node and its predecessor
-        let mut q = self.baserows[row]; // predecessor in row traversal
-        let baserow_n = self.arena.get(q).unwrap();
-        let mut p = baserow_n.left; // current pointer in row traversal
-
-        loop {
-            let p_n = self.arena.get(p).unwrap();
-            if let Some(pcol) = p_n.col {
-                if pcol == col {
-                    // Found the node to delete
-                    let node_to_delete = p;
-                    let left_ptr = p_n.left;
-                    let up_ptr = p_n.up;
-
-                    // Update row links: q.left = p.left
-                    let q_n = self.arena.get_mut(q).unwrap();
-                    q_n.left = left_ptr;
-
-                    // Traverse up from basecol to find predecessor in column
-                    let mut q_col = self.basecols[col];
-                    let basecol_n = self.arena.get(q_col).unwrap();
-                    let mut p_col = basecol_n.up;
-
-                    loop {
-                        let p_col_n = self.arena.get(p_col).unwrap();
-                        if let Some(prow) = p_col_n.row {
-                            if prow == row {
-                                // Found the node in column traversal
-                                // Update column links: q_col.up = p.up
-                                let q_col_n = self.arena.get_mut(q_col).unwrap();
-                                q_col_n.up = up_ptr;
-                                break;
-                            }
-                            q_col = p_col;
-                            let p_col_n = self.arena.get(p_col).unwrap();
-                            p_col = p_col_n.up;
-                        } else {
-                            // Reached basecol without finding node - cannot happen since we've
-                            // already found the node
-                            unreachable!()
-                        }
-                    }
-
-                    // Remove from arena
-                    self.arena.remove(node_to_delete);
-                    // TODO: sparse::delete: doesn't make sense to return the key if we delete from the arena
-                    return Ok(true);
-                } else if pcol < col {
-                    // Passed where the node would be, it doesn't exist
-                    return Ok(false);
-                }
-                q = p;
-                let p_n = self.arena.get(p).unwrap();
-                p = p_n.left;
-            } else {
-                // Reached baserow without finding node
-                return Ok(false);
-            }
-        }
+    /// Return the number of non-zero entries in the given column.
+    pub fn col_nnz(&self, col: usize) -> usize {
+        self.cols.get(col).map_or(0, |c| c.len())
     }
 
-    /// Perform a pivot operation on the matrix at the specified row and column.
+    /// Perform a pivot operation on the NxM matrix at the specified row and column.
     ///
     /// The pivot transforms matrix elements according to:
     ///
-    /// - Pivot element: a → 1/a
-    /// - Pivot row (non-pivot): b → b/a
-    /// - Pivot column (non-pivot): c → -c/a
-    /// - Other elements: d → d - b*c/a (where b is pivot row element, c is pivot column element)
+    /// - Pivot element: a -> 1/a
+    /// - Pivot row (non-pivot col): b -> -b/a
+    /// - Pivot column (non-pivot row): c -> c/a
+    /// - Other elements: d -> d - b*c/a (where b is from the original pivot row, c from pivot col)
     ///
-    /// Nodes that become zero are deleted from the sparse representation.
-    ///
-    /// TODO: sparse::pivot: the current implementation uses `get` and `delete_node` as helper
-    /// functions in a few places. This introduces some extra row/col traversals which can be
-    /// eliminated by combining with traversals in the pivot.
+    /// Entries that become zero are removed from the sparse representation.
     pub fn pivot(&mut self, row: usize, col: usize) -> SparseResult<()>
     where
-        V: Clone
-            + std::ops::Div<Output = V>
+        V: std::ops::Div<Output = V>
             + std::ops::Mul<Output = V>
             + std::ops::Sub<Output = V>
             + std::ops::Neg<Output = V>
             + From<i32>,
     {
-        // Validate bounds
-        if row >= self.baserows.len() || col >= self.basecols.len() {
+        self.validate_row_col(row, col)?;
+
+        let pivot_value = match self.rows[row].get(&col) {
+            Some(v) if !v.is_zero() => v.clone(),
+            Some(_) => return Err(SparseError("pivot element is zero".to_string())),
+            None => return Err(SparseError("pivot element is zero".to_string())),
+        };
+
+        let inv_pivot = V::from(1) / pivot_value.clone();
+
+        // Step 1: Snapshot the original pivot row (before modification)
+        // Worst case O(M)
+        let pivot_row_snapshot: HashMap<usize, V> = self.rows[row].clone();
+
+        // Step 2: Update the pivot row in-place
+        // Collect new values first, then write them
+        // Worst case O(M)
+        let new_pivot_row: HashMap<usize, V> = pivot_row_snapshot
+            .iter()
+            .map(|(j, b)| {
+                if *j == col {
+                    (*j, inv_pivot.clone())
+                } else {
+                    (*j, -(b.clone() * inv_pivot.clone()))
+                }
+            })
+            .collect();
+
+        self.rows[row] = new_pivot_row;
+        // Update cols to reflect new pivot row values (same set of columns, just new values)
+        // Worst case O(M)
+        for (j, new_val) in self.rows[row].iter() {
+            self.cols[*j].insert(row, new_val.clone());
+        }
+
+        // Step 3: Snapshot the pivot column (rows that have nonzero in column `col`, excluding pivot row)
+        // Worst case O(N)
+        let pivot_col_rows: Vec<(usize, V)> = self.cols[col]
+            .iter()
+            .filter(|(r, _)| **r != row)
+            .map(|(r, c)| (*r, c.clone()))
+            .collect();
+
+        // Step 4: Update non-pivot rows
+        for (i, c_val) in pivot_col_rows.iter() {
+            // For each column j in the original pivot row snapshot:
+            for (j, b_val) in pivot_row_snapshot.iter() {
+                if *j == col {
+                    // Pivot column entry: c -> c/a
+                    let new_val = c_val.clone() / pivot_value.clone();
+                    if new_val.is_zero() {
+                        self.rows[*i].remove(j);
+                        self.cols[*j].remove(i);
+                    } else {
+                        self.rows[*i].insert(*j, new_val.clone());
+                        self.cols[*j].insert(*i, new_val);
+                    }
+                } else {
+                    // General case: d -> d - b*c/a
+                    let d_val = self.rows[*i].get(j).cloned().unwrap_or_else(V::zero);
+                    let new_val =
+                        d_val - b_val.clone() * c_val.clone() * inv_pivot.clone();
+                    if new_val.is_zero() {
+                        self.rows[*i].remove(j);
+                        self.cols[*j].remove(i);
+                    } else {
+                        self.rows[*i].insert(*j, new_val.clone());
+                        self.cols[*j].insert(*i, new_val);
+                    }
+                }
+            }
+
+            // Handle columns NOT in the pivot row snapshot — these rows have
+            // entries that are unaffected (d -> d - 0 = d), so nothing to do.
+        }
+
+        Ok(())
+    }
+
+    fn validate_row_col(&self, row: usize, col: usize) -> SparseResult<()> {
+        if row >= self.rows.len() || col >= self.cols.len() {
             return Err(SparseError(format!(
                 "pivot position ({}, {}) is out of bounds for matrix with dimensions {} x {}",
                 row,
                 col,
-                self.baserows.len(),
-                self.basecols.len()
+                self.rows.len(),
+                self.cols.len()
             )));
         }
-
-        // Get pivot element and check it's non-zero
-        let pivot_value = match self.get(row, col) {
-            Some(v) if !v.is_zero() => v.clone(),
-            Some(_) => return Err(SparseError("pivot element is zero".to_string())),
-            None => return Err(SparseError("pivot position is out of bounds".to_string())),
-        };
-
-        // Calculate inverse of pivot
-        let inv_pivot = V::from(1) / pivot_value.clone();
-
-        // Cache pivot row values in a HashMap for efficient lookup in later passes
-        let mut pivot_row_map = HashMap::new(); // HashMap<col, value>
-        // Update pivot row: a -> 1/a for pivot elt., b → b/a for non-pivot elements
-        let baserow_k = self.baserows[row];
-        let baserow_n = self.arena.get(baserow_k).unwrap();
-        let mut p = baserow_n.left;
-        loop {
-            let p_n = self.arena.get_mut(p).unwrap();
-            if let Some(pcol) = p_n.col {
-                pivot_row_map.insert(pcol, p_n.value.clone());
-                // print!(
-                //     "DEBUG: pivot: update pivot row, col {}, {:?} -> ",
-                //     pcol, p_n.value
-                // );
-                if pcol == col {
-                    // a -> 1/a
-                    p_n.value = inv_pivot.clone();
-                } else {
-                    // b -> -b/a
-                    p_n.value = -(p_n.value.clone() * inv_pivot.clone());
-                }
-                p = p_n.left;
-            } else {
-                // Reached baserow node, stop
-                break;
-            }
-        }
-
-        // Update pivot column: c → -c/a for non-pivot rows
-        // Cache the pivot column values 'c' for later use in the general d -> d - b*c/a case
-        let mut pivot_col_values = HashMap::new();
-        let basecol_k = self.basecols[col];
-        let basecol_n = self.arena.get(basecol_k).unwrap();
-        let mut p = basecol_n.up;
-        loop {
-            let p_n = self.arena.get_mut(p).unwrap();
-            if let Some(prow) = p_n.row {
-                if prow != row {
-                    let old_value = &p_n.value;
-                    pivot_col_values.insert(prow, old_value.clone());
-                    p_n.value = old_value.clone() / pivot_value.clone();
-                }
-                p = p_n.up;
-            } else {
-                // Reached basecol node, stop
-                break;
-            }
-        }
-
-        // TODO: sparse::pivot: in the for { ... loop { ... } } code blocks below, efficiency can be improved by
-        // maintaining an array of column pointers as in Knuth 2.2.6 Algorithm S
-
-        // Update non-pivot rows: d → d - b*c/a
-        for r in 0..self.baserows.len() {
-            if r == row {
-                continue; // Skip pivot row
-            }
-
-            // Get pivot column value for this row (c) from cached values
-            let c_val = match pivot_col_values.get(&r).cloned() {
-                Some(v) if !v.is_zero() => v, // Note: guard is true by construction, but we're being defensive
-                _ => continue, // If c is zero (implicit or explicit), no updates needed for this row: d -> d - b*c/a = d
-            };
-
-            // Track which columns we've already seen/updated in this row
-            let mut updated_cols = HashSet::new();
-
-            // Collect nodes to update/delete in this row
-            let mut updates = Vec::new(); // Vec<(col, new_value)>
-            let baserow_k = self.baserows[r];
-            let baserow_n = self.arena.get(baserow_k).unwrap();
-            let mut p = baserow_n.left;
-
-            loop {
-                let p_n = self.arena.get(p).unwrap();
-                if let Some(pcol) = p_n.col {
-                    updated_cols.insert(pcol); // Mark this column as seen
-                    if pcol != col {
-                        // Get pivot row value b at (row, pcol) from the cached HashMap
-                        let b_val = pivot_row_map
-                            .get(&pcol)
-                            .cloned()
-                            .unwrap_or_else(|| V::zero());
-
-                        // Calculate new value: d - b*c/a
-                        let d_val = p_n.value.clone();
-                        let new_val = d_val - b_val * c_val.clone() * inv_pivot.clone();
-
-                        updates.push((pcol, new_val));
-                    }
-                    p = p_n.left;
-                } else {
-                    break;
-                }
-            }
-
-            // Apply updates to existing nodes
-            for (pcol, new_val) in updates {
-                if new_val.is_zero() {
-                    self.delete_node(r, pcol)?;
-                } else {
-                    let baserow_k = self.baserows[r];
-                    let baserow_n = self.arena.get(baserow_k).unwrap();
-                    let mut p = baserow_n.left;
-                    loop {
-                        let p_n = self.arena.get_mut(p).unwrap();
-                        if let Some(c) = p_n.col {
-                            if c == pcol {
-                                p_n.value = new_val;
-                                break;
-                            }
-                            p = p_n.left;
-                        } else {
-                            break;
-                        }
-                    }
-                }
-            }
-
-            // Handle column positions that were zero initially, but for which the corresponding
-            // pivot row and column values are non-zero, i.e. d=0, but b, c != 0.
-            for (pcol, b_val) in pivot_row_map.iter() {
-                if *pcol != col && !updated_cols.contains(pcol) {
-                    // d=0, calculate 0 - b*c/a = -b*c/a
-                    let new_val = -b_val.clone() * c_val.clone() * inv_pivot.clone();
-                    if !new_val.is_zero() {
-                        self.update_or_insert(r, *pcol, new_val)?;
-                    }
-                }
-            }
-        }
-
         Ok(())
     }
 }
@@ -594,29 +248,11 @@ mod tests {
     use crate::arithmetic::lia::types::{Rational, rbig};
 
     #[test]
-    ///
-    /// Matrix:
-    ///   baserows: [DefaultKey(1v1), DefaultKey(2v1)]
-    ///   basecols: [DefaultKey(3v1), DefaultKey(4v1)]
-    ///     Node { row: Some(0), col: None, value: 0, left: DefaultKey(1v1), up: DefaultKey(2v1) }
-    ///     Node { row: Some(1), col: None, value: 0, left: DefaultKey(2v1), up: DefaultKey(1v1) }
-    ///     Node { row: None, col: Some(0), value: 0, left: DefaultKey(4v1), up: DefaultKey(3v1) }
-    ///     Node { row: None, col: Some(1), value: 0, left: DefaultKey(3v1), up: DefaultKey(4v1) }
-    ///
     fn new_sparse_matrix() {
         let sp = Matrix::<i32>::new(2, 2);
         assert!(sp.is_ok());
     }
 
-    ///
-    /// Matrix:
-    ///   baserows: [DefaultKey(1v1), DefaultKey(2v1)]
-    ///   basecols: [DefaultKey(3v1), DefaultKey(4v1)]
-    ///     Node { row: Some(0), col: None, value: 0, left: DefaultKey(5v1), up: DefaultKey(2v1) }
-    ///     Node { row: Some(1), col: None, value: 0, left: DefaultKey(2v1), up: DefaultKey(1v1) }
-    ///     Node { row: None, col: Some(0), value: 0, left: DefaultKey(4v1), up: DefaultKey(3v1) }
-    ///     Node { row: None, col: Some(1), va lue: 0, left: DefaultKey(3v1), up: DefaultKey(4v1) }
-    ///     Node { row: Some(0), col: Some(0), value: 1, left: DefaultKey(1v1), up: Defau ltKey(5v1) }
     #[test]
     fn test_update_or_insert() {
         let mut sp = Matrix::<i32>::new(2, 2).expect("failed to create new sparse matrix");
@@ -687,12 +323,12 @@ mod tests {
         )
         .expect("failed to create matrix");
 
-        // Delete existing node
-        assert_eq!(m.delete_node(0, 1), Ok(true));
+        // Delete existing node by inserting zero
+        assert_eq!(m.update_or_insert(0, 1, rbig!(0)), Ok(true));
         assert_eq!(m.get(0, 1), Some(&rbig!(0)));
 
         // Delete non-existent node
-        assert_eq!(m.delete_node(2, 2), Ok(false));
+        assert_eq!(m.update_or_insert(2, 2, rbig!(0)), Ok(false));
 
         // Verify other nodes still exist
         assert_eq!(m.get(0, 0), Some(&rbig!(1)));
@@ -701,7 +337,7 @@ mod tests {
 
     #[test]
     fn test_delete_node_skipping() {
-        // [ 1   2   0 ]  deletion traversal must skip values 2 and 4 to fix up links
+        // [ 1   2   0 ]
         // [ 0   3   0 ]
         // [ 4   0   0 ]
         let mut m = Matrix::<Rational>::from_tuples(
@@ -717,9 +353,9 @@ mod tests {
         .expect("failed to create matrix");
 
         // Delete existing node
-        assert_eq!(m.delete_node(0, 0), Ok(true));
+        assert_eq!(m.update_or_insert(0, 0, rbig!(0)), Ok(true));
         assert_eq!(m.get(0, 0), Some(&rbig!(0)));
-        // Verify nodes that were skipped over still exist
+        // Verify other nodes still exist
         assert_eq!(m.get(0, 1), Some(&rbig!(2)));
         assert_eq!(m.get(2, 0), Some(&rbig!(4)));
     }
@@ -751,29 +387,29 @@ mod tests {
         assert!(m.pivot(0, 0).is_ok());
 
         // Expected result:
-        // [ 2   4   6 ]    [ 0.5  -2   -3 ]
-        // [ 1   3   5 ] -> [ 0.5   1    2 ]
-        // [ 3   6   9 ]    [ 1.5   0    0 ]
+        // [ 1/2  -2   -3 ]
+        // [ 1/2   1    2 ]
+        // [ 3/2   0    0 ]
 
-        // Check pivot element: 2 → 1/2
+        // Check pivot element: 2 -> 1/2
         assert_eq!(m.get(0, 0), Some(&rbig!(1 / 2)));
 
         // Check rest of the pivot row: b -> -b/a
         assert_eq!(m.get(0, 1), Some(&rbig!(-2)));
         assert_eq!(m.get(0, 2), Some(&rbig!(-3)));
 
-        // Check pivot column: c → c/a
+        // Check pivot column: c -> c/a
         assert_eq!(m.get(1, 0), Some(&rbig!(1 / 2)));
         assert_eq!(m.get(2, 0), Some(&rbig!(3 / 2)));
 
-        // Check other elements: d - b*c/2
-        // (1,1): 3 - 4*1/2 = 3 - 2 = 1
+        // Check other elements: d - b*c/a
+        // (1,1): 3 - 4*1/2 = 1
         assert_eq!(m.get(1, 1), Some(&rbig!(1)));
-        // (1,2): 5 - 6*1/2 = 5 - 3 = 2
+        // (1,2): 5 - 6*1/2 = 2
         assert_eq!(m.get(1, 2), Some(&rbig!(2)));
-        // (2,1): 6 - 4*3/2 = 6 - 6 = 0 (should be deleted)
+        // (2,1): 6 - 4*3/2 = 0 (should be deleted)
         assert_eq!(m.get(2, 1), Some(&rbig!(0)));
-        // (2,2): 9 - 6*3/2 = 9 - 9 = 0 (should be deleted)
+        // (2,2): 9 - 6*3/2 = 0 (should be deleted)
         assert_eq!(m.get(2, 2), Some(&rbig!(0)));
     }
 
@@ -823,8 +459,8 @@ mod tests {
         assert!(m.pivot(0, 0).is_ok());
 
         // Expected:
-        // [ 1/2  -2 ]  (0,1) = -4/2 = -2
-        // [ 1/2   0 ]  (1,1) = 2 - 4*1/2 = 2 - 2 = 0 (uses original pivot row value 4)
+        // [ 1/2  -2 ]
+        // [ 1/2   0 ]
         assert_eq!(m.get(0, 0), Some(&rbig!(1 / 2)));
         assert_eq!(m.get(0, 1), Some(&rbig!(-2)));
         assert_eq!(m.get(1, 0), Some(&rbig!(1 / 2)));
@@ -850,8 +486,8 @@ mod tests {
         assert!(m.pivot(0, 0).is_ok());
 
         // After first pivot:
-        // [ 1/3  -2 ]  (0,1) = -6/3 = -2
-        // [ 2/3   1 ]  (1,1) = 5 - 6*2/3 = 5 - 4 = 1 (uses original pivot row value 6)
+        // [ 1/3  -2 ]
+        // [ 2/3   1 ]
         assert_eq!(m.get(0, 0), Some(&rbig!(1 / 3)));
         assert_eq!(m.get(0, 1), Some(&rbig!(-2)));
         assert_eq!(m.get(1, 0), Some(&rbig!(2 / 3)));
@@ -861,10 +497,8 @@ mod tests {
         assert!(m.pivot(1, 1).is_ok());
 
         // After second pivot:
-        // [ 5/3  -2 ]  (0,0) -> 1/3 - (-2)*2/3/1 = 1/3 + 4/3 = 5/3 (uses original pivot row value -2)
-        //              (0,1) -> -2*1 = -2 (pivot column for non-pivot row)
-        // [-2/3   1 ]  (1,0) -> -(2/3)/1 = -2/3 (pivot row negated)
-        //              (1,1) -> 1/1 = 1
+        // [ 5/3  -2 ]
+        // [-2/3   1 ]
         assert_eq!(m.get(0, 0), Some(&rbig!(5 / 3)));
         assert_eq!(m.get(0, 1), Some(&rbig!(-2)));
         assert_eq!(m.get(1, 0), Some(&rbig!(-2 / 3)));
@@ -891,7 +525,7 @@ mod tests {
 
         // After pivot:
         // [ 1/2  -1/2 ]
-        // [ 1/2  -1/2 ] (1,1) entry goes from zero to non-zero --> 0 - 1*1/2 = -1/2 (uses original pivot row value 1)
+        // [ 1/2  -1/2 ]
         assert_eq!(m.get(0, 0), Some(&rbig!(1 / 2)));
         assert_eq!(m.get(0, 1), Some(&rbig!(-1 / 2)));
         assert_eq!(m.get(1, 0), Some(&rbig!(1 / 2)));
@@ -903,10 +537,7 @@ mod tests {
         let tuples = vec![
             (0, 0, rbig!(2)),
             (1, 1, rbig!(3)),
-            // (2, 2, rbig!(4)),
-            // rest of pivot row
             (0, 1, rbig!(4)),
-            // (0, 2, rbig!(5)),
         ];
         let mut m = Matrix::from_tuples(2, 2, tuples).expect("Failed to create matrix");
         m.pivot(0, 0).expect("first pivot failed");

--- a/src/arithmetic/lia/tableau.rs
+++ b/src/arithmetic/lia/tableau.rs
@@ -111,8 +111,8 @@ impl Tableau for TableauImpl {
         ncols: usize,
         t: Vec<(usize, usize, Rational)>,
     ) -> TableauResult<Self> {
-        // Default to dense; use TableauImpl::new() for runtime selection
-        Ok(TableauImpl::Dense(TableauDense::from_tuples(
+        // Default to sparse; use TableauImpl::new() for runtime selection
+        Ok(TableauImpl::Sparse(TableauSparse::from_tuples(
             nrows, ncols, t,
         )?))
     }

--- a/src/arithmetic/lia/tableau_sparse.rs
+++ b/src/arithmetic/lia/tableau_sparse.rs
@@ -94,6 +94,10 @@ impl Tableau for TableauSparse {
     fn ncols(&self) -> usize {
         self.matrix.ncols()
     }
+
+    fn col_nnz(&self, col: usize) -> usize {
+        self.matrix.col_nnz(col)
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION

*Description of changes:*

This is a rewrite of the spare matrix module which underlies the sparse tableau and simplex algorithm. The goal is to simplify the code, in particular moving away from a pointer chasing implementation on top of an arena.

 The sparse matrix has been rewritten from a `slotmap`/circular-linked-list design to mirrored `Vec<HashMap<usize, V>>` row and column vectors. The pivot operation is now obviously terminating. Several small optimizations to arithmetic in the pivot have also been made.

  Changes:
  - src/arithmetic/lia/sparse.rs — complete rewrite (~220 lines vs ~987 lines before)
  - src/arithmetic/lia/tableau_sparse.rs — added efficient `col_nnz` override

  Results:
  - All 110 tests pass
  - Benchmark: sparse pivot is ~794.07 µs for 100 pivots (improved by ~40% !)
  - Code is dramatically simpler — no arena allocation, no pointer management, no circular linked lists

See the comments for regression test and Verus benchmark results.

----
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
