### PR TITLE
fixing the tester issue

### DIFF
--- a/src/egraphs/congruence_closure.rs
+++ b/src/egraphs/congruence_closure.rs
@@ -362,22 +362,40 @@ pub fn find_if_eq_diseq<'a>(
     // assert! (!fixed); // I think we should never have things be fixed basically
     let hash = if !fixed { egraph.predecessor_hash } else { 0 };
     match term.repr() {
-        // todo: support both kinds of testers when we update Yaspar info
-        App(f, t, _) if matches!(f.get_kind(), Some(IdentifierKind::Is(_))) && sign => {
-            assert_eq!(t.len(), 1);
-            // we have to do the following because if let guard is experimental, c.f. https://github.com/rust-lang/rust/issues/51114
+        // Match both tester syntaxes: (_ is Ctor) and (is-Ctor x)
+        App(f, t, _)
+            if (matches!(f.get_kind(), Some(IdentifierKind::Is(_)))
+                || (f.get_kind().is_none() && f.id_str().get().starts_with("is-")))
+                && t.len() == 1
+                && sign =>
+        {
+            // Extract the constructor name from whichever syntax was used
             let ctor_name = if let Some(IdentifierKind::Is(sym)) = f.get_kind() {
-                sym.clone()
+                // (_ is Ctor) — indexed identifier, ctor name is directly available
+                Some(sym.clone())
             } else {
-                panic!("we just tested it!");
+                // (is-Ctor x) — strip "is-" prefix and look up the constructor
+                let name = &f.id_str().get()[3..];
+                egraph
+                    .datatype_info
+                    .constructors
+                    .keys()
+                    .find(|k| *k.get() == *name)
+                    .cloned()
             };
-            let inner_term = t[0].clone();
-            Assertion::Tester {
-                ctor_name,
-                inner_term,
-                term: term.clone(),
+            if let Some(ctor_name) = ctor_name {
+                let inner_term = t[0].clone();
+                Assertion::Tester {
+                    ctor_name,
+                    inner_term,
+                    term: term.clone(),
+                }
+            } else {
+                // is-X where X is not a known constructor; treat as uninterpreted
+                Assertion::Other
             }
         }
+
         Eq(left, right) => {
             if sign {
                 debug_println!(1, 2, "Creating equality assertion");

--- a/tests/regression/expected_results.json
+++ b/tests/regression/expected_results.json
@@ -264,6 +264,8 @@
     "datatypes/backtracking_new_terms.smt2": "unsat",
     "datatypes/insert_pred_sel_apps.smt2": "unsat",
     "datatypes/insert_pred_sel_apps2.smt2": "unsat",
+    "datatypes/is-tester.smt2": "unsat",
+    "datatypes/is-tester-uf.smt2": "unsat",
     "arithmetic/atmosphere_reduced_reduced_reduced.smt2": "unsat",
     "arithmetic/atmosphere_reduced_reduced.smt2": "unsat",
     "arithmetic/atmosphere_reduced.smt2": "unsat",

--- a/tests/regression/smt_files/datatypes/is-tester-uf.smt2
+++ b/tests/regression/smt_files/datatypes/is-tester-uf.smt2
@@ -1,0 +1,8 @@
+(set-logic ALL)
+(declare-datatypes ((color 0)) (((red) (blue))))
+(declare-const x color)
+(declare-fun is-test (Bool) Bool)
+(assert (is-red x))
+(assert (is-blue x))
+(assert (is-test true))
+(check-sat)

--- a/tests/regression/smt_files/datatypes/is-tester.smt2
+++ b/tests/regression/smt_files/datatypes/is-tester.smt2
@@ -1,0 +1,6 @@
+(set-logic ALL)
+(declare-datatypes ((color 0)) (((red) (blue))))
+(declare-const x color)
+(assert (is-red x))
+(assert (is-blue x))
+(check-sat)


### PR DESCRIPTION
*Issue #, if available: #115*

*Description of changes:* Adding support for the `is-{tester}` format. Previously this was buggy because we treated `is-{tester}` as unintepreted and we only supported `(_ is {tester})`


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
