### PR TITLE
Disable the default branch-and-bound step limit

### DIFF
--- a/src/arithmetic/lia/config.rs
+++ b/src/arithmetic/lia/config.rs
@@ -19,10 +19,7 @@ impl Default for SolverConfig {
     fn default() -> Self {
         Self {
             tableau_kind: TableauKind::Dense,
-            // 2^17; high enough that regression tests pass as expected
-            // i.e. they are either SAT/UNSAT or TIMEOUT. If this is lowered
-            // significantly, some will return UNKNOWN instead.
-            max_lra_solve_calls: Some(131_072),
+            max_lra_solve_calls: None,
         }
     }
 }


### PR DESCRIPTION

*Description of changes:*

This change improves the stability of Sundance, especially after several open PRs are applied, e.g. #99 and #114. Without this (or similar change), those PRs can't go through.

What we observe is that if the branch and bound limit is in place, certain regression tests can go from timeout to unknown depending on the platform (macos vs. Linux), especially on the CI workers.

Disabling the limit is a temporary measure. A better alternative will be to investigate if arithmetic gives us unknown and there are no quantifier instantiations to be found, only then do we run arithmetic with no resource limitations.

----
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
