### PR TITLE
Batching quantifier instantiations

### DIFF
--- a/src/cadical_propagator.rs
+++ b/src/cadical_propagator.rs
@@ -375,12 +375,8 @@ impl<'a> ExternalPropagator for CustomExternalPropagator<'a> {
         }
 
         debug_println!(11, 0, "Starting quantifier instantiations");
-        let quantifier_instantiations = instantiate_quantifiers(
-            self.solver_state,
-            &self.proof_tracer,
-            &self.assignments,
-            self.decision_level,
-        );
+        let quantifier_instantiations =
+            instantiate_quantifiers(self.solver_state, &self.proof_tracer, &self.assignments);
         debug_println!(
             11,
             0,

--- a/src/quantifiers/quantifier.rs
+++ b/src/quantifiers/quantifier.rs
@@ -24,6 +24,13 @@ pub enum QuantifierInstance {
     Skolemization { clause: Vec<i32> },
 }
 
+struct DeferredInstantiation {
+    substituted_term: Term,
+    is_exists: bool,
+    literal: i32,
+    quantifier_id: u64,
+}
+
 /// Returns a list of quantifier instantiation given the assignment and current state of the egraph
 ///
 /// TODO: level is only used for printing, can get rid of it later
@@ -41,7 +48,7 @@ pub fn instantiate_quantifiers(
     let quantifiers = &solver_state.quantifiers.clone();
     let mut instantiations = vec![];
     let mut skolemized_quantifier_idxs = vec![];
-    let mut deferred_instantiations: Vec<(Term, bool, i32, u64)> = vec![];
+    let mut deferred_instantiations: Vec<DeferredInstantiation> = vec![];
 
     // We `enumerate()` so we can update quantifiers[i].skolemized after the loop
     for (i, quantifier) in quantifiers.iter().enumerate() {
@@ -214,11 +221,12 @@ pub fn instantiate_quantifiers(
 
             if list_assignments.is_empty() {
                 debug_println!(
-                    24,
+                    6,
                     0,
-                    "No substitutions for {}",
+                    "We are skipping the quantifier {} because it has no substitutions",
                     solver_state.get_term(quantifier.id)
                 );
+                continue;
             }
 
             debug_println!(7, 0, "We have the following list of assignments:");
@@ -252,23 +260,52 @@ pub fn instantiate_quantifiers(
                     &mut solver_state.context,
                 );
                 let substituted_term = term.subst(&substitution, &mut solver_state.context);
-                deferred_instantiations.push((
+                deferred_instantiations.push(DeferredInstantiation {
                     substituted_term,
-                    quantifier_is_exists,
-                    quantifier_literal,
-                    quantifier.id,
-                ));
+                    is_exists: quantifier_is_exists,
+                    literal: quantifier_literal,
+                    quantifier_id: quantifier.id,
+                });
             }
         }
     }
 
-    // Phase 2: Process all deferred instantiations (substitute and add to egraph)
+    process_deferred_instantiations(
+        deferred_instantiations,
+        solver_state,
+        proof_tracer,
+        ddsmt,
+        lazy_dt,
+        level,
+        &mut instantiations,
+    );
+
+    // Now mark the quantifier indices as skolemized
+    for i in skolemized_quantifier_idxs {
+        solver_state.quantifiers[i].skolemized = true;
+    }
+
+    instantiations
+}
+
+fn process_deferred_instantiations(
+    deferred_instantiations: Vec<DeferredInstantiation>,
+    solver_state: &mut SolverState,
+    proof_tracer: &Rc<RefCell<SMTProofTracer>>,
+    ddsmt: bool,
+    lazy_dt: bool,
+    level: usize,
+    instantiations: &mut Vec<QuantifierInstance>,
+) {
     debug_println!(6, 0, "Starting to process deferred instantiations");
-    for (substituted_term, quantifier_is_exists, quantifier_literal, quantifier_id) in
-        deferred_instantiations
+    for DeferredInstantiation {
+        substituted_term,
+        is_exists,
+        literal,
+        quantifier_id,
+    } in deferred_instantiations
     {
-        // if this came from a negated existential, we have to negate the term
-        let t = if quantifier_is_exists {
+        let t = if is_exists {
             solver_state.context.not(substituted_term)
         } else {
             substituted_term
@@ -285,7 +322,6 @@ pub fn instantiate_quantifiers(
 
         debug_println!(4, 0, "We have the term {} with id {}", t, t.uid());
 
-        // eliminating lets
         let let_elim_term = t.let_elim(&mut solver_state.context);
 
         debug_println!(
@@ -326,12 +362,9 @@ pub fn instantiate_quantifiers(
             .map(|x| x.into_iter().collect::<Vec<_>>())
             .collect();
 
-        let quantifier_dimacs_literal = if quantifier_is_exists {
-            -quantifier_literal
-        } else {
-            quantifier_literal
-        };
+        let quantifier_dimacs_literal = if is_exists { -literal } else { literal };
         let nnf_term_literal = solver_state.get_lit_from_term(&nnf_term);
+        // Must happen *after* `cnf_tseitin` so Tseitin literals are registered first
         let subst_literal = if t.uid() != nnf_term.uid() {
             solver_state.get_or_allocate_lit_for_term(&t)
         } else {
@@ -366,13 +399,6 @@ pub fn instantiate_quantifiers(
             instantiations.push(instantiation);
         }
     }
-
-    // Now mark the quantifier indices as skolemized
-    for i in skolemized_quantifier_idxs {
-        solver_state.quantifiers[i].skolemized = true;
-    }
-
-    instantiations
 }
 
 // match_term and find_assignments_on_term moved to Egraph methods in solver_state.rs

--- a/src/quantifiers/quantifier.rs
+++ b/src/quantifiers/quantifier.rs
@@ -286,10 +286,9 @@ fn process_deferred_instantiations(
 
         let cnf_term = nnf_term.cnf_tseitin(solver_state);
 
-        let mut clauses: Vec<_> = cnf_term
-            .clone()
+        let mut clauses: Vec<Vec<i32>> = cnf_term
             .into_iter()
-            .map(|x| x.into_iter().collect::<Vec<_>>())
+            .map(|x| x.into_iter().collect::<Vec<i32>>())
             .collect();
 
         let quantifier_dimacs_literal = if is_exists { -literal } else { literal };

--- a/src/quantifiers/quantifier.rs
+++ b/src/quantifiers/quantifier.rs
@@ -16,7 +16,7 @@ use crate::solver_types::Polarity;
 use crate::utils::DeterministicHashMap;
 
 use crate::debug_println;
-use yaspar_ir::ast::{LetElim, Substitute, Substitution, Term, TermAllocator};
+use yaspar_ir::ast::{LetElim, Sort, Str, Substitute, Substitution, Term, TermAllocator};
 
 #[derive(Debug, Clone)]
 pub enum QuantifierInstance {
@@ -31,15 +31,18 @@ struct DeferredInstantiation {
     quantifier_id: u64,
 }
 
+struct DeferredSkolemization {
+    skolem: Term,
+    skolem_vars: Vec<(Str, Sort)>,
+    is_exists: bool,
+    literal: i32,
+}
+
 /// Returns a list of quantifier instantiation given the assignment and current state of the egraph
-///
-/// TODO: level is only used for printing, can get rid of it later
-/// (could use it for activate_bits, but right now we are activating everything at level 0)
 pub fn instantiate_quantifiers(
     solver_state: &mut SolverState,
     proof_tracer: &Rc<RefCell<SMTProofTracer>>,
-    assignments: &Vec<i32>,
-    level: usize,
+    assignments: &[i32],
 ) -> Vec<QuantifierInstance> {
     let eager_skolem = solver_state.eager_skolem;
     let ddsmt = solver_state.ddsmt;
@@ -48,6 +51,7 @@ pub fn instantiate_quantifiers(
     let quantifiers = &solver_state.quantifiers.clone();
     let mut instantiations = vec![];
     let mut skolemized_quantifier_idxs = vec![];
+    let mut deferred_skolemizations: Vec<DeferredSkolemization> = vec![];
     let mut deferred_instantiations: Vec<DeferredInstantiation> = vec![];
 
     // We `enumerate()` so we can update quantifiers[i].skolemized after the loop
@@ -65,20 +69,7 @@ pub fn instantiate_quantifiers(
         let quantifier_assignment = assignments[quantifier_literal.unsigned_abs() as usize];
 
         // if the quantifier is unassigned, we can skip it
-        if quantifier_assignment == 0
-        // || (quantifier_assignment > 0 && quantifier_literal < 0)
-        // || (quantifier_assignment < 0 && quantifier_literal > 0)
-        {
-            debug_println!(12, 0, "after4");
-            debug_println!(
-                6,
-                0,
-                "We are skipping the quantifier {} with quantifier_literal {} and quantifier_assignment {} | assignments {:?}",
-                solver_state.get_term(quantifier.id),
-                quantifier_literal,
-                quantifier_assignment,
-                assignments
-            );
+        if quantifier_assignment == 0 {
             continue;
         }
 
@@ -90,104 +81,18 @@ pub fn instantiate_quantifiers(
 
         // if the quantifier has positive polarity or we are doing ddsmt optimizations, and we haven't skolemized it yet, then we skolemize it
         if (quantifier_polarity || eager_skolem) && !quantifier.skolemized {
-            debug_println!(
-                6,
-                0,
-                "We are skolemizing the quantifier {} with quantifier_literal {} and quantifier_assignment {} | assignments {:?}",
-                solver_state.get_term(quantifier.id),
-                quantifier_literal,
-                quantifier_assignment,
-                assignments,
-            );
-
-            // Record this `Quantifier`'s index, so we can update its `.skolemized` field at the end
             skolemized_quantifier_idxs.push(i);
 
-            // Skolemize the term
             let term = solver_state.get_term(quantifier.id);
             let (skolem, skolem_vars) =
                 skolemize(&term, &mut solver_state.context, quantifier_is_exists);
 
-            // Reduce the skolemized term, since Sundance doesn't simplify formulas under quantifiers during parsing
-            let reduced_skolem: Term = skolem.let_elim(&mut solver_state.context);
-            let reduced_skolem = reduced_skolem.nnf(solver_state);
-            let additional_constraints =
-                check_for_function_bool(&reduced_skolem, solver_state, true, ddsmt, lazy_dt);
-
-            // Register the reduction with the egraph
-            solver_state.insert_predecessor(&reduced_skolem, None, None, true);
-
-            // Apply the Tseitin transformation to the reduced formula.
-            // NOTE: We must do this step *before* we add a Skolemization eDRAT proof step,
-            // since Sundance aggressively caches boolean sub-terms in its `CNFEnv` cache.
-            // We want Sundance to register those DIMACS literals before we specially
-            // request a new one for the un-reduced skolem term, just in case they match.
-            // (If they match, then `cnf_tseitin()` won't process any sub-terms, since
-            // the function otherwise has a cache hit.)
-            let clauses = reduced_skolem.cnf_tseitin(solver_state);
-
-            debug_println!(19, 0, "we are skolemizing {}", term);
-            debug_println!(26, 0, "(assert {})", reduced_skolem);
-            debug_println!(
-                24,
-                8,
-                "from quantifier {} [{}]",
-                solver_state.get_term(quantifier.id),
-                quantifier.id,
-            );
-
-            // Now we add proof clause(s) to the eDRAT proof to justify the Skolemization.
-            // Store the DIMACS literals we need beforehand.
-            let quantifier_dimacs_literal = if quantifier_is_exists {
-                quantifier_literal
-            } else {
-                -quantifier_literal
-            };
-            let reduced_skolem_literal = solver_state.get_lit_from_term(&reduced_skolem);
-            let skolem_literal = if skolem.uid() != reduced_skolem.uid() {
-                // Note: This must happen *after* calling `reduced_skolem.cnf_tseitin()`
-                solver_state.get_or_allocate_lit_for_term(&skolem)
-            } else {
-                0
-            };
-
-            proof_tracer
-                .borrow_mut()
-                .push_skolem_or_instantiation_derivation(
-                    quantifier_dimacs_literal,
-                    skolem_literal,
-                    &skolem,
-                    reduced_skolem_literal,
-                    &reduced_skolem,
-                    ProofStepType::Skolemization {
-                        parent_term: quantifier_literal,
-                        skolem_vars,
-                    },
-                );
-
-            // The SAT solver ultimately learns the Skolem as an implication
-            let skolem_imp = vec![-quantifier_dimacs_literal, reduced_skolem_literal];
-            instantiations.push(QuantifierInstance::Skolemization { clause: skolem_imp });
-
-            // Finally, clauses from the Tseitin transformation and from `additional_constraints`
-            // are implied by the reduced skolem formula.
-
-            // Lambda to add the skolem literal to the Tseitin/additional_constraints clauses
-            let mut add_clause = |mut clause: Vec<i32>, theory: Theory| {
-                if push_literal_if_not_tautology(&mut clause, -reduced_skolem_literal) {
-                    proof_tracer.borrow_mut().add_theory_clause(&clause, theory);
-                    instantiations.push(QuantifierInstance::Skolemization { clause })
-                }
-            };
-
-            for clause in clauses {
-                add_clause(clause.0, Theory::Boolean);
-            }
-
-            // CC TODO: Differentiate between `ite` axioms and `datatype` axioms
-            for clause in additional_constraints {
-                add_clause(clause, Theory::Boolean);
-            }
+            deferred_skolemizations.push(DeferredSkolemization {
+                skolem,
+                skolem_vars,
+                is_exists: quantifier_is_exists,
+                literal: quantifier_literal,
+            });
         }
 
         // if this was a skolemization case, we don't want to instantiate
@@ -195,12 +100,6 @@ pub fn instantiate_quantifiers(
             continue;
         }
 
-        debug_println!(
-            19,
-            0,
-            "instantiating the quantifier {}",
-            solver_state.get_term(quantifier.id)
-        );
         let triggers = &quantifier.triggers;
         // note we consider patterns in a multipattern conjunctively and multipatterns in a trigger disjunctively
         for multipattern in triggers {
@@ -208,28 +107,12 @@ pub fn instantiate_quantifiers(
             let trigger_term_pairs: Vec<(usize, Option<u32>)> =
                 multipattern.iter().map(|t| (*t, None)).collect();
 
-            debug_println!(12, 0, "after8");
-            debug_println!(
-                19,
-                0,
-                "About to match quantifier body {} with trigger {:?}",
-                solver_state.get_term(body),
-                trigger_term_pairs
-            );
-            debug_println!(12, 0, "after9");
             let list_assignments = solver_state.egraph.match_triggers(trigger_term_pairs);
 
             if list_assignments.is_empty() {
-                debug_println!(
-                    6,
-                    0,
-                    "We are skipping the quantifier {} because it has no substitutions",
-                    solver_state.get_term(quantifier.id)
-                );
                 continue;
             }
 
-            debug_println!(7, 0, "We have the following list of assignments:");
             for subs_ids in list_assignments.iter() {
                 // Convert ID map to Term map for substitution
                 let subs: DeterministicHashMap<String, Term> = subs_ids
@@ -253,7 +136,6 @@ pub fn instantiate_quantifiers(
                     .or_default()
                     .insert(subs.clone());
 
-                debug_println!(6, 0, "before12");
                 let term = solver_state.get_term(body);
                 let substitution = Substitution::new(
                     subs.iter().map(|(s, t)| (s, t.clone())),
@@ -270,15 +152,21 @@ pub fn instantiate_quantifiers(
         }
     }
 
-    process_deferred_instantiations(
+    instantiations.extend(process_deferred_skolemizations(
+        deferred_skolemizations,
+        solver_state,
+        proof_tracer,
+        ddsmt,
+        lazy_dt,
+    ));
+
+    instantiations.extend(process_deferred_instantiations(
         deferred_instantiations,
         solver_state,
         proof_tracer,
         ddsmt,
         lazy_dt,
-        level,
-        &mut instantiations,
-    );
+    ));
 
     // Now mark the quantifier indices as skolemized
     for i in skolemized_quantifier_idxs {
@@ -288,16 +176,85 @@ pub fn instantiate_quantifiers(
     instantiations
 }
 
+fn process_deferred_skolemizations(
+    deferred_skolemizations: Vec<DeferredSkolemization>,
+    solver_state: &mut SolverState,
+    proof_tracer: &Rc<RefCell<SMTProofTracer>>,
+    ddsmt: bool,
+    lazy_dt: bool,
+) -> Vec<QuantifierInstance> {
+    let mut results = vec![];
+    for DeferredSkolemization {
+        skolem,
+        skolem_vars,
+        is_exists,
+        literal,
+    } in deferred_skolemizations
+    {
+        let reduced_skolem: Term = skolem.let_elim(&mut solver_state.context);
+        let reduced_skolem = reduced_skolem.nnf(solver_state);
+        let additional_constraints =
+            check_for_function_bool(&reduced_skolem, solver_state, true, ddsmt, lazy_dt);
+
+        solver_state.insert_predecessor(&reduced_skolem, None, None, true);
+
+        // Must do Tseitin *before* allocating the skolem literal — see comment on instantiation path
+        let clauses = reduced_skolem.cnf_tseitin(solver_state);
+
+        debug_println!(26, 0, "(assert {})", reduced_skolem);
+
+        let quantifier_dimacs_literal = if is_exists { literal } else { -literal };
+        let reduced_skolem_literal = solver_state.get_lit_from_term(&reduced_skolem);
+        // Must happen *after* `cnf_tseitin` so Tseitin literals are registered first
+        let skolem_literal = if skolem.uid() != reduced_skolem.uid() {
+            solver_state.get_or_allocate_lit_for_term(&skolem)
+        } else {
+            0
+        };
+
+        proof_tracer
+            .borrow_mut()
+            .push_skolem_or_instantiation_derivation(
+                quantifier_dimacs_literal,
+                skolem_literal,
+                &skolem,
+                reduced_skolem_literal,
+                &reduced_skolem,
+                ProofStepType::Skolemization {
+                    parent_term: literal,
+                    skolem_vars,
+                },
+            );
+
+        let skolem_imp = vec![-quantifier_dimacs_literal, reduced_skolem_literal];
+        results.push(QuantifierInstance::Skolemization { clause: skolem_imp });
+
+        let mut add_clause = |mut clause: Vec<i32>, theory: Theory| {
+            if push_literal_if_not_tautology(&mut clause, -reduced_skolem_literal) {
+                proof_tracer.borrow_mut().add_theory_clause(&clause, theory);
+                results.push(QuantifierInstance::Skolemization { clause })
+            }
+        };
+
+        for clause in clauses {
+            add_clause(clause.0, Theory::Boolean);
+        }
+
+        for clause in additional_constraints {
+            add_clause(clause, Theory::Boolean);
+        }
+    }
+    results
+}
+
 fn process_deferred_instantiations(
     deferred_instantiations: Vec<DeferredInstantiation>,
     solver_state: &mut SolverState,
     proof_tracer: &Rc<RefCell<SMTProofTracer>>,
     ddsmt: bool,
     lazy_dt: bool,
-    level: usize,
-    instantiations: &mut Vec<QuantifierInstance>,
-) {
-    debug_println!(6, 0, "Starting to process deferred instantiations");
+) -> Vec<QuantifierInstance> {
+    let mut results = vec![];
     for DeferredInstantiation {
         substituted_term,
         is_exists,
@@ -314,47 +271,20 @@ fn process_deferred_instantiations(
         debug_println!(
             22,
             0,
-            "We are adding the instantiation {} for quantifier {} at level {}",
+            "We are adding the instantiation {} for quantifier {}",
             t.clone(),
             solver_state.get_term(quantifier_id),
-            level
         );
-
-        debug_println!(4, 0, "We have the term {} with id {}", t, t.uid());
 
         let let_elim_term = t.let_elim(&mut solver_state.context);
-
-        debug_println!(
-            8,
-            0,
-            "{} is an instantiation of {}",
-            let_elim_term,
-            solver_state.get_term(quantifier_id)
-        );
 
         let nnf_term = let_elim_term.nnf(solver_state);
 
         debug_println!(26, 4, "(assert {})", nnf_term.clone());
-        debug_println!(
-            24,
-            8,
-            "from quantifier {} [{}]",
-            solver_state.get_term(quantifier_id),
-            quantifier_id
-        );
-
-        debug_println!(
-            7,
-            0,
-            "We have the nnf term {} with id {}",
-            nnf_term,
-            nnf_term.uid()
-        );
 
         solver_state.insert_predecessor(&nnf_term, None, None, true);
 
         let cnf_term = nnf_term.cnf_tseitin(solver_state);
-        debug_println!(7, 0, "We have the cnf term {:?}", cnf_term);
 
         let mut clauses: Vec<_> = cnf_term
             .clone()
@@ -395,10 +325,8 @@ fn process_deferred_instantiations(
         clauses.extend(additional_constraints);
 
         for clause in clauses {
-            let instantiation = QuantifierInstance::Instantiation { clause };
-            instantiations.push(instantiation);
+            results.push(QuantifierInstance::Instantiation { clause });
         }
     }
+    results
 }
-
-// match_term and find_assignments_on_term moved to Egraph methods in solver_state.rs

--- a/src/quantifiers/quantifier.rs
+++ b/src/quantifiers/quantifier.rs
@@ -41,6 +41,7 @@ pub fn instantiate_quantifiers(
     let quantifiers = &solver_state.quantifiers.clone();
     let mut instantiations = vec![];
     let mut skolemized_quantifier_idxs = vec![];
+    let mut deferred_instantiations: Vec<(Term, bool, i32, u64)> = vec![];
 
     // We `enumerate()` so we can update quantifiers[i].skolemized after the loop
     for (i, quantifier) in quantifiers.iter().enumerate() {
@@ -221,7 +222,6 @@ pub fn instantiate_quantifiers(
             }
 
             debug_println!(7, 0, "We have the following list of assignments:");
-            let mut substitutions = vec![];
             for subs_ids in list_assignments.iter() {
                 // Convert ID map to Term map for substitution
                 let subs: DeterministicHashMap<String, Term> = subs_ids
@@ -252,138 +252,118 @@ pub fn instantiate_quantifiers(
                     &mut solver_state.context,
                 );
                 let substituted_term = term.subst(&substitution, &mut solver_state.context);
-                substitutions.push((substituted_term, subs));
+                deferred_instantiations.push((
+                    substituted_term,
+                    quantifier_is_exists,
+                    quantifier_literal,
+                    quantifier.id,
+                ));
             }
+        }
+    }
 
-            if substitutions.is_empty() {
-                debug_println!(
-                    6,
-                    0,
-                    "We are skipping the quantifier {} because it has no substitutions",
-                    solver_state.get_term(quantifier.id)
-                );
-                continue;
-            }
+    // Phase 2: Process all deferred instantiations (substitute and add to egraph)
+    debug_println!(6, 0, "Starting to process deferred instantiations");
+    for (substituted_term, quantifier_is_exists, quantifier_literal, quantifier_id) in
+        deferred_instantiations
+    {
+        // if this came from a negated existential, we have to negate the term
+        let t = if quantifier_is_exists {
+            solver_state.context.not(substituted_term)
+        } else {
+            substituted_term
+        };
 
-            debug_println!(6, 0, "Starting to look at substitutions");
-            for (t, _) in substitutions {
-                // skipping instantiations that have already been added
-                // TODO: need to come up with a more efficient way to do this
-                // TODO: have solver_state.added_instantiations as a string right now, really want to go back to u32
+        debug_println!(
+            22,
+            0,
+            "We are adding the instantiation {} for quantifier {} at level {}",
+            t.clone(),
+            solver_state.get_term(quantifier_id),
+            level
+        );
 
-                // if this came from a negated existential, we have to negate the term
-                let t = if quantifier_is_exists {
-                    solver_state.context.not(t)
-                } else {
-                    t
-                };
+        debug_println!(4, 0, "We have the term {} with id {}", t, t.uid());
 
-                debug_println!(
-                    22,
-                    0,
-                    "We are adding the instantiation {} for quantifier {} at level {}",
-                    t.clone(),
-                    solver_state.get_term(quantifier.id),
-                    level
-                );
+        // eliminating lets
+        let let_elim_term = t.let_elim(&mut solver_state.context);
 
-                debug_println!(4, 0, "We have the term {} with id {}", t, t.uid());
+        debug_println!(
+            8,
+            0,
+            "{} is an instantiation of {}",
+            let_elim_term,
+            solver_state.get_term(quantifier_id)
+        );
 
-                // eliminating lets
-                let let_elim_term = t.let_elim(&mut solver_state.context);
+        let nnf_term = let_elim_term.nnf(solver_state);
 
-                debug_println!(
-                    8,
-                    0,
-                    "{} is an instantiation of {}",
-                    let_elim_term,
-                    solver_state.get_term(quantifier.id)
-                );
+        debug_println!(26, 4, "(assert {})", nnf_term.clone());
+        debug_println!(
+            24,
+            8,
+            "from quantifier {} [{}]",
+            solver_state.get_term(quantifier_id),
+            quantifier_id
+        );
 
-                let nnf_term = let_elim_term.nnf(solver_state);
+        debug_println!(
+            7,
+            0,
+            "We have the nnf term {} with id {}",
+            nnf_term,
+            nnf_term.uid()
+        );
 
-                debug_println!(26, 4, "(assert {})", nnf_term.clone());
-                debug_println!(
-                    24,
-                    8,
-                    "from quantifier {} [{}]",
-                    solver_state.get_term(quantifier.id),
-                    quantifier.id
-                );
+        solver_state.insert_predecessor(&nnf_term, None, None, true);
 
-                debug_println!(
-                    7,
-                    0,
-                    "We have the nnf term {} with id {}",
-                    nnf_term,
-                    nnf_term.uid()
-                );
+        let cnf_term = nnf_term.cnf_tseitin(solver_state);
+        debug_println!(7, 0, "We have the cnf term {:?}", cnf_term);
 
-                // note we do this after nnf
-                // this might lead to weirdness when you have equality of booleans not being represented in egraph
-                // but it should be fine. This is necessary because we need to look up lits
-                // todo: also might be less efficient as well because we are losing structure from original formula in the egraph
-                solver_state.insert_predecessor(&nnf_term, None, None, true);
+        let mut clauses: Vec<_> = cnf_term
+            .clone()
+            .into_iter()
+            .map(|x| x.into_iter().collect::<Vec<_>>())
+            .collect();
 
-                let cnf_term = nnf_term.cnf_tseitin(solver_state);
-                debug_println!(7, 0, "We have the cnf term {:?}", cnf_term);
+        let quantifier_dimacs_literal = if quantifier_is_exists {
+            -quantifier_literal
+        } else {
+            quantifier_literal
+        };
+        let nnf_term_literal = solver_state.get_lit_from_term(&nnf_term);
+        let subst_literal = if t.uid() != nnf_term.uid() {
+            solver_state.get_or_allocate_lit_for_term(&t)
+        } else {
+            0
+        };
 
-                let mut clauses: Vec<_> = cnf_term
-                    .clone()
-                    .into_iter()
-                    .map(|x| x.into_iter().collect::<Vec<_>>())
-                    .collect();
+        proof_tracer
+            .borrow_mut()
+            .push_skolem_or_instantiation_derivation(
+                quantifier_dimacs_literal,
+                subst_literal,
+                &t,
+                nnf_term_literal,
+                &nnf_term,
+                ProofStepType::Instantiation,
+            );
 
-                let quantifier_dimacs_literal = if quantifier_is_exists {
-                    -quantifier_literal
-                } else {
-                    quantifier_literal
-                };
-                let nnf_term_literal = solver_state.get_lit_from_term(&nnf_term);
-                let subst_literal = if t.uid() != nnf_term.uid() {
-                    // Reserve a fresh DIMACS literal for the un-reduced term.
-                    // Note: This must happen *after* calling `nnf_term.cnf_tseitin()`
-                    solver_state.get_or_allocate_lit_for_term(&t)
-                } else {
-                    0
-                };
+        proof_tracer
+            .borrow_mut()
+            .push_steps(&clauses, ProofStepType::TheoryClause(Theory::Boolean));
 
-                // Add the "quantifier implies instantiation" clause to the proof
-                proof_tracer
-                    .borrow_mut()
-                    .push_skolem_or_instantiation_derivation(
-                        quantifier_dimacs_literal,
-                        subst_literal,
-                        &t,
-                        nnf_term_literal,
-                        &nnf_term,
-                        ProofStepType::Instantiation,
-                    );
+        let additional_constraints =
+            check_for_function_bool(&nnf_term, solver_state, true, ddsmt, lazy_dt);
+        proof_tracer.borrow_mut().push_steps(
+            &additional_constraints,
+            ProofStepType::TheoryClause(Theory::Background),
+        );
+        clauses.extend(additional_constraints);
 
-                // Add proof steps witnessing the Tseitin transformation of `nnf_term`
-                proof_tracer
-                    .borrow_mut()
-                    .push_steps(&clauses, ProofStepType::TheoryClause(Theory::Boolean));
-
-                // the bug comes from the additional constraints
-                // basically the additional constraints are valid lits -> converted to valid u64, but may not be in the actual term mapping
-                // it should be added in insert_predecessor which calls get_or_insert which adds into terms_list
-                let additional_constraints =
-                    check_for_function_bool(&nnf_term, solver_state, true, ddsmt, lazy_dt);
-                proof_tracer.borrow_mut().push_steps(
-                    &additional_constraints,
-                    ProofStepType::TheoryClause(Theory::Background),
-                );
-                clauses.extend(additional_constraints);
-
-                // could activate bits here (the level should not be 0)
-                // activate_bits(&t, 0, egraph);
-
-                for clause in clauses {
-                    let instantiation = QuantifierInstance::Instantiation { clause };
-                    instantiations.push(instantiation); // TODO: I would prefer to push t.uid() here, but it seems like the uid is not getting adding to the terms list
-                }
-            }
+        for clause in clauses {
+            let instantiation = QuantifierInstance::Instantiation { clause };
+            instantiations.push(instantiation);
         }
     }
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* We modify our quantifier instantiation loop, so we first compute all of the instantiations before we make the substitutions. Before when we were looping through quantifiers: $Q_1, Q_2, Q_3, \ldots$, when trying to e-match against $Q_2$, this would include all of the terms that were created by instantiating $Q_1$. This led to instability (as noticed by Long) since the order of quantifiers could have a large affect on performance.

This also shows a performance improvement on the Verus benchmarks from 71.4% to 72.4%. I think this points to a bigger issue, that we are learning quantifier instantiations too eagerly, but I am not sure how to fix it yet.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
