### PR TITLE
Making constants root of their eclass

### DIFF
--- a/src/cadical_propagator.rs
+++ b/src/cadical_propagator.rs
@@ -185,7 +185,6 @@ impl<'a> ExternalPropagator for CustomExternalPropagator<'a> {
                         .add_theory_clause(&shrunk_constraint, Theory::Background);
 
                     // let theory_reason = format!("congruence_closure_level_{}", self.decision_level);
-
                     self.disequalities.borrow_mut().push(shrunk_constraint);
                     debug_println!(
                         14 - 3,
@@ -305,6 +304,7 @@ impl<'a> ExternalPropagator for CustomExternalPropagator<'a> {
                         arithmetic_literals
                     );
                     // let negated_arithmetic_literals = arithmetic_literals.iter().map(|x| -x).collect();
+                    // todo: add proof logging
                     self.disequalities.borrow_mut().push(arithmetic_literals);
                     return false;
                 }

--- a/src/egraphs/basic/egraph.rs
+++ b/src/egraphs/basic/egraph.rs
@@ -899,7 +899,7 @@ impl Egraph {
             return EgraphResult::with_conflict(Conflict {
                 equalities,
                 disequality: (t1, t2),
-                diseq_lit,
+                diseq_lit: None,
             });
         }
         let hash = self.predecessor_hash;
@@ -1175,7 +1175,7 @@ impl Egraph {
             return EgraphResult::with_conflict(Conflict {
                 equalities,
                 disequality: (x_root, y_root),
-                diseq_lit: 0,
+                diseq_lit: None,
             });
         }
 
@@ -1236,7 +1236,7 @@ impl Egraph {
                 return EgraphResult::with_conflict(Conflict {
                     equalities,
                     disequality: disequality.original_disequality,
-                    diseq_lit: disequality.diseq_lit,
+                    diseq_lit: Some(disequality.diseq_lit),
                 });
             } else {
                 panic!(

--- a/src/egraphs/basic/egraph.rs
+++ b/src/egraphs/basic/egraph.rs
@@ -1161,9 +1161,10 @@ impl Egraph {
             let mut equalities = Vec::new();
             let mut tracker = ProofTracker::new();
             if x != x_root
-                && let Some(path) = self.leastcommonancestor(x, x_root, &mut tracker) {
-                    equalities.extend(path);
-                }
+                && let Some(path) = self.leastcommonancestor(x, x_root, &mut tracker)
+            {
+                equalities.extend(path);
+            }
             // Explain the current merge from the proof_parent edge
             match &proof_parent {
                 ProofForestEdge::Equality {
@@ -1184,9 +1185,10 @@ impl Egraph {
             }
             tracker = ProofTracker::new();
             if y != y_root
-                && let Some(path) = self.leastcommonancestor(y, y_root, &mut tracker) {
-                    equalities.extend(path);
-                }
+                && let Some(path) = self.leastcommonancestor(y, y_root, &mut tracker)
+            {
+                equalities.extend(path);
+            }
             return EgraphResult::with_conflict(Conflict {
                 equalities,
                 disequality: (x_root, y_root),

--- a/src/egraphs/basic/egraph.rs
+++ b/src/egraphs/basic/egraph.rs
@@ -601,15 +601,6 @@ impl Egraph {
         self.sig_trail.push((level, key, term_id, true));
     }
 
-    /// Remove a term from the sig_table (if it maps to expected_id), recording a trail entry.
-    fn sig_table_remove(&mut self, key: &SigKey, expected_id: u32, level: usize) {
-        if self.sig_table.get(key) == Some(&expected_id) {
-            self.sig_table.remove(key);
-            self.sig_trail
-                .push((level, key.clone(), expected_id, false));
-        }
-    }
-
     /// Build a congruence proof edge and merge two terms that have the same signature.
     /// Returns the result of cc_union (which may contain a conflict).
     fn congruence_merge(&mut self, a: u32, b: u32, level: usize) -> EgraphResult<u32> {
@@ -1134,14 +1125,6 @@ impl Egraph {
             level,
             proof_parent
         );
-        debug_println!(11, 0, "{}", self);
-        // assert_eq!(
-        //     self.display_term(x).get_sort(self),
-        //     self.display_term(y).get_sort(self),
-        //     "We are comparing terms {} and {}",
-        //     self.display_term(x),
-        //     self.display_term(y)
-        // );
 
         if x_root == y_root {
             debug_println!(
@@ -1266,21 +1249,6 @@ impl Egraph {
             }
         }
 
-        // Phase 1: Remove sig_table entries for y_root's predecessors.
-        // Their signatures use y_root as a child representative; after the union
-        // they need new entries with x_root instead.
-        // Only process valid (non-stale) predecessors.
-        let y_root_pred_keys: Vec<u32> = self.predecessors[y_root as usize]
-            .iter()
-            .filter(|(_, p)| valid_hash(p.hash, p.level, &self.predecessor_level))
-            .map(|(k, _)| *k)
-            .collect();
-        for pred_id in &y_root_pred_keys {
-            if let Some(old_sig) = self.compute_signature(*pred_id) {
-                self.sig_table_remove(&old_sig, *pred_id, level);
-            }
-        }
-
         // need to add the new disequalities into x_root
         // TODO: could also clean up some backtracking stuff here, probably want to factor this into its own function
         let (x_root_disequalities_edge, y_root_disequalities_edge) = if x_root > y_root {
@@ -1354,10 +1322,11 @@ impl Egraph {
             }
         }
 
-        // Phase 3: Reinsert y_root's predecessors into sig_table with new canonical forms
+        // Reinsert y_root's predecessors into sig_table with new canonical forms
         // and immediately merge any congruent pairs found.
         // Also move predecessors from y_root to x_root.
         let predecessors_v = std::mem::take(&mut self.predecessors[y_root as usize]);
+        let mut y_root_pred_keys: Vec<u32> = Vec::new();
         for (pred_key, pred_val) in &predecessors_v {
             let new_pred = Predecessor {
                 level,
@@ -1366,9 +1335,11 @@ impl Egraph {
                 inner_term: pred_val.inner_term,
             };
             self.add_predecessor(x_root, *pred_key, new_pred);
+            if valid_hash(pred_val.hash, pred_val.level, &self.predecessor_level) {
+                y_root_pred_keys.push(*pred_key);
+            }
         }
         self.predecessors[y_root as usize] = predecessors_v;
-
         for &pred_id in &y_root_pred_keys {
             if let Some(new_sig) = self.compute_signature(pred_id) {
                 if let Some(&existing) = self.sig_table.get(&new_sig) {

--- a/src/egraphs/basic/egraph.rs
+++ b/src/egraphs/basic/egraph.rs
@@ -896,6 +896,8 @@ impl Egraph {
         self.advance_to_level(level);
         let mut tracker = ProofTracker::new();
         if let Some(equalities) = self.leastcommonancestor(t1, t2, &mut tracker) {
+            // diseq_lit is None: the disequality being asserted is implicit in the
+            // conflict (the caller reconstructs it from the assertion context).
             return EgraphResult::with_conflict(Conflict {
                 equalities,
                 disequality: (t1, t2),
@@ -1140,6 +1142,8 @@ impl Egraph {
         let x_root_is_const = self.is_constant(x_root);
         let y_root_is_const = self.is_constant(y_root);
 
+        // Two distinct constants merged — immediate conflict since constant
+        // disequality is implicit (no SAT literal needed).
         if x_root_is_const && y_root_is_const {
             debug_assert!(self.display_term(x_root) != self.display_term(y_root));
             let mut equalities = Vec::new();
@@ -1187,9 +1191,6 @@ impl Egraph {
         } else {
             (x, y, x_root, y_root)
         };
-
-        // keep track of original proof_parent
-        let _proof_parent_original = proof_parent.clone();
 
         // making x the parent of y ~> could also do this based on relative depth of x and y tree
         let proof_parent: ProofForestEdge =
@@ -1323,6 +1324,9 @@ impl Egraph {
             }
         }
 
+        // No explicit sig_table removal phase needed: old entries keyed on y_root
+        // become stale (unreachable by compute_signature after the union) and are
+        // naturally superseded by the fresh insertions below.
         // Reinsert y_root's predecessors into sig_table with new canonical forms
         // and immediately merge any congruent pairs found.
         // Also move predecessors from y_root to x_root.

--- a/src/egraphs/basic/egraph.rs
+++ b/src/egraphs/basic/egraph.rs
@@ -1141,6 +1141,7 @@ impl Egraph {
         let y_root_is_const = self.is_constant(y_root);
 
         if x_root_is_const && y_root_is_const {
+            debug_assert!(self.display_term(x_root) != self.display_term(y_root));
             let mut equalities = Vec::new();
             let mut tracker = ProofTracker::new();
             if x != x_root

--- a/src/egraphs/basic/egraph.rs
+++ b/src/egraphs/basic/egraph.rs
@@ -418,6 +418,16 @@ impl Egraph {
         id
     }
 
+    fn is_constant(&self, id: u32) -> bool {
+        matches!(
+            &self.terms[id as usize],
+            TermSlot::Term(TermEntry {
+                op: Op::Constant(_),
+                ..
+            })
+        )
+    }
+
     fn find(&self, x: u32) -> u32 {
         let p: &ProofForestEdge = &self.proof_forest[x as usize];
         match p {
@@ -1144,6 +1154,54 @@ impl Egraph {
             return EgraphResult::ok();
         }
 
+        let x_root_is_const = self.is_constant(x_root);
+        let y_root_is_const = self.is_constant(y_root);
+
+        if x_root_is_const && y_root_is_const {
+            let mut equalities = Vec::new();
+            let mut tracker = ProofTracker::new();
+            if x != x_root
+                && let Some(path) = self.leastcommonancestor(x, x_root, &mut tracker) {
+                    equalities.extend(path);
+                }
+            // Explain the current merge from the proof_parent edge
+            match &proof_parent {
+                ProofForestEdge::Equality {
+                    term: Some((t1, t2)),
+                    ..
+                } => {
+                    equalities.push((*t1, *t2));
+                }
+                ProofForestEdge::Congruence { pairs, .. } => {
+                    for (a, b) in pairs {
+                        tracker = ProofTracker::new();
+                        if let Some(path) = self.leastcommonancestor(*a, *b, &mut tracker) {
+                            equalities.extend(path);
+                        }
+                    }
+                }
+                _ => {}
+            }
+            tracker = ProofTracker::new();
+            if y != y_root
+                && let Some(path) = self.leastcommonancestor(y, y_root, &mut tracker) {
+                    equalities.extend(path);
+                }
+            return EgraphResult::with_conflict(Conflict {
+                equalities,
+                disequality: (x_root, y_root),
+                diseq_lit: 0,
+            });
+        }
+
+        // Ensure the constant (if any) remains the root: make the constant
+        // side "x" so that x_root stays as root after the union.
+        let (x, y, x_root, y_root) = if y_root_is_const {
+            (y, x, y_root, x_root)
+        } else {
+            (x, y, x_root, y_root)
+        };
+
         // keep track of original proof_parent
         let _proof_parent_original = proof_parent.clone();
 
@@ -1171,9 +1229,44 @@ impl Egraph {
             ));
         }
 
-        // Phase 1: Remove sig_table entries for y_root's predecessors BEFORE updating the UF.
-        // Their signatures currently use y_root as a child representative; after the UF
-        // update they'll need new entries with x_root instead.
+        // Perform the union first so we can check for disequality violations early.
+        debug_println!(
+            16,
+            2,
+            "Making {} the root of its equivalence class [previously was {}]",
+            self.display_term(y),
+            self.display_term(y_root)
+        );
+        self.make_root(y, proof_parent);
+
+        // Early conflict check: x_root's existing disequalities may already be
+        // violated now that y's class has been merged in.
+        if let Some(disequality) = self.check_self_disequality(x_root) {
+            let mut tracker = ProofTracker::new();
+            if let Some(equalities) = self.leastcommonancestor(
+                disequality.original_disequality.0,
+                disequality.original_disequality.1,
+                &mut tracker,
+            ) {
+                return EgraphResult::with_conflict(Conflict {
+                    equalities,
+                    disequality: disequality.original_disequality,
+                    diseq_lit: disequality.diseq_lit,
+                });
+            } else {
+                panic!(
+                    "Should have found a equality between {} [root: {}] and {} [root: {}]",
+                    self.display_term(disequality.original_disequality.0),
+                    self.display_term(self.find(disequality.original_disequality.0)),
+                    self.display_term(disequality.original_disequality.1),
+                    self.display_term(self.find(disequality.original_disequality.1)),
+                );
+            }
+        }
+
+        // Phase 1: Remove sig_table entries for y_root's predecessors.
+        // Their signatures use y_root as a child representative; after the union
+        // they need new entries with x_root instead.
         // Only process valid (non-stale) predecessors.
         let y_root_pred_keys: Vec<u32> = self.predecessors[y_root as usize]
             .iter()
@@ -1185,16 +1278,6 @@ impl Egraph {
                 self.sig_table_remove(&old_sig, *pred_id, level);
             }
         }
-
-        // Phase 2: Perform the union and propagate disequalities from y_root to x_root.
-        debug_println!(
-            16,
-            2,
-            "Making {} the root of its equivalence class [previously was {}]",
-            self.display_term(y),
-            self.display_term(y_root)
-        );
-        self.make_root(y, proof_parent);
 
         // need to add the new disequalities into x_root
         // TODO: could also clean up some backtracking stuff here, probably want to factor this into its own function
@@ -1269,50 +1352,6 @@ impl Egraph {
             }
         }
 
-        // basically checking if the current equality that we just added violated any earlier disequalities and if it did, we learn a conflict clause
-        // TODO: now I am actually not sure if disequality checking is really necessary
-        // kind've a weird way to do it since we have already unioned, we are just checking if two things are unequal to themselves
-        debug_println!(
-            5,
-            0,
-            "A. Checking the equality {} = {} with disequalities {:?}",
-            self.display_term(x),
-            self.display_term(y),
-            self.proof_forest[x as usize].disequalities()
-        );
-        if let Some(disequality) = self.check_self_disequality(x_root).clone() {
-            debug_println!(
-                11,
-                0,
-                "B. Checking the equality {} = {} with disequality {} != {}",
-                self.display_term(x),
-                self.display_term(y),
-                self.display_term(disequality.original_disequality.0),
-                self.display_term(disequality.original_disequality.1)
-            );
-            let mut tracker = ProofTracker::new();
-            if let Some(equalities) = self.leastcommonancestor(
-                disequality.original_disequality.0,
-                disequality.original_disequality.1,
-                &mut tracker,
-            ) {
-                return EgraphResult::with_conflict(Conflict {
-                    equalities,
-                    disequality: disequality.original_disequality,
-                    diseq_lit: disequality.diseq_lit,
-                });
-            } else {
-                debug_println!(16, 0, "{}", self);
-                panic!(
-                    "Should have found a equality between {} [root: {}] and {} [root: {}]",
-                    self.display_term(disequality.original_disequality.0),
-                    self.display_term(self.find(disequality.original_disequality.0)),
-                    self.display_term(disequality.original_disequality.1),
-                    self.display_term(self.find(disequality.original_disequality.1)),
-                );
-            }
-        }
-
         // Phase 3: Reinsert y_root's predecessors into sig_table with new canonical forms
         // and immediately merge any congruent pairs found.
         // Also move predecessors from y_root to x_root.
@@ -1342,6 +1381,12 @@ impl Egraph {
                 }
             }
         }
+
+        debug_assert!(
+            !x_root_is_const || self.find(x_root) == x_root,
+            "constant root invariant violated for {}",
+            self.display_term(x_root)
+        );
 
         EgraphResult::ok()
     }
@@ -1633,6 +1678,16 @@ impl EgraphTrait for Egraph {
         let id = self.next_id;
         self.next_id += 1;
         self.register_term_internal(id, op, children, dynamic);
+        id
+    }
+
+    fn register_constant(&mut self, op: Self::Op) -> Self::TermId {
+        // TODO: currently relies on Op::Constant variant to distinguish constants
+        // from other 0-arity terms. If Op is unified in the future, this method
+        // should mark the term as a constant via a separate mechanism.
+        let id = self.next_id;
+        self.next_id += 1;
+        self.register_term_internal(id, op, &[], false);
         id
     }
 

--- a/src/egraphs/traits.rs
+++ b/src/egraphs/traits.rs
@@ -73,6 +73,13 @@ pub trait EgraphTrait {
         dynamic: bool,
     ) -> Self::TermId;
 
+    /// Register a constant (0-arity term). The constant is guaranteed to be
+    /// the root of its equivalence class. When two constants are merged, it
+    /// is immediately detected as a conflict.
+    fn register_constant(&mut self, op: Self::Op) -> Self::TermId {
+        self.register_term(op, &[], false)
+    }
+
     /// Register an opaque term — participates in union-find but has no
     /// internal structure visible to congruence closure.
     fn register_opaque(&mut self) -> Self::TermId;

--- a/src/egraphs/traits.rs
+++ b/src/egraphs/traits.rs
@@ -23,8 +23,8 @@ pub struct Conflict<T> {
     pub equalities: Vec<(T, T)>,
     /// The disequality that was violated.
     pub disequality: (T, T),
-    /// The SAT literal that asserted the disequality.
-    pub diseq_lit: Lit,
+    /// The SAT literal that asserted the disequality (if one exists).
+    pub diseq_lit: Option<Lit>,
 }
 
 /// Result of a mutating egraph operation (assert_equal, assert_disequal, etc.).

--- a/src/egraphs/traits.rs
+++ b/src/egraphs/traits.rs
@@ -73,12 +73,8 @@ pub trait EgraphTrait {
         dynamic: bool,
     ) -> Self::TermId;
 
-    /// Register a constant (0-arity term). The constant is guaranteed to be
-    /// the root of its equivalence class. When two constants are merged, it
-    /// is immediately detected as a conflict.
-    fn register_constant(&mut self, op: Self::Op) -> Self::TermId {
-        self.register_term(op, &[], false)
-    }
+    /// Register a constant (0-arity term).
+    fn register_constant(&mut self, op: Self::Op) -> Self::TermId;
 
     /// Register an opaque term — participates in union-find but has no
     /// internal structure visible to congruence closure.

--- a/src/proof/proof_tracer.rs
+++ b/src/proof/proof_tracer.rs
@@ -130,7 +130,7 @@ fn format_function_declaration(symbol_name: &Str, sigs: &[(Sig, FunctionMeta)]) 
             if !meta.rec_deps.is_empty() {
                 panic!("We do not handle recursive function definitions!");
             }
-            format!("(define-fun {})\n", meta.def)
+            format!("(define-fun {})", meta.def)
         }
         _ => String::new(),
     }
@@ -212,8 +212,8 @@ impl SMTProofTracer {
         self.get_lit_info(literal).is_some() || self.get_lit_info(-literal).is_some()
     }
 
-    /// Pushes literal definitions.
-    /// Panics if a literal is not in the terms list.
+    /// Pushes literal definitions
+    /// If one of the literals is not in terms list, then this clause is useless and we return false
     fn introduce_literals(
         &self,
         literals_defined: &mut HashSet<i32>,
@@ -245,28 +245,6 @@ impl SMTProofTracer {
                     "We should have introduced the literal {} in the terms list",
                     lit
                 );
-            }
-        }
-        out.push_str(&temp_output);
-    }
-
-    /// Like `introduce_literals`, but skips literals not in the terms list
-    /// (e.g., SAT-internal auxiliary variables that were never registered).
-    fn introduce_literals_lenient(
-        &self,
-        literals_defined: &mut HashSet<i32>,
-        clause: &Vec<i32>,
-        out: &mut String,
-    ) {
-        let mut temp_output = String::new();
-        for &lit in clause {
-            if let Some((lit, _id, term, polarity)) = self.get_lit_info(lit) {
-                let lit = lit.abs();
-                let polarized_term = polarize_term(&term, polarity);
-                if !literals_defined.contains(&lit) {
-                    temp_output.push_str(&format!("(edrat-literal {} {})\n", lit, polarized_term));
-                    literals_defined.insert(lit);
-                }
             }
         }
         out.push_str(&temp_output);
@@ -307,13 +285,6 @@ impl SMTProofTracer {
         typ: ProofStepType,
     ) {
         assert!(parent_literal != 0 && reduced_literal != 0);
-        match typ {
-            ProofStepType::Skolemization { parent_term, .. } => {
-                assert!(parent_term.abs() == parent_literal.abs())
-            }
-            _ => assert!(matches!(typ, ProofStepType::Instantiation)),
-        }
-
         if child.uid() != reduced.uid() {
             assert!(child_literal != 0);
         }
@@ -368,10 +339,8 @@ impl SMTProofTracer {
             match typ {
                 ProofStepType::OriginalClause
                 | ProofStepType::TheoryClause(..)
-                | ProofStepType::Instantiation
-                | ProofStepType::SATClause
-                | ProofStepType::Deletion => {
-                    self.introduce_literals_lenient(&mut literals_defined, clause, &mut output)
+                | ProofStepType::Instantiation => {
+                    self.introduce_literals(&mut literals_defined, clause, &mut output)
                 }
                 ProofStepType::Skolemization {
                     parent_term,
@@ -393,6 +362,7 @@ impl SMTProofTracer {
                     }
                     self.introduce_literals(&mut literals_defined, clause, &mut output);
                 }
+                _ => {}
             }
 
             step.push_line_to(&mut output);

--- a/src/proof/proof_tracer.rs
+++ b/src/proof/proof_tracer.rs
@@ -212,8 +212,8 @@ impl SMTProofTracer {
         self.get_lit_info(literal).is_some() || self.get_lit_info(-literal).is_some()
     }
 
-    /// Pushes literal definitions
-    /// If one of the literals is not in terms list, then this clause is useless and we return false
+    /// Pushes literal definitions.
+    /// Panics if a literal is not in the terms list.
     fn introduce_literals(
         &self,
         literals_defined: &mut HashSet<i32>,
@@ -245,6 +245,28 @@ impl SMTProofTracer {
                     "We should have introduced the literal {} in the terms list",
                     lit
                 );
+            }
+        }
+        out.push_str(&temp_output);
+    }
+
+    /// Like `introduce_literals`, but skips literals not in the terms list
+    /// (e.g., SAT-internal auxiliary variables that were never registered).
+    fn introduce_literals_lenient(
+        &self,
+        literals_defined: &mut HashSet<i32>,
+        clause: &Vec<i32>,
+        out: &mut String,
+    ) {
+        let mut temp_output = String::new();
+        for &lit in clause {
+            if let Some((lit, _id, term, polarity)) = self.get_lit_info(lit) {
+                let lit = lit.abs();
+                let polarized_term = polarize_term(&term, polarity);
+                if !literals_defined.contains(&lit) {
+                    temp_output.push_str(&format!("(edrat-literal {} {})\n", lit, polarized_term));
+                    literals_defined.insert(lit);
+                }
             }
         }
         out.push_str(&temp_output);
@@ -339,8 +361,10 @@ impl SMTProofTracer {
             match typ {
                 ProofStepType::OriginalClause
                 | ProofStepType::TheoryClause(..)
-                | ProofStepType::Instantiation => {
-                    self.introduce_literals(&mut literals_defined, clause, &mut output)
+                | ProofStepType::Instantiation
+                | ProofStepType::SATClause
+                | ProofStepType::Deletion => {
+                    self.introduce_literals_lenient(&mut literals_defined, clause, &mut output)
                 }
                 ProofStepType::Skolemization {
                     parent_term,
@@ -362,7 +386,6 @@ impl SMTProofTracer {
                     }
                     self.introduce_literals(&mut literals_defined, clause, &mut output);
                 }
-                _ => {}
             }
 
             step.push_line_to(&mut output);

--- a/src/proof/proof_tracer.rs
+++ b/src/proof/proof_tracer.rs
@@ -130,7 +130,7 @@ fn format_function_declaration(symbol_name: &Str, sigs: &[(Sig, FunctionMeta)]) 
             if !meta.rec_deps.is_empty() {
                 panic!("We do not handle recursive function definitions!");
             }
-            format!("(define-fun {})", meta.def)
+            format!("(define-fun {})\n", meta.def)
         }
         _ => String::new(),
     }

--- a/src/proof/proof_tracer.rs
+++ b/src/proof/proof_tracer.rs
@@ -307,6 +307,13 @@ impl SMTProofTracer {
         typ: ProofStepType,
     ) {
         assert!(parent_literal != 0 && reduced_literal != 0);
+        match typ {
+            ProofStepType::Skolemization { parent_term, .. } => {
+                assert!(parent_term.abs() == parent_literal.abs())
+            }
+            _ => assert!(matches!(typ, ProofStepType::Instantiation)),
+        }
+
         if child.uid() != reduced.uid() {
             assert!(child_literal != 0);
         }

--- a/src/solver_state.rs
+++ b/src/solver_state.rs
@@ -607,8 +607,8 @@ pub fn process_assignment(
                 .iter()
                 .map(|(a, b)| -solver_state.make_eq(*a, *b))
                 .collect();
-            if conflict.diseq_lit != 0 {
-                model_terms.push(-conflict.diseq_lit);
+            if let Some(lit) = conflict.diseq_lit {
+                model_terms.push(-lit);
             }
             return Some(vec![model_terms]);
         }
@@ -633,8 +633,8 @@ pub fn process_assignment(
                 .iter()
                 .map(|(a, b)| -solver_state.make_eq(*a, *b))
                 .collect();
-            if conflict.diseq_lit != 0 {
-                model_terms.push(-conflict.diseq_lit);
+            if let Some(lit) = conflict.diseq_lit {
+                model_terms.push(-lit);
             }
             return Some(vec![model_terms]);
         };
@@ -747,8 +747,8 @@ pub fn process_assignment(
                     .iter()
                     .map(|(a, b)| -solver_state.make_eq(*a, *b))
                     .collect();
-                if conflict.diseq_lit != 0 {
-                    model_terms.push(-conflict.diseq_lit);
+                if let Some(lit) = conflict.diseq_lit {
+                    model_terms.push(-lit);
                 }
                 Some(vec![model_terms])
             } else {
@@ -803,7 +803,7 @@ pub fn process_assignment(
                     .into_iter()
                     .map(|(a, b)| -solver_state.make_eq(a, b))
                     .collect();
-                model_terms.push(-conflict.diseq_lit);
+                model_terms.push(-lit);
                 debug_println!(16, 0, "Contradiction found in distinct: {:?}", model_terms);
                 return Some(vec![model_terms]);
             }

--- a/src/solver_state.rs
+++ b/src/solver_state.rs
@@ -27,7 +27,6 @@ use crate::solver_types::{
     Assertion, ConstructorType, ConstructorType::*, Polarity, Quantifier, TermOption,
 };
 
-use crate::log::is_important;
 use crate::utils::DeterministicHashMap;
 
 fn get_subterms(term: &Term) -> (String, Vec<&Term>) {
@@ -308,12 +307,12 @@ impl SolverState {
     pub fn register_bool_constants(&mut self, true_term: &Term, false_term: &Term) {
         use crate::egraphs::repr::Op;
         use crate::egraphs::traits::EgraphTrait;
-        let true_egraph_id =
-            self.egraph
-                .register_term(Op::Constant("true".to_string()), &[], false);
-        let false_egraph_id =
-            self.egraph
-                .register_term(Op::Constant("false".to_string()), &[], false);
+        let true_egraph_id = self
+            .egraph
+            .register_constant(Op::Constant("true".to_string()));
+        let false_egraph_id = self
+            .egraph
+            .register_constant(Op::Constant("false".to_string()));
 
         let true_uid = true_term.uid();
         let false_uid = false_term.uid();
@@ -351,7 +350,7 @@ impl SolverState {
                     Op::App(key)
                 }
             }
-            Global(qid, _) => Op::Constant(qid.id_str().get().to_string()),
+            Global(qid, _) => Op::App(qid.id_str().get().to_string()),
             Constant(c, _) => Op::Constant(format!("{:?}", c)),
             Local(local) => Op::Local(local.symbol.to_string()),
             _ => panic!("extract_op: unsupported term type {:?}", term.repr()),
@@ -368,6 +367,7 @@ impl SolverState {
         guard: Option<u64>,
         from_quantifier: bool,
     ) -> u32 {
+        use crate::egraphs::repr::Op;
         let num = term.uid();
 
         // Early return if already registered
@@ -405,9 +405,12 @@ impl SolverState {
 
         // Register this term in the egraph
         let op = Self::extract_op(term);
-        let egraph_id = self
-            .egraph
-            .register_term(op, &egraph_children, from_quantifier);
+        let egraph_id = if matches!(op, Op::Constant(_)) {
+            self.egraph.register_constant(op)
+        } else {
+            self.egraph
+                .register_term(op, &egraph_children, from_quantifier)
+        };
         self.id_map.insert(num, egraph_id);
         self.register_arithmetic_and_quantifier(term, guard);
         egraph_id
@@ -444,7 +447,11 @@ impl SolverState {
                     let egraph_id = if let Some(&eid) = self.id_map.get_by_left(&uid) {
                         eid
                     } else {
-                        let eid = self.egraph.register_term(op.clone(), &[], false);
+                        let eid = if matches!(op, Op::Constant(_)) {
+                            self.egraph.register_constant(op.clone())
+                        } else {
+                            self.egraph.register_term(op.clone(), &[], false)
+                        };
                         self.id_map.insert(uid, eid);
                         while self.terms_list.len() <= uid as usize {
                             self.terms_list
@@ -600,7 +607,9 @@ pub fn process_assignment(
                 .iter()
                 .map(|(a, b)| -solver_state.make_eq(*a, *b))
                 .collect();
-            model_terms.push(-conflict.diseq_lit);
+            if conflict.diseq_lit != 0 {
+                model_terms.push(-conflict.diseq_lit);
+            }
             return Some(vec![model_terms]);
         }
     }
@@ -624,7 +633,9 @@ pub fn process_assignment(
                 .iter()
                 .map(|(a, b)| -solver_state.make_eq(*a, *b))
                 .collect();
-            model_terms.push(-conflict.diseq_lit);
+            if conflict.diseq_lit != 0 {
+                model_terms.push(-conflict.diseq_lit);
+            }
             return Some(vec![model_terms]);
         };
     }
@@ -736,7 +747,9 @@ pub fn process_assignment(
                     .iter()
                     .map(|(a, b)| -solver_state.make_eq(*a, *b))
                     .collect();
-                model_terms.push(-conflict.diseq_lit);
+                if conflict.diseq_lit != 0 {
+                    model_terms.push(-conflict.diseq_lit);
+                }
                 Some(vec![model_terms])
             } else {
                 None
@@ -799,49 +812,11 @@ pub fn process_assignment(
         Assertion::Other => None,
     };
 
-    debug_println!(
-        4,
-        0,
-        "We are in process_assignment, checking for contradiction with true and false",
+    debug_assert!(
+        solver_state.egraph.find(true_egraph_id) != solver_state.egraph.find(false_egraph_id),
+        "true and false merged without conflict being detected"
     );
-    if let Some(negated_model) = solver_state
-        .egraph
-        .explain_equality(true_egraph_id, false_egraph_id)
-    {
-        let negated_model_terms: Vec<i32> = negated_model
-            .into_iter()
-            .map(|x| -solver_state.make_eq(x.0, x.1))
-            .collect();
-        debug_println!(
-            24,
-            1,
-            "Contradiction found [2] (setting true = false): {:?} [{:?}]",
-            negated_model_terms
-                .iter()
-                .map(|x| solver_state.get_term_from_lit(*x))
-                .collect::<Vec<_>>(),
-            negated_model_terms
-        );
-        if is_important(7) {
-            for lit in negated_model_terms.clone() {
-                debug_println!(7, 4, "{}", solver_state.get_term_from_lit(lit));
-            }
-        }
 
-        return if let Some(mut constraints) = additional_constraints {
-            constraints.push(negated_model_terms);
-            Some(constraints)
-        } else {
-            Some(vec![negated_model_terms])
-        };
-    }
-
-    debug_println!(
-        24,
-        0,
-        "We have the additional constraints {:?}",
-        additional_constraints
-    );
     additional_constraints
 }
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* This modifies the egraph, so that constants such as `true`, `false`, `1`, `2`, ... are always the root of their eclass and will immediately detect a conflict if they are set equal to each other


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
