### PR TITLE
Replace term vec clones with iteration

### DIFF
--- a/src/arithmetic/lialp.rs
+++ b/src/arithmetic/lialp.rs
@@ -43,7 +43,8 @@ pub fn check_integer_constraints_satisfiable_lia(
     // it. This is used later for translating an "infeasible" outcome into an unsat core.
     let mut slack_to_lits: HashMap<Var, Vec<i32>> = HashMap::new();
 
-    for term_id in solver_state.arithmetic_terms.clone() {
+    for idx in 0..solver_state.arithmetic_terms.len() {
+        let term_id = solver_state.arithmetic_terms[idx];
         let egraph_id = solver_state.to_egraph_id(term_id);
         if solver_state.egraph.find(egraph_id) == egraph_id {
             let (expr, additional_constraints) = extract_linear_expression(term_id, solver_state);

--- a/src/arithmetic/z3lp.rs
+++ b/src/arithmetic/z3lp.rs
@@ -72,7 +72,8 @@ pub fn check_integer_constraints_satisfiable_z3(
     // also save the roots
     // todo: might be able to move this later
     let mut roots = vec![];
-    for term_id in solver_state.arithmetic_terms.clone() {
+    for idx in 0..solver_state.arithmetic_terms.len() {
+        let term_id = solver_state.arithmetic_terms[idx];
         let egraph_id = solver_state.to_egraph_id(term_id);
         if solver_state.egraph.find(egraph_id) == egraph_id {
             let left_expr = Int::new_const(format!("var_{}", egraph_id));


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* I was looking back at this code and realized we were doing an unnecessary clone. Minor improvement but somewhat noticeable. The plot is for `--arithmetic internal`; I didn't benchmark the z3 path.

 <img width="880" height="874" alt="Screenshot 2026-06-26 at 9 21 57 AM" src="https://github.com/user-attachments/assets/66c0f82f-befa-407d-83a0-b46102efb8f4" />
---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
