### PR TITLE
Lazy quantifier instantiation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ local-z3 = ["z3-solver"]
 [dependencies]
 yaspar-ir = "=2.7.2"
 sat-interface = "0.1.1"
-cadical-sys = { path = "cadical-sys-local" }
+cadical-sys = { git = "https://github.com/amarshah1/cadical-sys.git", branch = "elevate" }
 
 array2d = "^0.3"
 clap = { version = "4.5.40", features = ["derive"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ local-z3 = ["z3-solver"]
 [dependencies]
 yaspar-ir = "=2.7.2"
 sat-interface = "0.1.1"
-cadical-sys = { version = "0.7.0" }
+cadical-sys = { path = "cadical-sys-local" }
 
 array2d = "^0.3"
 clap = { version = "4.5.40", features = ["derive"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,8 @@ local-z3 = ["z3-solver"]
 [dependencies]
 yaspar-ir = "=2.7.2"
 sat-interface = "0.1.1"
-cadical-sys = { git = "https://github.com/amarshah1/cadical-sys.git", branch = "elevate" }
+# Pin the elevate fork until upstream cadical-sys exposes CaDiCaL's elevate option.
+cadical-sys = { git = "https://github.com/amarshah1/cadical-sys.git", rev = "2f234ec95dd36ca74057691cf2fd4e8766a3c40f" }
 
 array2d = "^0.3"
 clap = { version = "4.5.40", features = ["derive"] }

--- a/src/cadical_propagator.rs
+++ b/src/cadical_propagator.rs
@@ -280,39 +280,39 @@ impl<'a> ExternalPropagator for CustomExternalPropagator<'a> {
         if let Some(mut pending) = self.pending.take()
             && let Some(instances) =
                 materialize_next(&mut pending, self.solver_state, &self.proof_tracer)
-            {
-                for inst in &instances {
-                    match inst {
-                        Instantiation { clauses } => {
-                            for clause in clauses {
-                                for lit in clause {
-                                    self.add_observed_variable(*lit);
-                                    self.add_lit_to_proof_tracer(*lit);
-                                }
-                                self.disequalities.borrow_mut().push(clause.clone());
+        {
+            for inst in &instances {
+                match inst {
+                    Instantiation { clauses } => {
+                        for clause in clauses {
+                            for lit in clause {
+                                self.add_observed_variable(*lit);
+                                self.add_lit_to_proof_tracer(*lit);
                             }
-                            self.stats.instantiations += 1;
+                            self.disequalities.borrow_mut().push(clause.clone());
                         }
-                        Skolemization { clauses } => {
-                            for clause in clauses {
-                                for lit in clause {
-                                    self.add_observed_variable(*lit);
-                                    self.add_lit_to_proof_tracer(*lit);
-                                }
-                                self.disequalities.borrow_mut().push(clause.clone());
+                        self.stats.instantiations += 1;
+                    }
+                    Skolemization { clauses } => {
+                        for clause in clauses {
+                            for lit in clause {
+                                self.add_observed_variable(*lit);
+                                self.add_lit_to_proof_tracer(*lit);
                             }
+                            self.disequalities.borrow_mut().push(clause.clone());
                         }
                     }
                 }
-                if pending.is_empty() {
-                    for i in &pending.skolemized_quantifier_idxs {
-                        self.solver_state.quantifiers[*i].skolemized = true;
-                    }
-                } else {
-                    self.pending = Some(pending);
-                }
-                return false;
             }
+            if pending.is_empty() {
+                for i in &pending.skolemized_quantifier_idxs {
+                    self.solver_state.quantifiers[*i].skolemized = true;
+                }
+            } else {
+                self.pending = Some(pending);
+            }
+            return false;
+        }
 
         for term in model {
             let (u64_val, polarity) = self.solver_state.get_u64_from_lit_with_polarity(*term);

--- a/src/cadical_propagator.rs
+++ b/src/cadical_propagator.rs
@@ -221,7 +221,6 @@ impl<'a> ExternalPropagator for CustomExternalPropagator<'a> {
 
     fn notify_backtrack(&mut self, level: usize) {
         self.stats.backtracks += 1;
-        eprintln!("BACKTRACK: {} -> {}", self.decision_level, level);
         debug_println!(
             23,
             0,

--- a/src/cadical_propagator.rs
+++ b/src/cadical_propagator.rs
@@ -377,25 +377,29 @@ impl<'a> ExternalPropagator for CustomExternalPropagator<'a> {
 
         // If we have pending instantiations from a previous round, materialize the next one
         if let Some(mut pending) = self.pending.take() {
-            if let Some(clauses) =
+            if let Some(instances) =
                 materialize_next(&mut pending, self.solver_state, &self.proof_tracer)
             {
-                for inst in &clauses {
+                for inst in &instances {
                     match inst {
-                        Instantiation { clause } => {
-                            for lit in clause {
-                                self.add_observed_variable(*lit);
-                                self.add_lit_to_proof_tracer(*lit);
+                        Instantiation { clauses } => {
+                            for clause in clauses {
+                                for lit in clause {
+                                    self.add_observed_variable(*lit);
+                                    self.add_lit_to_proof_tracer(*lit);
+                                }
+                                self.disequalities.borrow_mut().push(clause.clone());
                             }
-                            self.disequalities.borrow_mut().push(clause.clone());
                             self.stats.instantiations += 1;
                         }
-                        Skolemization { clause } => {
-                            for lit in clause {
-                                self.add_observed_variable(*lit);
-                                self.add_lit_to_proof_tracer(*lit);
+                        Skolemization { clauses } => {
+                            for clause in clauses {
+                                for lit in clause {
+                                    self.add_observed_variable(*lit);
+                                    self.add_lit_to_proof_tracer(*lit);
+                                }
+                                self.disequalities.borrow_mut().push(clause.clone());
                             }
-                            self.disequalities.borrow_mut().push(clause.clone());
                         }
                     }
                 }
@@ -420,23 +424,27 @@ impl<'a> ExternalPropagator for CustomExternalPropagator<'a> {
         }
 
         // Materialize the first one now
-        if let Some(clauses) = materialize_next(&mut pending, self.solver_state, &self.proof_tracer) {
-            for inst in &clauses {
+        if let Some(instances) = materialize_next(&mut pending, self.solver_state, &self.proof_tracer) {
+            for inst in &instances {
                 match inst {
-                    Instantiation { clause } => {
-                        for lit in clause {
-                            self.add_observed_variable(*lit);
-                            self.add_lit_to_proof_tracer(*lit);
+                    Instantiation { clauses } => {
+                        for clause in clauses {
+                            for lit in clause {
+                                self.add_observed_variable(*lit);
+                                self.add_lit_to_proof_tracer(*lit);
+                            }
+                            self.disequalities.borrow_mut().push(clause.clone());
                         }
-                        self.disequalities.borrow_mut().push(clause.clone());
                         self.stats.instantiations += 1;
                     }
-                    Skolemization { clause } => {
-                        for lit in clause {
-                            self.add_observed_variable(*lit);
-                            self.add_lit_to_proof_tracer(*lit);
+                    Skolemization { clauses } => {
+                        for clause in clauses {
+                            for lit in clause {
+                                self.add_observed_variable(*lit);
+                                self.add_lit_to_proof_tracer(*lit);
+                            }
+                            self.disequalities.borrow_mut().push(clause.clone());
                         }
-                        self.disequalities.borrow_mut().push(clause.clone());
                     }
                 }
             }

--- a/src/cadical_propagator.rs
+++ b/src/cadical_propagator.rs
@@ -82,7 +82,6 @@ impl<'a> CustomExternalPropagator<'a> {
 
 impl<'a> ExternalPropagator for CustomExternalPropagator<'a> {
     fn notify_assignment(&mut self, lits: &[i32]) {
-        eprintln!("NOTIFY_ASSIGNMENT: level={} lits={:?}", self.decision_level, lits);
         debug_println!(
             22,
             0,
@@ -221,7 +220,6 @@ impl<'a> ExternalPropagator for CustomExternalPropagator<'a> {
 
     fn notify_backtrack(&mut self, level: usize) {
         self.stats.backtracks += 1;
-        eprintln!("BACKTRACK: {} -> {}", self.decision_level, level);
         debug_println!(
             23,
             0,

--- a/src/cadical_propagator.rs
+++ b/src/cadical_propagator.rs
@@ -80,6 +80,35 @@ impl<'a> CustomExternalPropagator<'a> {
             (*self.solver).add_observed_var(abs_lit);
         }
     }
+
+    fn apply_instances(
+        &mut self,
+        instances: &[crate::quantifiers::quantifier::QuantifierInstance],
+    ) {
+        for inst in instances {
+            match inst {
+                Instantiation { clauses } => {
+                    for clause in clauses {
+                        for lit in clause {
+                            self.add_observed_variable(*lit);
+                            self.add_lit_to_proof_tracer(*lit);
+                        }
+                        self.disequalities.borrow_mut().push(clause.clone());
+                    }
+                    self.stats.instantiations += 1;
+                }
+                Skolemization { clauses } => {
+                    for clause in clauses {
+                        for lit in clause {
+                            self.add_observed_variable(*lit);
+                            self.add_lit_to_proof_tracer(*lit);
+                        }
+                        self.disequalities.borrow_mut().push(clause.clone());
+                    }
+                }
+            }
+        }
+    }
 }
 
 impl<'a> ExternalPropagator for CustomExternalPropagator<'a> {
@@ -280,29 +309,7 @@ impl<'a> ExternalPropagator for CustomExternalPropagator<'a> {
             && let Some(instances) =
                 materialize_next(&mut pending, self.solver_state, &self.proof_tracer)
         {
-            for inst in &instances {
-                match inst {
-                    Instantiation { clauses } => {
-                        for clause in clauses {
-                            for lit in clause {
-                                self.add_observed_variable(*lit);
-                                self.add_lit_to_proof_tracer(*lit);
-                            }
-                            self.disequalities.borrow_mut().push(clause.clone());
-                        }
-                        self.stats.instantiations += 1;
-                    }
-                    Skolemization { clauses } => {
-                        for clause in clauses {
-                            for lit in clause {
-                                self.add_observed_variable(*lit);
-                                self.add_lit_to_proof_tracer(*lit);
-                            }
-                            self.disequalities.borrow_mut().push(clause.clone());
-                        }
-                    }
-                }
-            }
+            self.apply_instances(&instances);
             if pending.is_empty() {
                 for i in &pending.skolemized_quantifier_idxs {
                     self.solver_state.quantifiers[*i].skolemized = true;
@@ -421,29 +428,7 @@ impl<'a> ExternalPropagator for CustomExternalPropagator<'a> {
         if let Some(instances) =
             materialize_next(&mut pending, self.solver_state, &self.proof_tracer)
         {
-            for inst in &instances {
-                match inst {
-                    Instantiation { clauses } => {
-                        for clause in clauses {
-                            for lit in clause {
-                                self.add_observed_variable(*lit);
-                                self.add_lit_to_proof_tracer(*lit);
-                            }
-                            self.disequalities.borrow_mut().push(clause.clone());
-                        }
-                        self.stats.instantiations += 1;
-                    }
-                    Skolemization { clauses } => {
-                        for clause in clauses {
-                            for lit in clause {
-                                self.add_observed_variable(*lit);
-                                self.add_lit_to_proof_tracer(*lit);
-                            }
-                            self.disequalities.borrow_mut().push(clause.clone());
-                        }
-                    }
-                }
-            }
+            self.apply_instances(&instances);
         }
 
         // If there's more to materialize later, store the pending state

--- a/src/cadical_propagator.rs
+++ b/src/cadical_propagator.rs
@@ -82,6 +82,7 @@ impl<'a> CustomExternalPropagator<'a> {
 
 impl<'a> ExternalPropagator for CustomExternalPropagator<'a> {
     fn notify_assignment(&mut self, lits: &[i32]) {
+        eprintln!("NOTIFY_ASSIGNMENT: level={} lits={:?}", self.decision_level, lits);
         debug_println!(
             22,
             0,
@@ -220,6 +221,7 @@ impl<'a> ExternalPropagator for CustomExternalPropagator<'a> {
 
     fn notify_backtrack(&mut self, level: usize) {
         self.stats.backtracks += 1;
+        eprintln!("BACKTRACK: {} -> {}", self.decision_level, level);
         debug_println!(
             23,
             0,

--- a/src/cadical_propagator.rs
+++ b/src/cadical_propagator.rs
@@ -9,7 +9,9 @@ use crate::egraphs::EgraphTrait;
 use crate::log::is_important;
 use crate::proof::{SMTProofTracer, Theory};
 use crate::quantifiers::quantifier::QuantifierInstance::{Instantiation, Skolemization};
-use crate::quantifiers::quantifier::{instantiate_quantifiers, materialize_next, PendingInstantiations};
+use crate::quantifiers::quantifier::{
+    PendingInstantiations, instantiate_quantifiers, materialize_next,
+};
 use crate::solver_state::{SolverState, process_assignment};
 use crate::stats::SolverStats;
 use crate::utils::DeterministicHashSet;
@@ -220,6 +222,7 @@ impl<'a> ExternalPropagator for CustomExternalPropagator<'a> {
 
     fn notify_backtrack(&mut self, level: usize) {
         self.stats.backtracks += 1;
+        eprintln!("BACKTRACK: {} -> {}", self.decision_level, level);
         debug_println!(
             23,
             0,
@@ -264,10 +267,6 @@ impl<'a> ExternalPropagator for CustomExternalPropagator<'a> {
                 .collect::<Vec<_>>(),
         );
 
-        // for lit in model{
-        //      debug_println!(11, 4, "{}", self.solver_state.get_term_from_lit(*lit))
-        // }
-
         if !self.disequalities.borrow_mut().is_empty() {
             debug_println!(
                 24,
@@ -275,6 +274,46 @@ impl<'a> ExternalPropagator for CustomExternalPropagator<'a> {
                 "Trying to check model when the disequalities are not empty"
             );
             return false;
+        }
+
+        // If we have pending instantiations from a previous round, serve one immediately
+        // without redoing arithmetic or datatype checks.
+        if let Some(mut pending) = self.pending.take() {
+            if let Some(instances) =
+                materialize_next(&mut pending, self.solver_state, &self.proof_tracer)
+            {
+                for inst in &instances {
+                    match inst {
+                        Instantiation { clauses } => {
+                            for clause in clauses {
+                                for lit in clause {
+                                    self.add_observed_variable(*lit);
+                                    self.add_lit_to_proof_tracer(*lit);
+                                }
+                                self.disequalities.borrow_mut().push(clause.clone());
+                            }
+                            self.stats.instantiations += 1;
+                        }
+                        Skolemization { clauses } => {
+                            for clause in clauses {
+                                for lit in clause {
+                                    self.add_observed_variable(*lit);
+                                    self.add_lit_to_proof_tracer(*lit);
+                                }
+                                self.disequalities.borrow_mut().push(clause.clone());
+                            }
+                        }
+                    }
+                }
+                if pending.is_empty() {
+                    for i in &pending.skolemized_quantifier_idxs {
+                        self.solver_state.quantifiers[*i].skolemized = true;
+                    }
+                } else {
+                    self.pending = Some(pending);
+                }
+                return false;
+            }
         }
 
         for term in model {
@@ -291,7 +330,7 @@ impl<'a> ExternalPropagator for CustomExternalPropagator<'a> {
         }
         debug_println!(24, 0, "{}", self.solver_state.egraph);
 
-        // Check arithmetic consistency before instantiating quantifiers
+        // Check arithmetic consistency
         debug_println!(21, 0, "Starting arithmetic check",);
         self.stats.arith_checks += 1;
 
@@ -305,7 +344,6 @@ impl<'a> ExternalPropagator for CustomExternalPropagator<'a> {
                         "PROPAGATOR: Arithmetic inconsistency detected: {:?}",
                         arithmetic_literals
                     );
-                    // let negated_arithmetic_literals = arithmetic_literals.iter().map(|x| -x).collect();
                     self.disequalities.borrow_mut().push(arithmetic_literals);
                     return false;
                 }
@@ -328,11 +366,9 @@ impl<'a> ExternalPropagator for CustomExternalPropagator<'a> {
                         {
                             debug_println!(25, 0, "adding in the nelson oppen term {}", term);
                             let term_nnf = term.nnf(self.solver_state);
-                            // println!("we have the term {:?}", term);
                             self.solver_state
                                 .insert_predecessor(&term_nnf, None, None, true);
                             let term_cnf = term.cnf_tseitin(self.solver_state);
-                            // assert!(term_cnf.0.len() == 1, "We have term_cnf {:?}", term_cnf);
                             for clause in term_cnf {
                                 for lit in &clause.0 {
                                     self.add_observed_variable(*lit);
@@ -375,45 +411,6 @@ impl<'a> ExternalPropagator for CustomExternalPropagator<'a> {
             }
         }
 
-        // If we have pending instantiations from a previous round, materialize the next one
-        if let Some(mut pending) = self.pending.take() {
-            if let Some(instances) =
-                materialize_next(&mut pending, self.solver_state, &self.proof_tracer)
-            {
-                for inst in &instances {
-                    match inst {
-                        Instantiation { clauses } => {
-                            for clause in clauses {
-                                for lit in clause {
-                                    self.add_observed_variable(*lit);
-                                    self.add_lit_to_proof_tracer(*lit);
-                                }
-                                self.disequalities.borrow_mut().push(clause.clone());
-                            }
-                            self.stats.instantiations += 1;
-                        }
-                        Skolemization { clauses } => {
-                            for clause in clauses {
-                                for lit in clause {
-                                    self.add_observed_variable(*lit);
-                                    self.add_lit_to_proof_tracer(*lit);
-                                }
-                                self.disequalities.borrow_mut().push(clause.clone());
-                            }
-                        }
-                    }
-                }
-                if pending.is_empty() {
-                    for i in &pending.skolemized_quantifier_idxs {
-                        self.solver_state.quantifiers[*i].skolemized = true;
-                    }
-                } else {
-                    self.pending = Some(pending);
-                }
-                return false;
-            }
-        }
-
         debug_println!(11, 0, "Starting quantifier instantiations");
         let mut pending = instantiate_quantifiers(self.solver_state, &self.assignments);
 
@@ -424,7 +421,9 @@ impl<'a> ExternalPropagator for CustomExternalPropagator<'a> {
         }
 
         // Materialize the first one now
-        if let Some(instances) = materialize_next(&mut pending, self.solver_state, &self.proof_tracer) {
+        if let Some(instances) =
+            materialize_next(&mut pending, self.solver_state, &self.proof_tracer)
+        {
             for inst in &instances {
                 match inst {
                     Instantiation { clauses } => {

--- a/src/cadical_propagator.rs
+++ b/src/cadical_propagator.rs
@@ -303,15 +303,15 @@ impl<'a> ExternalPropagator for CustomExternalPropagator<'a> {
             return false;
         }
 
-        // If we have pending instantiations from a previous round, serve one immediately
-        // without redoing arithmetic or datatype checks.
+        // If we have pending instantiations from a previous round, materialize one
+        // immediately without redoing arithmetic or datatype checks.
         if let Some(mut pending) = self.pending.take()
             && let Some(instances) =
                 materialize_next(&mut pending, self.solver_state, &self.proof_tracer)
         {
             self.apply_instances(&instances);
             if pending.is_empty() {
-                for i in &pending.skolemized_quantifier_idxs {
+                for i in pending.skolemized_quantifier_idxs() {
                     self.solver_state.quantifiers[*i].skolemized = true;
                 }
             } else {
@@ -433,7 +433,7 @@ impl<'a> ExternalPropagator for CustomExternalPropagator<'a> {
 
         // If there's more to materialize later, store the pending state
         if pending.is_empty() {
-            for i in &pending.skolemized_quantifier_idxs {
+            for i in pending.skolemized_quantifier_idxs() {
                 self.solver_state.quantifiers[*i].skolemized = true;
             }
         } else {

--- a/src/cadical_propagator.rs
+++ b/src/cadical_propagator.rs
@@ -277,8 +277,8 @@ impl<'a> ExternalPropagator for CustomExternalPropagator<'a> {
 
         // If we have pending instantiations from a previous round, serve one immediately
         // without redoing arithmetic or datatype checks.
-        if let Some(mut pending) = self.pending.take() {
-            if let Some(instances) =
+        if let Some(mut pending) = self.pending.take()
+            && let Some(instances) =
                 materialize_next(&mut pending, self.solver_state, &self.proof_tracer)
             {
                 for inst in &instances {
@@ -313,7 +313,6 @@ impl<'a> ExternalPropagator for CustomExternalPropagator<'a> {
                 }
                 return false;
             }
-        }
 
         for term in model {
             let (u64_val, polarity) = self.solver_state.get_u64_from_lit_with_polarity(*term);

--- a/src/cadical_propagator.rs
+++ b/src/cadical_propagator.rs
@@ -9,7 +9,7 @@ use crate::egraphs::EgraphTrait;
 use crate::log::is_important;
 use crate::proof::{SMTProofTracer, Theory};
 use crate::quantifiers::quantifier::QuantifierInstance::{Instantiation, Skolemization};
-use crate::quantifiers::quantifier::instantiate_quantifiers;
+use crate::quantifiers::quantifier::{instantiate_quantifiers, materialize_next, PendingInstantiations};
 use crate::solver_state::{SolverState, process_assignment};
 use crate::stats::SolverStats;
 use crate::utils::DeterministicHashSet;
@@ -28,6 +28,7 @@ pub struct CustomExternalPropagator<'a> {
     pub solver: *mut CaDiCal,
     pub arithmetic: ArithSolver, // whether we are doing arithmetic solving or not
     pub stats: SolverStats,
+    pub pending: Option<PendingInstantiations>,
 }
 
 impl<'a> CustomExternalPropagator<'a> {
@@ -374,47 +375,80 @@ impl<'a> ExternalPropagator for CustomExternalPropagator<'a> {
             }
         }
 
-        debug_println!(11, 0, "Starting quantifier instantiations");
-        let quantifier_instantiations =
-            instantiate_quantifiers(self.solver_state, &self.proof_tracer, &self.assignments);
-        debug_println!(
-            11,
-            0,
-            "Found quantifier instantiations {:?}",
-            quantifier_instantiations
-        );
+        // If we have pending instantiations from a previous round, materialize the next one
+        if let Some(mut pending) = self.pending.take() {
+            if let Some(clauses) =
+                materialize_next(&mut pending, self.solver_state, &self.proof_tracer)
+            {
+                for inst in &clauses {
+                    match inst {
+                        Instantiation { clause } => {
+                            for lit in clause {
+                                self.add_observed_variable(*lit);
+                                self.add_lit_to_proof_tracer(*lit);
+                            }
+                            self.disequalities.borrow_mut().push(clause.clone());
+                            self.stats.instantiations += 1;
+                        }
+                        Skolemization { clause } => {
+                            for lit in clause {
+                                self.add_observed_variable(*lit);
+                                self.add_lit_to_proof_tracer(*lit);
+                            }
+                            self.disequalities.borrow_mut().push(clause.clone());
+                        }
+                    }
+                }
+                if pending.is_empty() {
+                    for i in &pending.skolemized_quantifier_idxs {
+                        self.solver_state.quantifiers[*i].skolemized = true;
+                    }
+                } else {
+                    self.pending = Some(pending);
+                }
+                return false;
+            }
+        }
 
-        if quantifier_instantiations.is_empty() {
+        debug_println!(11, 0, "Starting quantifier instantiations");
+        let mut pending = instantiate_quantifiers(self.solver_state, &self.assignments);
+
+        if pending.is_empty() {
             debug_println!(10, 0, "{}", self.solver_state.egraph);
             assert!(self.disequalities.borrow().is_empty());
-
             return true;
         }
 
-        // Add each quantifier instantiation as an instantiation clause to the proof tracker
-        // adds clauses of the formal (or (not (forall ....)) (INSTANTIATED PART)) same as (forall ...) => INSTANTIATED PART
-        for instantiation in &quantifier_instantiations {
-            match instantiation {
-                Instantiation { clause, .. } => {
-                    // , skolemized
-                    for lit in clause {
-                        self.add_observed_variable(*lit);
-                        self.add_lit_to_proof_tracer(*lit);
+        // Materialize the first one now
+        if let Some(clauses) = materialize_next(&mut pending, self.solver_state, &self.proof_tracer) {
+            for inst in &clauses {
+                match inst {
+                    Instantiation { clause } => {
+                        for lit in clause {
+                            self.add_observed_variable(*lit);
+                            self.add_lit_to_proof_tracer(*lit);
+                        }
+                        self.disequalities.borrow_mut().push(clause.clone());
+                        self.stats.instantiations += 1;
                     }
-
-                    // TODO: since I am adding literals, I might have to add them as observed literals
-                    self.disequalities.borrow_mut().push(clause.clone());
-                    self.stats.instantiations += 1;
-                }
-                Skolemization { clause } => {
-                    for lit in clause {
-                        self.add_observed_variable(*lit);
-                        self.add_lit_to_proof_tracer(*lit);
+                    Skolemization { clause } => {
+                        for lit in clause {
+                            self.add_observed_variable(*lit);
+                            self.add_lit_to_proof_tracer(*lit);
+                        }
+                        self.disequalities.borrow_mut().push(clause.clone());
                     }
-
-                    self.disequalities.borrow_mut().push(clause.clone());
                 }
             }
+        }
+
+        // If there's more to materialize later, store the pending state
+        if pending.is_empty() {
+            for i in &pending.skolemized_quantifier_idxs {
+                self.solver_state.quantifiers[*i].skolemized = true;
+            }
+        } else {
+            self.pending = Some(pending);
         }
 
         debug_println!(4, 0, "Returning false in cb_check_found_model");

--- a/src/cadical_propagator.rs
+++ b/src/cadical_propagator.rs
@@ -375,12 +375,8 @@ impl<'a> ExternalPropagator for CustomExternalPropagator<'a> {
         }
 
         debug_println!(11, 0, "Starting quantifier instantiations");
-        let quantifier_instantiations = instantiate_quantifiers(
-            self.solver_state,
-            &self.proof_tracer,
-            &self.assignments,
-            self.decision_level,
-        );
+        let quantifier_instantiations =
+            instantiate_quantifiers(self.solver_state, &self.proof_tracer, &self.assignments);
         debug_println!(
             11,
             0,

--- a/src/cdcl.rs
+++ b/src/cdcl.rs
@@ -42,7 +42,7 @@ pub fn cdcl_decision_procedure(
     timeout: u64,
 ) -> (Status, SolverStats) {
     let mut solver = CaDiCal::new();
-    solver.set("elevate".to_string(), 0);
+    solver.set("elevate".to_string(), 3);
 
     // Create proof tracker for real-time proof tracking wrapped in Rc<RefCell<>>
     // todo: for right now always have hid_quantifiers to be true, need to change this

--- a/src/cdcl.rs
+++ b/src/cdcl.rs
@@ -43,7 +43,10 @@ pub fn cdcl_decision_procedure(
     elevate: i32,
 ) -> (Status, SolverStats) {
     let mut solver = CaDiCal::new();
-    solver.set("elevate".to_string(), elevate);
+    assert!(
+        solver.set("elevate".to_string(), elevate),
+        "CaDiCaL option 'elevate' is unavailable; Sundance requires the cadical-sys elevate fork for lazy quantifier instantiation"
+    );
 
     // Create proof tracker for real-time proof tracking wrapped in Rc<RefCell<>>
     // todo: for right now always have hid_quantifiers to be true, need to change this

--- a/src/cdcl.rs
+++ b/src/cdcl.rs
@@ -42,6 +42,7 @@ pub fn cdcl_decision_procedure(
     timeout: u64,
 ) -> (Status, SolverStats) {
     let mut solver = CaDiCal::new();
+    solver.set("elevate".to_string(), 3);
 
     // Create proof tracker for real-time proof tracking wrapped in Rc<RefCell<>>
     // todo: for right now always have hid_quantifiers to be true, need to change this
@@ -71,6 +72,7 @@ pub fn cdcl_decision_procedure(
         solver: &mut solver as *mut CaDiCal,
         arithmetic,
         stats: SolverStats::new(),
+        pending: None,
     };
 
     solver.connect_external_propagator(&mut propagator);

--- a/src/cdcl.rs
+++ b/src/cdcl.rs
@@ -40,9 +40,10 @@ pub fn cdcl_decision_procedure(
     symbol_table: HashMap<Str, Vec<(Sig, FunctionMeta)>>,
     arithmetic: ArithSolver,
     timeout: u64,
+    elevate: i32,
 ) -> (Status, SolverStats) {
     let mut solver = CaDiCal::new();
-    solver.set("elevate".to_string(), 3);
+    solver.set("elevate".to_string(), elevate);
 
     // Create proof tracker for real-time proof tracking wrapped in Rc<RefCell<>>
     // todo: for right now always have hid_quantifiers to be true, need to change this

--- a/src/cdcl.rs
+++ b/src/cdcl.rs
@@ -42,7 +42,7 @@ pub fn cdcl_decision_procedure(
     timeout: u64,
 ) -> (Status, SolverStats) {
     let mut solver = CaDiCal::new();
-    solver.set("elevate".to_string(), 3);
+    solver.set("elevate".to_string(), 0);
 
     // Create proof tracker for real-time proof tracking wrapped in Rc<RefCell<>>
     // todo: for right now always have hid_quantifiers to be true, need to change this

--- a/src/config.rs
+++ b/src/config.rs
@@ -38,6 +38,9 @@ pub struct Args {
     /// Eagerly skolemize every quantifier
     #[arg(long, default_value_t = false)]
     pub eager_skolem: bool,
+    /// CaDiCaL elevate setting for lazy quantifier instantiation (0 to disable)
+    #[arg(long, default_value_t = 3)]
+    pub elevate: i32,
     /// Set timeout in seconds (0 means no timeout)
     #[arg(long, default_value_t = 0)]
     pub timeout: u64,

--- a/src/egraphs/basic/egraph.rs
+++ b/src/egraphs/basic/egraph.rs
@@ -934,29 +934,6 @@ impl Egraph {
 
         self.decision_level = level;
 
-        // Check for out-of-order entries: an entry at level > target that appears
-        // BEFORE (lower index = deeper in stack) an entry at level <= target
-        let mut has_above_target_after_stop = false;
-        let mut stop_idx = self.proof_forest_backtrack_stack.len();
-        // Find where we'd stop (last entry with level <= target from the top)
-        for (i, entry) in self.proof_forest_backtrack_stack.iter().enumerate().rev() {
-            if entry.0 <= level {
-                stop_idx = i;
-                break;
-            }
-        }
-        // Check if there are entries above target level below the stop point
-        for i in 0..stop_idx {
-            if self.proof_forest_backtrack_stack[i].0 > level {
-                has_above_target_after_stop = true;
-                eprintln!(
-                    "OUT_OF_ORDER: backtracking to level={}, stack[{}] has level={} (above target) but is below stop_idx={}",
-                    level, i, self.proof_forest_backtrack_stack[i].0, stop_idx
-                );
-                break;
-            }
-        }
-
         // Pop proof forest backtrack stack (restore UF first)
         while !self.proof_forest_backtrack_stack.is_empty() {
             let last_level = self.proof_forest_backtrack_stack.last().unwrap().0;
@@ -1236,12 +1213,7 @@ impl Egraph {
         // TODO: write helper functions to make copying over hased things easier
         for (key, value) in y_root_disequalities {
             // make sure we update the disequality level
-            if value.hash >= self.predecessor_level[value.level]
-                || value.hash == 0
-                || value.level == 0
-            {
-                // added value.level == 0 since I think all hashes should be valid at level 0
-                // TODO: borrowing issue so I can't use valid_hash function
+            if valid_hash(value.hash, value.level, &self.predecessor_level) {
 
                 // we can have that we introduce a new equality via eclass option after a quantifier instantiation
                 // this equality could be at level 0
@@ -1326,19 +1298,6 @@ impl Egraph {
                 });
             } else {
                 debug_println!(16, 0, "{}", self);
-                eprintln!("EGRAPH PANIC: merging x={} y={} at level={}", x, y, level);
-                eprintln!("  disequality nodes: {} != {}",
-                    disequality.original_disequality.0,
-                    disequality.original_disequality.1);
-                eprintln!("  disequality terms: {} != {}",
-                    self.display_term(disequality.original_disequality.0),
-                    self.display_term(disequality.original_disequality.1));
-                eprintln!("  find(diseq.0)={} find(diseq.1)={}",
-                    self.find(disequality.original_disequality.0),
-                    self.find(disequality.original_disequality.1));
-                eprintln!("  x_root={} y_root={}", self.find(x), self.find(y));
-                eprintln!("  proof_forest[diseq.0]={:?}", self.proof_forest[disequality.original_disequality.0 as usize]);
-                eprintln!("  proof_forest[diseq.1]={:?}", self.proof_forest[disequality.original_disequality.1 as usize]);
                 panic!(
                     "Should have found a equality between {} [root: {}] and {} [root: {}]",
                     self.display_term(disequality.original_disequality.0),
@@ -1653,7 +1612,7 @@ fn valid_hash(hash: u32, level: usize, predecessor_level: &[u32]) -> bool {
         hash,
         level
     );
-    hash >= predecessor_level[level] || hash == 0 || level == 0 // todo: I added this level ==0 ~> I think this is correct but need to double check to be sure
+    hash >= predecessor_level[level] || level == 0 // todo: I added this level ==0 ~> I think this is correct but need to double check to be sure
 }
 
 impl EgraphTrait for Egraph {

--- a/src/egraphs/basic/egraph.rs
+++ b/src/egraphs/basic/egraph.rs
@@ -934,6 +934,29 @@ impl Egraph {
 
         self.decision_level = level;
 
+        // Check for out-of-order entries: an entry at level > target that appears
+        // BEFORE (lower index = deeper in stack) an entry at level <= target
+        let mut has_above_target_after_stop = false;
+        let mut stop_idx = self.proof_forest_backtrack_stack.len();
+        // Find where we'd stop (last entry with level <= target from the top)
+        for (i, entry) in self.proof_forest_backtrack_stack.iter().enumerate().rev() {
+            if entry.0 <= level {
+                stop_idx = i;
+                break;
+            }
+        }
+        // Check if there are entries above target level below the stop point
+        for i in 0..stop_idx {
+            if self.proof_forest_backtrack_stack[i].0 > level {
+                has_above_target_after_stop = true;
+                eprintln!(
+                    "OUT_OF_ORDER: backtracking to level={}, stack[{}] has level={} (above target) but is below stop_idx={}",
+                    level, i, self.proof_forest_backtrack_stack[i].0, stop_idx
+                );
+                break;
+            }
+        }
+
         // Pop proof forest backtrack stack (restore UF first)
         while !self.proof_forest_backtrack_stack.is_empty() {
             let last_level = self.proof_forest_backtrack_stack.last().unwrap().0;
@@ -1303,6 +1326,19 @@ impl Egraph {
                 });
             } else {
                 debug_println!(16, 0, "{}", self);
+                eprintln!("EGRAPH PANIC: merging x={} y={} at level={}", x, y, level);
+                eprintln!("  disequality nodes: {} != {}",
+                    disequality.original_disequality.0,
+                    disequality.original_disequality.1);
+                eprintln!("  disequality terms: {} != {}",
+                    self.display_term(disequality.original_disequality.0),
+                    self.display_term(disequality.original_disequality.1));
+                eprintln!("  find(diseq.0)={} find(diseq.1)={}",
+                    self.find(disequality.original_disequality.0),
+                    self.find(disequality.original_disequality.1));
+                eprintln!("  x_root={} y_root={}", self.find(x), self.find(y));
+                eprintln!("  proof_forest[diseq.0]={:?}", self.proof_forest[disequality.original_disequality.0 as usize]);
+                eprintln!("  proof_forest[diseq.1]={:?}", self.proof_forest[disequality.original_disequality.1 as usize]);
                 panic!(
                     "Should have found a equality between {} [root: {}] and {} [root: {}]",
                     self.display_term(disequality.original_disequality.0),

--- a/src/egraphs/basic/egraph.rs
+++ b/src/egraphs/basic/egraph.rs
@@ -1634,7 +1634,7 @@ fn valid_hash(hash: u32, level: usize, predecessor_level: &[u32]) -> bool {
         hash,
         level
     );
-    hash >= predecessor_level[level] || level == 0 // todo: I added this level ==0 ~> I think this is correct but need to double check to be sure
+    hash >= predecessor_level[level] || level == 0
 }
 
 impl EgraphTrait for Egraph {

--- a/src/egraphs/basic/egraph.rs
+++ b/src/egraphs/basic/egraph.rs
@@ -1214,7 +1214,6 @@ impl Egraph {
         for (key, value) in y_root_disequalities {
             // make sure we update the disequality level
             if valid_hash(value.hash, value.level, &self.predecessor_level) {
-
                 // we can have that we introduce a new equality via eclass option after a quantifier instantiation
                 // this equality could be at level 0
                 // but then it's possible that there are disequalities that get copied over such that one of the disequalities are at a level higher than 0

--- a/src/main.rs
+++ b/src/main.rs
@@ -179,6 +179,7 @@ fn main() -> Result<(), String> {
         symbol_table,
         args.arithmetic,
         args.timeout,
+        args.elevate,
     );
 
     match return_value {

--- a/src/quantifiers/quantifier.rs
+++ b/src/quantifiers/quantifier.rs
@@ -24,32 +24,41 @@ pub enum QuantifierInstance {
     Skolemization { clause: Vec<i32> },
 }
 
-struct DeferredInstantiation {
-    substituted_term: Term,
-    is_exists: bool,
-    literal: i32,
-    quantifier_id: u64,
+pub struct DeferredInstantiation {
+    pub substituted_term: Term,
+    pub is_exists: bool,
+    pub literal: i32,
+    pub quantifier_id: u64,
 }
 
-struct DeferredSkolemization {
-    skolem: Term,
-    skolem_vars: Vec<(Str, Sort)>,
-    is_exists: bool,
-    literal: i32,
+pub struct DeferredSkolemization {
+    pub skolem: Term,
+    pub skolem_vars: Vec<(Str, Sort)>,
+    pub is_exists: bool,
+    pub literal: i32,
 }
 
-/// Returns a list of quantifier instantiation given the assignment and current state of the egraph
+pub struct PendingInstantiations {
+    pub deferred_instantiations: Vec<DeferredInstantiation>,
+    pub deferred_skolemizations: Vec<DeferredSkolemization>,
+    pub skolemized_quantifier_idxs: Vec<usize>,
+}
+
+impl PendingInstantiations {
+    pub fn is_empty(&self) -> bool {
+        self.deferred_instantiations.is_empty() && self.deferred_skolemizations.is_empty()
+    }
+}
+
+/// Computes trigger matches and substitutions, returning deferred items
+/// that can be materialized one at a time.
 pub fn instantiate_quantifiers(
     solver_state: &mut SolverState,
-    proof_tracer: &Rc<RefCell<SMTProofTracer>>,
     assignments: &[i32],
-) -> Vec<QuantifierInstance> {
+) -> PendingInstantiations {
     let eager_skolem = solver_state.eager_skolem;
-    let ddsmt = solver_state.ddsmt;
-    let lazy_dt = solver_state.lazy_dt;
     debug_println!(24, 0, "Starting a matching round");
     let quantifiers = &solver_state.quantifiers.clone();
-    let mut instantiations = vec![];
     let mut skolemized_quantifier_idxs = vec![];
     let mut deferred_skolemizations: Vec<DeferredSkolemization> = vec![];
     let mut deferred_instantiations: Vec<DeferredInstantiation> = vec![];
@@ -152,28 +161,49 @@ pub fn instantiate_quantifiers(
         }
     }
 
-    instantiations.extend(process_deferred_skolemizations(
-        deferred_skolemizations,
-        solver_state,
-        proof_tracer,
-        ddsmt,
-        lazy_dt,
-    ));
-
-    instantiations.extend(process_deferred_instantiations(
+    PendingInstantiations {
         deferred_instantiations,
-        solver_state,
-        proof_tracer,
-        ddsmt,
-        lazy_dt,
-    ));
+        deferred_skolemizations,
+        skolemized_quantifier_idxs,
+    }
+}
 
-    // Now mark the quantifier indices as skolemized
-    for i in skolemized_quantifier_idxs {
-        solver_state.quantifiers[i].skolemized = true;
+/// Materializes the next pending instantiation or skolemization.
+/// This does the expensive work: insert_predecessor, cnf_tseitin, proof steps.
+/// Returns None if there's nothing left to materialize.
+pub fn materialize_next(
+    pending: &mut PendingInstantiations,
+    solver_state: &mut SolverState,
+    proof_tracer: &Rc<RefCell<SMTProofTracer>>,
+) -> Option<Vec<QuantifierInstance>> {
+    let ddsmt = solver_state.ddsmt;
+    let lazy_dt = solver_state.lazy_dt;
+
+    // Skolemizations first
+    if let Some(deferred) = pending.deferred_skolemizations.pop() {
+        let results = process_deferred_skolemizations(
+            vec![deferred],
+            solver_state,
+            proof_tracer,
+            ddsmt,
+            lazy_dt,
+        );
+        return Some(results);
     }
 
-    instantiations
+    // Then instantiations
+    if let Some(deferred) = pending.deferred_instantiations.pop() {
+        let results = process_deferred_instantiations(
+            vec![deferred],
+            solver_state,
+            proof_tracer,
+            ddsmt,
+            lazy_dt,
+        );
+        return Some(results);
+    }
+
+    None
 }
 
 fn process_deferred_skolemizations(

--- a/src/quantifiers/quantifier.rs
+++ b/src/quantifiers/quantifier.rs
@@ -4,6 +4,7 @@
 //! Instantiation of quantifiers
 
 use std::cell::RefCell;
+use std::collections::VecDeque;
 use std::rc::Rc;
 
 use crate::cnf::{CNFConversion, push_literal_if_not_tautology};
@@ -19,40 +20,44 @@ use crate::debug_println;
 use yaspar_ir::ast::{LetElim, Sort, Str, Substitute, Substitution, Term, TermAllocator};
 
 #[derive(Debug, Clone)]
-pub enum QuantifierInstance {
+pub(crate) enum QuantifierInstance {
     Instantiation { clauses: Vec<Vec<i32>> },
     Skolemization { clauses: Vec<Vec<i32>> },
 }
 
-pub struct DeferredInstantiation {
-    pub substituted_term: Term,
-    pub is_exists: bool,
-    pub literal: i32,
-    pub quantifier_id: u64,
+struct DeferredInstantiation {
+    substituted_term: Term,
+    is_exists: bool,
+    literal: i32,
+    quantifier_id: u64,
 }
 
-pub struct DeferredSkolemization {
-    pub skolem: Term,
-    pub skolem_vars: Vec<(Str, Sort)>,
-    pub is_exists: bool,
-    pub literal: i32,
+struct DeferredSkolemization {
+    skolem: Term,
+    skolem_vars: Vec<(Str, Sort)>,
+    is_exists: bool,
+    literal: i32,
 }
 
-pub struct PendingInstantiations {
-    pub deferred_instantiations: Vec<DeferredInstantiation>,
-    pub deferred_skolemizations: Vec<DeferredSkolemization>,
-    pub skolemized_quantifier_idxs: Vec<usize>,
+pub(crate) struct PendingInstantiations {
+    deferred_instantiations: VecDeque<DeferredInstantiation>,
+    deferred_skolemizations: VecDeque<DeferredSkolemization>,
+    skolemized_quantifier_idxs: Vec<usize>,
 }
 
 impl PendingInstantiations {
-    pub fn is_empty(&self) -> bool {
+    pub(crate) fn is_empty(&self) -> bool {
         self.deferred_instantiations.is_empty() && self.deferred_skolemizations.is_empty()
+    }
+
+    pub(crate) fn skolemized_quantifier_idxs(&self) -> &[usize] {
+        &self.skolemized_quantifier_idxs
     }
 }
 
 /// Computes trigger matches and substitutions, returning deferred items
 /// that can be materialized one at a time.
-pub fn instantiate_quantifiers(
+pub(crate) fn instantiate_quantifiers(
     solver_state: &mut SolverState,
     assignments: &[i32],
 ) -> PendingInstantiations {
@@ -60,8 +65,8 @@ pub fn instantiate_quantifiers(
     debug_println!(24, 0, "Starting a matching round");
     let quantifiers = &solver_state.quantifiers.clone();
     let mut skolemized_quantifier_idxs = vec![];
-    let mut deferred_skolemizations: Vec<DeferredSkolemization> = vec![];
-    let mut deferred_instantiations: Vec<DeferredInstantiation> = vec![];
+    let mut deferred_skolemizations: VecDeque<DeferredSkolemization> = VecDeque::new();
+    let mut deferred_instantiations: VecDeque<DeferredInstantiation> = VecDeque::new();
 
     // We `enumerate()` so we can update quantifiers[i].skolemized after the loop
     for (i, quantifier) in quantifiers.iter().enumerate() {
@@ -96,7 +101,7 @@ pub fn instantiate_quantifiers(
             let (skolem, skolem_vars) =
                 skolemize(&term, &mut solver_state.context, quantifier_is_exists);
 
-            deferred_skolemizations.push(DeferredSkolemization {
+            deferred_skolemizations.push_back(DeferredSkolemization {
                 skolem,
                 skolem_vars,
                 is_exists: quantifier_is_exists,
@@ -151,7 +156,7 @@ pub fn instantiate_quantifiers(
                     &mut solver_state.context,
                 );
                 let substituted_term = term.subst(&substitution, &mut solver_state.context);
-                deferred_instantiations.push(DeferredInstantiation {
+                deferred_instantiations.push_back(DeferredInstantiation {
                     substituted_term,
                     is_exists: quantifier_is_exists,
                     literal: quantifier_literal,
@@ -171,7 +176,7 @@ pub fn instantiate_quantifiers(
 /// Materializes the next pending instantiation or skolemization.
 /// This does the expensive work: insert_predecessor, cnf_tseitin, proof steps.
 /// Returns None if there's nothing left to materialize.
-pub fn materialize_next(
+pub(crate) fn materialize_next(
     pending: &mut PendingInstantiations,
     solver_state: &mut SolverState,
     proof_tracer: &Rc<RefCell<SMTProofTracer>>,
@@ -180,7 +185,7 @@ pub fn materialize_next(
     let lazy_dt = solver_state.lazy_dt;
 
     // Skolemizations first
-    if let Some(deferred) = pending.deferred_skolemizations.pop() {
+    if let Some(deferred) = pending.deferred_skolemizations.pop_front() {
         let results = process_deferred_skolemizations(
             vec![deferred],
             solver_state,
@@ -192,7 +197,7 @@ pub fn materialize_next(
     }
 
     // Then instantiations
-    if let Some(deferred) = pending.deferred_instantiations.pop() {
+    if let Some(deferred) = pending.deferred_instantiations.pop_front() {
         let results = process_deferred_instantiations(
             vec![deferred],
             solver_state,

--- a/src/quantifiers/quantifier.rs
+++ b/src/quantifiers/quantifier.rs
@@ -326,7 +326,6 @@ fn process_deferred_instantiations(
         let cnf_term = nnf_term.cnf_tseitin(solver_state);
 
         let mut clauses: Vec<_> = cnf_term
-            .clone()
             .into_iter()
             .map(|x| x.into_iter().collect::<Vec<_>>())
             .collect();

--- a/src/quantifiers/quantifier.rs
+++ b/src/quantifiers/quantifier.rs
@@ -20,8 +20,8 @@ use yaspar_ir::ast::{LetElim, Sort, Str, Substitute, Substitution, Term, TermAll
 
 #[derive(Debug, Clone)]
 pub enum QuantifierInstance {
-    Instantiation { clause: Vec<i32> },
-    Skolemization { clause: Vec<i32> },
+    Instantiation { clauses: Vec<Vec<i32>> },
+    Skolemization { clauses: Vec<Vec<i32>> },
 }
 
 pub struct DeferredInstantiation {
@@ -257,22 +257,25 @@ fn process_deferred_skolemizations(
             );
 
         let skolem_imp = vec![-quantifier_dimacs_literal, reduced_skolem_literal];
-        results.push(QuantifierInstance::Skolemization { clause: skolem_imp });
-
-        let mut add_clause = |mut clause: Vec<i32>, theory: Theory| {
-            if push_literal_if_not_tautology(&mut clause, -reduced_skolem_literal) {
-                proof_tracer.borrow_mut().add_theory_clause(&clause, theory);
-                results.push(QuantifierInstance::Skolemization { clause })
-            }
-        };
+        let mut skolem_clauses = vec![skolem_imp];
 
         for clause in clauses {
-            add_clause(clause.0, Theory::Boolean);
+            let mut c = clause.0;
+            if push_literal_if_not_tautology(&mut c, -reduced_skolem_literal) {
+                proof_tracer.borrow_mut().add_theory_clause(&c, Theory::Boolean);
+                skolem_clauses.push(c);
+            }
         }
 
         for clause in additional_constraints {
-            add_clause(clause, Theory::Boolean);
+            let mut c = clause;
+            if push_literal_if_not_tautology(&mut c, -reduced_skolem_literal) {
+                proof_tracer.borrow_mut().add_theory_clause(&c, Theory::Boolean);
+                skolem_clauses.push(c);
+            }
         }
+
+        results.push(QuantifierInstance::Skolemization { clauses: skolem_clauses });
     }
     results
 }
@@ -354,9 +357,7 @@ fn process_deferred_instantiations(
         );
         clauses.extend(additional_constraints);
 
-        for clause in clauses {
-            results.push(QuantifierInstance::Instantiation { clause });
-        }
+        results.push(QuantifierInstance::Instantiation { clauses });
     }
     results
 }

--- a/src/quantifiers/quantifier.rs
+++ b/src/quantifiers/quantifier.rs
@@ -24,6 +24,13 @@ pub enum QuantifierInstance {
     Skolemization { clause: Vec<i32> },
 }
 
+struct DeferredInstantiation {
+    substituted_term: Term,
+    is_exists: bool,
+    literal: i32,
+    quantifier_id: u64,
+}
+
 /// Returns a list of quantifier instantiation given the assignment and current state of the egraph
 ///
 /// TODO: level is only used for printing, can get rid of it later
@@ -41,7 +48,7 @@ pub fn instantiate_quantifiers(
     let quantifiers = &solver_state.quantifiers.clone();
     let mut instantiations = vec![];
     let mut skolemized_quantifier_idxs = vec![];
-    let mut deferred_instantiations: Vec<(Term, bool, i32, u64)> = vec![];
+    let mut deferred_instantiations: Vec<DeferredInstantiation> = vec![];
 
     // We `enumerate()` so we can update quantifiers[i].skolemized after the loop
     for (i, quantifier) in quantifiers.iter().enumerate() {
@@ -214,11 +221,12 @@ pub fn instantiate_quantifiers(
 
             if list_assignments.is_empty() {
                 debug_println!(
-                    24,
+                    6,
                     0,
-                    "No substitutions for {}",
+                    "We are skipping the quantifier {} because it has no substitutions",
                     solver_state.get_term(quantifier.id)
                 );
+                continue;
             }
 
             debug_println!(7, 0, "We have the following list of assignments:");
@@ -252,23 +260,52 @@ pub fn instantiate_quantifiers(
                     &mut solver_state.context,
                 );
                 let substituted_term = term.subst(&substitution, &mut solver_state.context);
-                deferred_instantiations.push((
+                deferred_instantiations.push(DeferredInstantiation {
                     substituted_term,
-                    quantifier_is_exists,
-                    quantifier_literal,
-                    quantifier.id,
-                ));
+                    is_exists: quantifier_is_exists,
+                    literal: quantifier_literal,
+                    quantifier_id: quantifier.id,
+                });
             }
         }
     }
 
-    // Phase 2: Process all deferred instantiations (substitute and add to egraph)
+    process_deferred_instantiations(
+        deferred_instantiations,
+        solver_state,
+        proof_tracer,
+        ddsmt,
+        lazy_dt,
+        level,
+        &mut instantiations,
+    );
+
+    // Now mark the quantifier indices as skolemized
+    for i in skolemized_quantifier_idxs {
+        solver_state.quantifiers[i].skolemized = true;
+    }
+
+    instantiations
+}
+
+fn process_deferred_instantiations(
+    deferred_instantiations: Vec<DeferredInstantiation>,
+    solver_state: &mut SolverState,
+    proof_tracer: &Rc<RefCell<SMTProofTracer>>,
+    ddsmt: bool,
+    lazy_dt: bool,
+    level: usize,
+    instantiations: &mut Vec<QuantifierInstance>,
+) {
     debug_println!(6, 0, "Starting to process deferred instantiations");
-    for (substituted_term, quantifier_is_exists, quantifier_literal, quantifier_id) in
-        deferred_instantiations
+    for DeferredInstantiation {
+        substituted_term,
+        is_exists,
+        literal,
+        quantifier_id,
+    } in deferred_instantiations
     {
-        // if this came from a negated existential, we have to negate the term
-        let t = if quantifier_is_exists {
+        let t = if is_exists {
             solver_state.context.not(substituted_term)
         } else {
             substituted_term
@@ -285,7 +322,6 @@ pub fn instantiate_quantifiers(
 
         debug_println!(4, 0, "We have the term {} with id {}", t, t.uid());
 
-        // eliminating lets
         let let_elim_term = t.let_elim(&mut solver_state.context);
 
         debug_println!(
@@ -326,12 +362,9 @@ pub fn instantiate_quantifiers(
             .map(|x| x.into_iter().collect::<Vec<_>>())
             .collect();
 
-        let quantifier_dimacs_literal = if quantifier_is_exists {
-            -quantifier_literal
-        } else {
-            quantifier_literal
-        };
+        let quantifier_dimacs_literal = if is_exists { -literal } else { literal };
         let nnf_term_literal = solver_state.get_lit_from_term(&nnf_term);
+        // Must happen *after* `cnf_tseitin` so Tseitin literals are registered first
         let subst_literal = if t.uid() != nnf_term.uid() {
             solver_state.get_or_allocate_lit_for_term(&t)
         } else {
@@ -366,13 +399,6 @@ pub fn instantiate_quantifiers(
             instantiations.push(instantiation);
         }
     }
-
-    // Now mark the quantifier indices as skolemized
-    for i in skolemized_quantifier_idxs {
-        solver_state.quantifiers[i].skolemized = true;
-    }
-
-    instantiations
 }
 
 // match_term and find_assignments_on_term moved to Egraph methods in solver_state.rs

--- a/src/quantifiers/quantifier.rs
+++ b/src/quantifiers/quantifier.rs
@@ -16,7 +16,7 @@ use crate::solver_types::Polarity;
 use crate::utils::DeterministicHashMap;
 
 use crate::debug_println;
-use yaspar_ir::ast::{LetElim, Substitute, Substitution, Term, TermAllocator};
+use yaspar_ir::ast::{LetElim, Sort, Str, Substitute, Substitution, Term, TermAllocator};
 
 #[derive(Debug, Clone)]
 pub enum QuantifierInstance {
@@ -31,15 +31,18 @@ struct DeferredInstantiation {
     quantifier_id: u64,
 }
 
+struct DeferredSkolemization {
+    skolem: Term,
+    skolem_vars: Vec<(Str, Sort)>,
+    is_exists: bool,
+    literal: i32,
+}
+
 /// Returns a list of quantifier instantiation given the assignment and current state of the egraph
-///
-/// TODO: level is only used for printing, can get rid of it later
-/// (could use it for activate_bits, but right now we are activating everything at level 0)
 pub fn instantiate_quantifiers(
     solver_state: &mut SolverState,
     proof_tracer: &Rc<RefCell<SMTProofTracer>>,
-    assignments: &Vec<i32>,
-    level: usize,
+    assignments: &[i32],
 ) -> Vec<QuantifierInstance> {
     let eager_skolem = solver_state.eager_skolem;
     let ddsmt = solver_state.ddsmt;
@@ -48,6 +51,7 @@ pub fn instantiate_quantifiers(
     let quantifiers = &solver_state.quantifiers.clone();
     let mut instantiations = vec![];
     let mut skolemized_quantifier_idxs = vec![];
+    let mut deferred_skolemizations: Vec<DeferredSkolemization> = vec![];
     let mut deferred_instantiations: Vec<DeferredInstantiation> = vec![];
 
     // We `enumerate()` so we can update quantifiers[i].skolemized after the loop
@@ -65,20 +69,7 @@ pub fn instantiate_quantifiers(
         let quantifier_assignment = assignments[quantifier_literal.unsigned_abs() as usize];
 
         // if the quantifier is unassigned, we can skip it
-        if quantifier_assignment == 0
-        // || (quantifier_assignment > 0 && quantifier_literal < 0)
-        // || (quantifier_assignment < 0 && quantifier_literal > 0)
-        {
-            debug_println!(12, 0, "after4");
-            debug_println!(
-                6,
-                0,
-                "We are skipping the quantifier {} with quantifier_literal {} and quantifier_assignment {} | assignments {:?}",
-                solver_state.get_term(quantifier.id),
-                quantifier_literal,
-                quantifier_assignment,
-                assignments
-            );
+        if quantifier_assignment == 0 {
             continue;
         }
 
@@ -90,104 +81,18 @@ pub fn instantiate_quantifiers(
 
         // if the quantifier has positive polarity or we are doing ddsmt optimizations, and we haven't skolemized it yet, then we skolemize it
         if (quantifier_polarity || eager_skolem) && !quantifier.skolemized {
-            debug_println!(
-                6,
-                0,
-                "We are skolemizing the quantifier {} with quantifier_literal {} and quantifier_assignment {} | assignments {:?}",
-                solver_state.get_term(quantifier.id),
-                quantifier_literal,
-                quantifier_assignment,
-                assignments,
-            );
-
-            // Record this `Quantifier`'s index, so we can update its `.skolemized` field at the end
             skolemized_quantifier_idxs.push(i);
 
-            // Skolemize the term
             let term = solver_state.get_term(quantifier.id);
             let (skolem, skolem_vars) =
                 skolemize(&term, &mut solver_state.context, quantifier_is_exists);
 
-            // Reduce the skolemized term, since Sundance doesn't simplify formulas under quantifiers during parsing
-            let reduced_skolem: Term = skolem.let_elim(&mut solver_state.context);
-            let reduced_skolem = reduced_skolem.nnf(solver_state);
-            let additional_constraints =
-                check_for_function_bool(&reduced_skolem, solver_state, true, ddsmt, lazy_dt);
-
-            // Register the reduction with the egraph
-            solver_state.insert_predecessor(&reduced_skolem, None, None, true);
-
-            // Apply the Tseitin transformation to the reduced formula.
-            // NOTE: We must do this step *before* we add a Skolemization eDRAT proof step,
-            // since Sundance aggressively caches boolean sub-terms in its `CNFEnv` cache.
-            // We want Sundance to register those DIMACS literals before we specially
-            // request a new one for the un-reduced skolem term, just in case they match.
-            // (If they match, then `cnf_tseitin()` won't process any sub-terms, since
-            // the function otherwise has a cache hit.)
-            let clauses = reduced_skolem.cnf_tseitin(solver_state);
-
-            debug_println!(19, 0, "we are skolemizing {}", term);
-            debug_println!(26, 0, "(assert {})", reduced_skolem);
-            debug_println!(
-                24,
-                8,
-                "from quantifier {} [{}]",
-                solver_state.get_term(quantifier.id),
-                quantifier.id,
-            );
-
-            // Now we add proof clause(s) to the eDRAT proof to justify the Skolemization.
-            // Store the DIMACS literals we need beforehand.
-            let quantifier_dimacs_literal = if quantifier_is_exists {
-                quantifier_literal
-            } else {
-                -quantifier_literal
-            };
-            let reduced_skolem_literal = solver_state.get_lit_from_term(&reduced_skolem);
-            let skolem_literal = if skolem.uid() != reduced_skolem.uid() {
-                // Note: This must happen *after* calling `reduced_skolem.cnf_tseitin()`
-                solver_state.get_or_allocate_lit_for_term(&skolem)
-            } else {
-                0
-            };
-
-            proof_tracer
-                .borrow_mut()
-                .push_skolem_or_instantiation_derivation(
-                    quantifier_dimacs_literal,
-                    skolem_literal,
-                    &skolem,
-                    reduced_skolem_literal,
-                    &reduced_skolem,
-                    ProofStepType::Skolemization {
-                        parent_term: quantifier_literal,
-                        skolem_vars,
-                    },
-                );
-
-            // The SAT solver ultimately learns the Skolem as an implication
-            let skolem_imp = vec![-quantifier_dimacs_literal, reduced_skolem_literal];
-            instantiations.push(QuantifierInstance::Skolemization { clause: skolem_imp });
-
-            // Finally, clauses from the Tseitin transformation and from `additional_constraints`
-            // are implied by the reduced skolem formula.
-
-            // Lambda to add the skolem literal to the Tseitin/additional_constraints clauses
-            let mut add_clause = |mut clause: Vec<i32>, theory: Theory| {
-                if push_literal_if_not_tautology(&mut clause, -reduced_skolem_literal) {
-                    proof_tracer.borrow_mut().add_theory_clause(&clause, theory);
-                    instantiations.push(QuantifierInstance::Skolemization { clause })
-                }
-            };
-
-            for clause in clauses {
-                add_clause(clause.0, Theory::Boolean);
-            }
-
-            // CC TODO: Differentiate between `ite` axioms and `datatype` axioms
-            for clause in additional_constraints {
-                add_clause(clause, Theory::Boolean);
-            }
+            deferred_skolemizations.push(DeferredSkolemization {
+                skolem,
+                skolem_vars,
+                is_exists: quantifier_is_exists,
+                literal: quantifier_literal,
+            });
         }
 
         // if this was a skolemization case, we don't want to instantiate
@@ -195,12 +100,6 @@ pub fn instantiate_quantifiers(
             continue;
         }
 
-        debug_println!(
-            19,
-            0,
-            "instantiating the quantifier {}",
-            solver_state.get_term(quantifier.id)
-        );
         let triggers = &quantifier.triggers;
         // note we consider patterns in a multipattern conjunctively and multipatterns in a trigger disjunctively
         for multipattern in triggers {
@@ -208,28 +107,12 @@ pub fn instantiate_quantifiers(
             let trigger_term_pairs: Vec<(usize, Option<u32>)> =
                 multipattern.iter().map(|t| (*t, None)).collect();
 
-            debug_println!(12, 0, "after8");
-            debug_println!(
-                19,
-                0,
-                "About to match quantifier body {} with trigger {:?}",
-                solver_state.get_term(body),
-                trigger_term_pairs
-            );
-            debug_println!(12, 0, "after9");
             let list_assignments = solver_state.egraph.match_triggers(trigger_term_pairs);
 
             if list_assignments.is_empty() {
-                debug_println!(
-                    6,
-                    0,
-                    "We are skipping the quantifier {} because it has no substitutions",
-                    solver_state.get_term(quantifier.id)
-                );
                 continue;
             }
 
-            debug_println!(7, 0, "We have the following list of assignments:");
             for subs_ids in list_assignments.iter() {
                 // Convert ID map to Term map for substitution
                 let subs: DeterministicHashMap<String, Term> = subs_ids
@@ -253,7 +136,6 @@ pub fn instantiate_quantifiers(
                     .or_default()
                     .insert(subs.clone());
 
-                debug_println!(6, 0, "before12");
                 let term = solver_state.get_term(body);
                 let substitution = Substitution::new(
                     subs.iter().map(|(s, t)| (s, t.clone())),
@@ -270,15 +152,21 @@ pub fn instantiate_quantifiers(
         }
     }
 
-    process_deferred_instantiations(
+    instantiations.extend(process_deferred_skolemizations(
+        deferred_skolemizations,
+        solver_state,
+        proof_tracer,
+        ddsmt,
+        lazy_dt,
+    ));
+
+    instantiations.extend(process_deferred_instantiations(
         deferred_instantiations,
         solver_state,
         proof_tracer,
         ddsmt,
         lazy_dt,
-        level,
-        &mut instantiations,
-    );
+    ));
 
     // Now mark the quantifier indices as skolemized
     for i in skolemized_quantifier_idxs {
@@ -288,16 +176,85 @@ pub fn instantiate_quantifiers(
     instantiations
 }
 
+fn process_deferred_skolemizations(
+    deferred_skolemizations: Vec<DeferredSkolemization>,
+    solver_state: &mut SolverState,
+    proof_tracer: &Rc<RefCell<SMTProofTracer>>,
+    ddsmt: bool,
+    lazy_dt: bool,
+) -> Vec<QuantifierInstance> {
+    let mut results = vec![];
+    for DeferredSkolemization {
+        skolem,
+        skolem_vars,
+        is_exists,
+        literal,
+    } in deferred_skolemizations
+    {
+        let reduced_skolem: Term = skolem.let_elim(&mut solver_state.context);
+        let reduced_skolem = reduced_skolem.nnf(solver_state);
+        let additional_constraints =
+            check_for_function_bool(&reduced_skolem, solver_state, true, ddsmt, lazy_dt);
+
+        solver_state.insert_predecessor(&reduced_skolem, None, None, true);
+
+        // Must do Tseitin *before* allocating the skolem literal — see comment on instantiation path
+        let clauses = reduced_skolem.cnf_tseitin(solver_state);
+
+        debug_println!(26, 0, "(assert {})", reduced_skolem);
+
+        let quantifier_dimacs_literal = if is_exists { literal } else { -literal };
+        let reduced_skolem_literal = solver_state.get_lit_from_term(&reduced_skolem);
+        // Must happen *after* `cnf_tseitin` so Tseitin literals are registered first
+        let skolem_literal = if skolem.uid() != reduced_skolem.uid() {
+            solver_state.get_or_allocate_lit_for_term(&skolem)
+        } else {
+            0
+        };
+
+        proof_tracer
+            .borrow_mut()
+            .push_skolem_or_instantiation_derivation(
+                quantifier_dimacs_literal,
+                skolem_literal,
+                &skolem,
+                reduced_skolem_literal,
+                &reduced_skolem,
+                ProofStepType::Skolemization {
+                    parent_term: literal,
+                    skolem_vars,
+                },
+            );
+
+        let skolem_imp = vec![-quantifier_dimacs_literal, reduced_skolem_literal];
+        results.push(QuantifierInstance::Skolemization { clause: skolem_imp });
+
+        let mut add_clause = |mut clause: Vec<i32>, theory: Theory| {
+            if push_literal_if_not_tautology(&mut clause, -reduced_skolem_literal) {
+                proof_tracer.borrow_mut().add_theory_clause(&clause, theory);
+                results.push(QuantifierInstance::Skolemization { clause })
+            }
+        };
+
+        for clause in clauses {
+            add_clause(clause.0, Theory::Boolean);
+        }
+
+        for clause in additional_constraints {
+            add_clause(clause, Theory::Boolean);
+        }
+    }
+    results
+}
+
 fn process_deferred_instantiations(
     deferred_instantiations: Vec<DeferredInstantiation>,
     solver_state: &mut SolverState,
     proof_tracer: &Rc<RefCell<SMTProofTracer>>,
     ddsmt: bool,
     lazy_dt: bool,
-    level: usize,
-    instantiations: &mut Vec<QuantifierInstance>,
-) {
-    debug_println!(6, 0, "Starting to process deferred instantiations");
+) -> Vec<QuantifierInstance> {
+    let mut results = vec![];
     for DeferredInstantiation {
         substituted_term,
         is_exists,
@@ -314,47 +271,20 @@ fn process_deferred_instantiations(
         debug_println!(
             22,
             0,
-            "We are adding the instantiation {} for quantifier {} at level {}",
+            "We are adding the instantiation {} for quantifier {}",
             t.clone(),
             solver_state.get_term(quantifier_id),
-            level
         );
-
-        debug_println!(4, 0, "We have the term {} with id {}", t, t.uid());
 
         let let_elim_term = t.let_elim(&mut solver_state.context);
-
-        debug_println!(
-            8,
-            0,
-            "{} is an instantiation of {}",
-            let_elim_term,
-            solver_state.get_term(quantifier_id)
-        );
 
         let nnf_term = let_elim_term.nnf(solver_state);
 
         debug_println!(26, 4, "(assert {})", nnf_term.clone());
-        debug_println!(
-            24,
-            8,
-            "from quantifier {} [{}]",
-            solver_state.get_term(quantifier_id),
-            quantifier_id
-        );
-
-        debug_println!(
-            7,
-            0,
-            "We have the nnf term {} with id {}",
-            nnf_term,
-            nnf_term.uid()
-        );
 
         solver_state.insert_predecessor(&nnf_term, None, None, true);
 
         let cnf_term = nnf_term.cnf_tseitin(solver_state);
-        debug_println!(7, 0, "We have the cnf term {:?}", cnf_term);
 
         let mut clauses: Vec<_> = cnf_term
             .clone()
@@ -395,10 +325,8 @@ fn process_deferred_instantiations(
         clauses.extend(additional_constraints);
 
         for clause in clauses {
-            let instantiation = QuantifierInstance::Instantiation { clause };
-            instantiations.push(instantiation);
+            results.push(QuantifierInstance::Instantiation { clause });
         }
     }
+    results
 }
-
-// match_term and find_assignments_on_term moved to Egraph methods in solver_state.rs

--- a/src/quantifiers/quantifier.rs
+++ b/src/quantifiers/quantifier.rs
@@ -262,7 +262,9 @@ fn process_deferred_skolemizations(
         for clause in clauses {
             let mut c = clause.0;
             if push_literal_if_not_tautology(&mut c, -reduced_skolem_literal) {
-                proof_tracer.borrow_mut().add_theory_clause(&c, Theory::Boolean);
+                proof_tracer
+                    .borrow_mut()
+                    .add_theory_clause(&c, Theory::Boolean);
                 skolem_clauses.push(c);
             }
         }
@@ -270,12 +272,16 @@ fn process_deferred_skolemizations(
         for clause in additional_constraints {
             let mut c = clause;
             if push_literal_if_not_tautology(&mut c, -reduced_skolem_literal) {
-                proof_tracer.borrow_mut().add_theory_clause(&c, Theory::Boolean);
+                proof_tracer
+                    .borrow_mut()
+                    .add_theory_clause(&c, Theory::Boolean);
                 skolem_clauses.push(c);
             }
         }
 
-        results.push(QuantifierInstance::Skolemization { clauses: skolem_clauses });
+        results.push(QuantifierInstance::Skolemization {
+            clauses: skolem_clauses,
+        });
     }
     results
 }

--- a/src/quantifiers/quantifier.rs
+++ b/src/quantifiers/quantifier.rs
@@ -41,6 +41,7 @@ pub fn instantiate_quantifiers(
     let quantifiers = &solver_state.quantifiers.clone();
     let mut instantiations = vec![];
     let mut skolemized_quantifier_idxs = vec![];
+    let mut deferred_instantiations: Vec<(Term, bool, i32, u64)> = vec![];
 
     // We `enumerate()` so we can update quantifiers[i].skolemized after the loop
     for (i, quantifier) in quantifiers.iter().enumerate() {
@@ -221,7 +222,6 @@ pub fn instantiate_quantifiers(
             }
 
             debug_println!(7, 0, "We have the following list of assignments:");
-            let mut substitutions = vec![];
             for subs_ids in list_assignments.iter() {
                 // Convert ID map to Term map for substitution
                 let subs: DeterministicHashMap<String, Term> = subs_ids
@@ -252,138 +252,118 @@ pub fn instantiate_quantifiers(
                     &mut solver_state.context,
                 );
                 let substituted_term = term.subst(&substitution, &mut solver_state.context);
-                substitutions.push((substituted_term, subs));
+                deferred_instantiations.push((
+                    substituted_term,
+                    quantifier_is_exists,
+                    quantifier_literal,
+                    quantifier.id,
+                ));
             }
+        }
+    }
 
-            if substitutions.is_empty() {
-                debug_println!(
-                    6,
-                    0,
-                    "We are skipping the quantifier {} because it has no substitutions",
-                    solver_state.get_term(quantifier.id)
-                );
-                continue;
-            }
+    // Phase 2: Process all deferred instantiations (substitute and add to egraph)
+    debug_println!(6, 0, "Starting to process deferred instantiations");
+    for (substituted_term, quantifier_is_exists, quantifier_literal, quantifier_id) in
+        deferred_instantiations
+    {
+        // if this came from a negated existential, we have to negate the term
+        let t = if quantifier_is_exists {
+            solver_state.context.not(substituted_term)
+        } else {
+            substituted_term
+        };
 
-            debug_println!(6, 0, "Starting to look at substitutions");
-            for (t, _) in substitutions {
-                // skipping instantiations that have already been added
-                // TODO: need to come up with a more efficient way to do this
-                // TODO: have solver_state.added_instantiations as a string right now, really want to go back to u32
+        debug_println!(
+            22,
+            0,
+            "We are adding the instantiation {} for quantifier {} at level {}",
+            t.clone(),
+            solver_state.get_term(quantifier_id),
+            level
+        );
 
-                // if this came from a negated existential, we have to negate the term
-                let t = if quantifier_is_exists {
-                    solver_state.context.not(t)
-                } else {
-                    t
-                };
+        debug_println!(4, 0, "We have the term {} with id {}", t, t.uid());
 
-                debug_println!(
-                    22,
-                    0,
-                    "We are adding the instantiation {} for quantifier {} at level {}",
-                    t.clone(),
-                    solver_state.get_term(quantifier.id),
-                    level
-                );
+        // eliminating lets
+        let let_elim_term = t.let_elim(&mut solver_state.context);
 
-                debug_println!(4, 0, "We have the term {} with id {}", t, t.uid());
+        debug_println!(
+            8,
+            0,
+            "{} is an instantiation of {}",
+            let_elim_term,
+            solver_state.get_term(quantifier_id)
+        );
 
-                // eliminating lets
-                let let_elim_term = t.let_elim(&mut solver_state.context);
+        let nnf_term = let_elim_term.nnf(solver_state);
 
-                debug_println!(
-                    8,
-                    0,
-                    "{} is an instantiation of {}",
-                    let_elim_term,
-                    solver_state.get_term(quantifier.id)
-                );
+        debug_println!(26, 4, "(assert {})", nnf_term.clone());
+        debug_println!(
+            24,
+            8,
+            "from quantifier {} [{}]",
+            solver_state.get_term(quantifier_id),
+            quantifier_id
+        );
 
-                let nnf_term = let_elim_term.nnf(solver_state);
+        debug_println!(
+            7,
+            0,
+            "We have the nnf term {} with id {}",
+            nnf_term,
+            nnf_term.uid()
+        );
 
-                debug_println!(26, 4, "(assert {})", nnf_term.clone());
-                debug_println!(
-                    24,
-                    8,
-                    "from quantifier {} [{}]",
-                    solver_state.get_term(quantifier.id),
-                    quantifier.id
-                );
+        solver_state.insert_predecessor(&nnf_term, None, None, true);
 
-                debug_println!(
-                    7,
-                    0,
-                    "We have the nnf term {} with id {}",
-                    nnf_term,
-                    nnf_term.uid()
-                );
+        let cnf_term = nnf_term.cnf_tseitin(solver_state);
+        debug_println!(7, 0, "We have the cnf term {:?}", cnf_term);
 
-                // note we do this after nnf
-                // this might lead to weirdness when you have equality of booleans not being represented in egraph
-                // but it should be fine. This is necessary because we need to look up lits
-                // todo: also might be less efficient as well because we are losing structure from original formula in the egraph
-                solver_state.insert_predecessor(&nnf_term, None, None, true);
+        let mut clauses: Vec<_> = cnf_term
+            .clone()
+            .into_iter()
+            .map(|x| x.into_iter().collect::<Vec<_>>())
+            .collect();
 
-                let cnf_term = nnf_term.cnf_tseitin(solver_state);
-                debug_println!(7, 0, "We have the cnf term {:?}", cnf_term);
+        let quantifier_dimacs_literal = if quantifier_is_exists {
+            -quantifier_literal
+        } else {
+            quantifier_literal
+        };
+        let nnf_term_literal = solver_state.get_lit_from_term(&nnf_term);
+        let subst_literal = if t.uid() != nnf_term.uid() {
+            solver_state.get_or_allocate_lit_for_term(&t)
+        } else {
+            0
+        };
 
-                let mut clauses: Vec<_> = cnf_term
-                    .clone()
-                    .into_iter()
-                    .map(|x| x.into_iter().collect::<Vec<_>>())
-                    .collect();
+        proof_tracer
+            .borrow_mut()
+            .push_skolem_or_instantiation_derivation(
+                quantifier_dimacs_literal,
+                subst_literal,
+                &t,
+                nnf_term_literal,
+                &nnf_term,
+                ProofStepType::Instantiation,
+            );
 
-                let quantifier_dimacs_literal = if quantifier_is_exists {
-                    -quantifier_literal
-                } else {
-                    quantifier_literal
-                };
-                let nnf_term_literal = solver_state.get_lit_from_term(&nnf_term);
-                let subst_literal = if t.uid() != nnf_term.uid() {
-                    // Reserve a fresh DIMACS literal for the un-reduced term.
-                    // Note: This must happen *after* calling `nnf_term.cnf_tseitin()`
-                    solver_state.get_or_allocate_lit_for_term(&t)
-                } else {
-                    0
-                };
+        proof_tracer
+            .borrow_mut()
+            .push_steps(&clauses, ProofStepType::TheoryClause(Theory::Boolean));
 
-                // Add the "quantifier implies instantiation" clause to the proof
-                proof_tracer
-                    .borrow_mut()
-                    .push_skolem_or_instantiation_derivation(
-                        quantifier_dimacs_literal,
-                        subst_literal,
-                        &t,
-                        nnf_term_literal,
-                        &nnf_term,
-                        ProofStepType::Instantiation,
-                    );
+        let additional_constraints =
+            check_for_function_bool(&nnf_term, solver_state, true, ddsmt, lazy_dt);
+        proof_tracer.borrow_mut().push_steps(
+            &additional_constraints,
+            ProofStepType::TheoryClause(Theory::Background),
+        );
+        clauses.extend(additional_constraints);
 
-                // Add proof steps witnessing the Tseitin transformation of `nnf_term`
-                proof_tracer
-                    .borrow_mut()
-                    .push_steps(&clauses, ProofStepType::TheoryClause(Theory::Boolean));
-
-                // the bug comes from the additional constraints
-                // basically the additional constraints are valid lits -> converted to valid u64, but may not be in the actual term mapping
-                // it should be added in insert_predecessor which calls get_or_insert which adds into terms_list
-                let additional_constraints =
-                    check_for_function_bool(&nnf_term, solver_state, true, ddsmt, lazy_dt);
-                proof_tracer.borrow_mut().push_steps(
-                    &additional_constraints,
-                    ProofStepType::TheoryClause(Theory::Background),
-                );
-                clauses.extend(additional_constraints);
-
-                // could activate bits here (the level should not be 0)
-                // activate_bits(&t, 0, egraph);
-
-                for clause in clauses {
-                    let instantiation = QuantifierInstance::Instantiation { clause };
-                    instantiations.push(instantiation); // TODO: I would prefer to push t.uid() here, but it seems like the uid is not getting adding to the terms list
-                }
-            }
+        for clause in clauses {
+            let instantiation = QuantifierInstance::Instantiation { clause };
+            instantiations.push(instantiation);
         }
     }
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* This implements lazy quantifier instantiation, where instead of learning a batch of quantifier instantiations at the same time, we learn quantifier instantiations one-at-a-time. However, if we did this naively, cadical would require a backtrack after every quantifier instantiation. Instead, we have to use the an experimental cadical feature "elevate", which exists in a branch. I created my own fork of cadical-sys that uses this branch and Sundance will have to use this for right now

This provides a *very* modest performance improvement, but will be super useful for adding other performance improvements on top of it, like term garbage collection and heuristics for exploring quantifier instantiation order. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
