### PR TITLE
Support unannotated existential quantifiers in positive position

### DIFF
--- a/src/quantifiers/quantifier.rs
+++ b/src/quantifiers/quantifier.rs
@@ -101,6 +101,10 @@ pub fn instantiate_quantifiers(
         }
 
         let triggers = &quantifier.triggers;
+        // Skip quantifiers with no triggers — nothing to match against
+        if triggers.is_empty() {
+            continue;
+        }
         // note we consider patterns in a multipattern conjunctively and multipatterns in a trigger disjunctively
         for multipattern in triggers {
             let body = quantifier.body;

--- a/src/quantifiers/quantifier.rs
+++ b/src/quantifiers/quantifier.rs
@@ -101,8 +101,11 @@ pub fn instantiate_quantifiers(
         }
 
         let triggers = &quantifier.triggers;
-        // Skip quantifiers with no triggers — nothing to match against
         if triggers.is_empty() {
+            debug_println!(
+                "Warning: quantifier {} reached instantiation with no triggers",
+                quantifier.id
+            );
             continue;
         }
         // note we consider patterns in a multipattern conjunctively and multipatterns in a trigger disjunctively

--- a/src/solver_state.rs
+++ b/src/solver_state.rs
@@ -61,22 +61,26 @@ fn get_subterms(term: &Term) -> (String, Vec<&Term>) {
         Let(_, _) => panic!("We should have inlined all Let bindings"),
         Matching(..) => todo!(),
         Forall(_, middle_term) | Exists(_, middle_term) => {
-            if let Annotated(inner_term, attrs) = middle_term.repr() {
-                let mut subterms = vec![inner_term];
-                for attr in attrs.iter() {
-                    if let Attribute::Pattern(s_exprs) = &attr {
-                        subterms.extend(s_exprs.iter());
+            let (inner_term, pattern_subterms) =
+                if let Annotated(inner_term, attrs) = middle_term.repr() {
+                    let mut patterns = vec![];
+                    for attr in attrs.iter() {
+                        if let Attribute::Pattern(s_exprs) = &attr {
+                            patterns.extend(s_exprs.iter());
+                        }
                     }
-                }
-                let name = if let Forall(..) = term.repr() {
-                    "forall".to_string()
+                    (inner_term, patterns)
                 } else {
-                    "exists".to_string()
+                    (middle_term, vec![])
                 };
-                (name, subterms)
+            let mut subterms = vec![inner_term];
+            subterms.extend(pattern_subterms);
+            let name = if let Forall(..) = term.repr() {
+                "forall".to_string()
             } else {
-                panic!("We have a forall/exists case that is not annotated");
-            }
+                "exists".to_string()
+            };
+            (name, subterms)
         }
         Constant(..) | Global(..) | Local(..) => ("".to_string(), vec![]),
     }
@@ -488,48 +492,49 @@ impl SolverState {
 
         // Quantifier registration
         if let Exists(sorted_vars, middle_term) | Forall(sorted_vars, middle_term) = term.repr() {
-            if let Annotated(inner_term, attrs) = middle_term.repr() {
-                // Store quantifier body in terms_list (needed for substitution during instantiation)
-                let body_uid = inner_term.uid();
-                while self.terms_list.len() <= body_uid as usize {
-                    self.terms_list
-                        .resize(self.terms_list.len() * 2, TermOption::None);
-                }
-                if self.terms_list[body_uid as usize].is_none() {
-                    self.terms_list[body_uid as usize] =
-                        TermOption::Uninitialized(inner_term.clone());
-                }
-
-                let mut trigger_ids = vec![];
-
-                for attr in attrs.iter() {
-                    if let Attribute::Pattern(s_exprs) = attr {
-                        let pattern_ids: Vec<crate::egraphs::repr::PatternId> =
-                            s_exprs.iter().map(|p| self.build_pattern(p)).collect();
-                        trigger_ids.push(pattern_ids);
+            let (inner_term, trigger_ids) =
+                if let Annotated(inner_term, attrs) = middle_term.repr() {
+                    let mut trigger_ids = vec![];
+                    for attr in attrs.iter() {
+                        if let Attribute::Pattern(s_exprs) = attr {
+                            let pattern_ids: Vec<crate::egraphs::repr::PatternId> =
+                                s_exprs.iter().map(|p| self.build_pattern(p)).collect();
+                            trigger_ids.push(pattern_ids);
+                        }
                     }
-                }
-
-                let variables: Vec<String> = sorted_vars.iter().map(|x| x.0.to_string()).collect();
-
-                let polarity = if let Forall(..) = term.repr() {
-                    Polarity::Universal
+                    (inner_term, trigger_ids)
                 } else {
-                    Polarity::Existential
+                    // Unannotated quantifier (no triggers) — will be skolemized on assignment
+                    (middle_term, vec![])
                 };
 
-                self.quantifiers.push(Quantifier {
-                    triggers: trigger_ids,
-                    variables,
-                    body: inner_term.uid(),
-                    id: term.uid(),
-                    guard,
-                    polarity,
-                    skolemized: false,
-                });
-            } else {
-                panic!("Quantifier {} does not have an annotation", term);
+            // Store quantifier body in terms_list (needed for substitution during instantiation)
+            let body_uid = inner_term.uid();
+            while self.terms_list.len() <= body_uid as usize {
+                self.terms_list
+                    .resize(self.terms_list.len() * 2, TermOption::None);
             }
+            if self.terms_list[body_uid as usize].is_none() {
+                self.terms_list[body_uid as usize] = TermOption::Uninitialized(inner_term.clone());
+            }
+
+            let variables: Vec<String> = sorted_vars.iter().map(|x| x.0.to_string()).collect();
+
+            let polarity = if let Forall(..) = term.repr() {
+                Polarity::Universal
+            } else {
+                Polarity::Existential
+            };
+
+            self.quantifiers.push(Quantifier {
+                triggers: trigger_ids,
+                variables,
+                body: inner_term.uid(),
+                id: term.uid(),
+                guard,
+                polarity,
+                skolemized: false,
+            });
         }
     }
 }

--- a/src/solver_state.rs
+++ b/src/solver_state.rs
@@ -70,6 +70,8 @@ fn get_subterms(term: &Term) -> (String, Vec<&Term>) {
                         }
                     }
                     (inner_term, patterns)
+                } else if let Forall(..) = term.repr() {
+                    panic!("Unannotated forall quantifier (no triggers): {term}")
                 } else {
                     (middle_term, vec![])
                 };
@@ -503,8 +505,10 @@ impl SolverState {
                     }
                 }
                 (inner_term, trigger_ids)
+            } else if let Forall(..) = term.repr() {
+                panic!("Unannotated forall quantifier (no triggers): {term}")
             } else {
-                // Unannotated quantifier (no triggers) — will be skolemized on assignment
+                // Unannotated existential (no triggers) — will be skolemized on assignment
                 (middle_term, vec![])
             };
 

--- a/src/solver_state.rs
+++ b/src/solver_state.rs
@@ -492,21 +492,21 @@ impl SolverState {
 
         // Quantifier registration
         if let Exists(sorted_vars, middle_term) | Forall(sorted_vars, middle_term) = term.repr() {
-            let (inner_term, trigger_ids) =
-                if let Annotated(inner_term, attrs) = middle_term.repr() {
-                    let mut trigger_ids = vec![];
-                    for attr in attrs.iter() {
-                        if let Attribute::Pattern(s_exprs) = attr {
-                            let pattern_ids: Vec<crate::egraphs::repr::PatternId> =
-                                s_exprs.iter().map(|p| self.build_pattern(p)).collect();
-                            trigger_ids.push(pattern_ids);
-                        }
+            let (inner_term, trigger_ids) = if let Annotated(inner_term, attrs) = middle_term.repr()
+            {
+                let mut trigger_ids = vec![];
+                for attr in attrs.iter() {
+                    if let Attribute::Pattern(s_exprs) = attr {
+                        let pattern_ids: Vec<crate::egraphs::repr::PatternId> =
+                            s_exprs.iter().map(|p| self.build_pattern(p)).collect();
+                        trigger_ids.push(pattern_ids);
                     }
-                    (inner_term, trigger_ids)
-                } else {
-                    // Unannotated quantifier (no triggers) — will be skolemized on assignment
-                    (middle_term, vec![])
-                };
+                }
+                (inner_term, trigger_ids)
+            } else {
+                // Unannotated quantifier (no triggers) — will be skolemized on assignment
+                (middle_term, vec![])
+            };
 
             // Store quantifier body in terms_list (needed for substitution during instantiation)
             let body_uid = inner_term.uid();

--- a/tests/regression/expected_results.json
+++ b/tests/regression/expected_results.json
@@ -197,6 +197,7 @@
     "skolemization/skolem-unioneclass5.smt2": "unsat",
     "skolemization/existsexists.smt2": "unsat",
     "skolemization/existsforall.smt2": "unsat",
+    "skolemization/skolem-unannotated-exists.smt2": "unsat",
     "TypeSafe/z3.1184131.smt2": "unsat",
     "TypeSafe/z3.1184147.smt2": "unsat",
     "TypeSafe/z3.1184163.smt2": "unsat",

--- a/tests/regression/smt_files/skolemization/skolem-unannotated-exists.smt2
+++ b/tests/regression/smt_files/skolemization/skolem-unannotated-exists.smt2
@@ -1,0 +1,6 @@
+(set-logic ALL)
+(declare-sort T 0)
+(declare-fun f (T) Bool)
+(assert (exists ((x T)) (f x)))
+(assert (forall ((y T)) (! (not (f y)) :pattern ((f y)))))
+(check-sat)


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* Existentials without :pattern annotations (e.g., Verus fuel witnesses like `(exists ((fuel% Fuel)) (= fuel_nat%... (succ fuel%)))`) previously caused a panic because the code assumed all quantifier bodies were wrapped in `Annotated(...)`. Now we handle unannotated quantifiers by registering them with an empty trigger list — they still get skolemized correctly when their literal is assigned.

We went from 47-> 18 other results, although all but 3 of these ended up becoming timeouts.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
