### PR TITLE
Lazy nelson oppen (probe version)

### DIFF
--- a/src/arithmetic/lialp.rs
+++ b/src/arithmetic/lialp.rs
@@ -17,7 +17,7 @@ use crate::debug_println;
 use crate::egraphs::EgraphTrait;
 use crate::solver_state::SolverState;
 use crate::utils::{DeterministicHashMap, DeterministicHashSet};
-use dashu::{Integer, Rational};
+use dashu::{Integer, Rational, integer::IBig};
 use std::collections::HashMap;
 
 pub fn check_integer_constraints_satisfiable_lia(
@@ -119,13 +119,12 @@ pub fn check_integer_constraints_satisfiable_lia(
             let stats = ret.stats;
             match ret.decision {
                 SolverDecision::FEASIBLE(assignment) => {
-                    let mut model_hashmap: DeterministicHashMap<i64, DeterministicHashSet<u64>> =
+                    let mut model_hashmap: DeterministicHashMap<IBig, DeterministicHashSet<u64>> =
                         DeterministicHashMap::new();
                     for (term_id, root_var) in &roots {
                         if let Some(value) = assignment.get(root_var) {
-                            let val_i64: i64 =
-                                value.to_int().value().try_into().unwrap_or(i64::MAX);
-                            model_hashmap.entry(val_i64).or_default().insert(*term_id);
+                            let val: IBig = value.to_int().value().clone();
+                            model_hashmap.entry(val).or_default().insert(*term_id);
                         }
                     }
                     ArithResult::Sat(model_hashmap, stats)

--- a/src/arithmetic/lp.rs
+++ b/src/arithmetic/lp.rs
@@ -59,7 +59,7 @@ impl fmt::Display for ArithSolverParseError {
 pub enum ArithResult {
     Unsat(Vec<i32>, LiaStats), // conflict clause
     Sat(
-        DeterministicHashMap<i64, DeterministicHashSet<u64>>,
+        DeterministicHashMap<IBig, DeterministicHashSet<u64>>,
         LiaStats,
     ), // literals that correspond to inequalities <= where the two terms are equal
     None,

--- a/src/arithmetic/nelsonoppen.rs
+++ b/src/arithmetic/nelsonoppen.rs
@@ -80,6 +80,42 @@ pub fn nelson_oppen_clause(literal: i32, solver_state: &mut SolverState) -> Opti
 //     }
 // }
 
+/// Build the three sub-terms (lt, gt, eq) for the trichotomy on (x, y).
+/// Returns None if the trichotomy has already been emitted for this pair.
+/// Marks the pair as emitted on the first successful call.
+pub fn nelson_oppen_trichotomy_terms(
+    x: u64,
+    y: u64,
+    solver_state: &mut SolverState,
+) -> Option<(Term, Term, Term)> {
+    if solver_state.nelson_oppen_ineq_literals.contains(&(x, y)) {
+        return None;
+    }
+    solver_state.nelson_oppen_ineq_literals.insert((x, y));
+
+    let bool_sort = solver_state.context.bool_sort();
+
+    let lt = QualifiedIdentifier::simple(solver_state.context.allocate_symbol("<"));
+    let lt_term = solver_state.context.app(
+        lt,
+        vec![solver_state.get_term(x), solver_state.get_term(y)],
+        Some(bool_sort.clone()),
+    );
+
+    let gt = QualifiedIdentifier::simple(solver_state.context.allocate_symbol(">"));
+    let gt_term = solver_state.context.app(
+        gt,
+        vec![solver_state.get_term(x), solver_state.get_term(y)],
+        Some(bool_sort),
+    );
+
+    let eq_term = solver_state
+        .context
+        .eq(solver_state.get_term(x), solver_state.get_term(y));
+
+    Some((lt_term, gt_term, eq_term))
+}
+
 // learn the clause x = y \/ x > y \/ x < y
 pub fn nelson_oppen_clause_pair(x: u64, y: u64, solver_state: &mut SolverState) -> Option<Term> {
     if solver_state.nelson_oppen_ineq_literals.contains(&(x, y)) {

--- a/src/arithmetic/nelsonoppen.rs
+++ b/src/arithmetic/nelsonoppen.rs
@@ -115,35 +115,3 @@ pub fn nelson_oppen_trichotomy_terms(
 
     Some((lt_term, gt_term, eq_term))
 }
-
-// learn the clause x = y \/ x > y \/ x < y
-pub fn nelson_oppen_clause_pair(x: u64, y: u64, solver_state: &mut SolverState) -> Option<Term> {
-    if solver_state.nelson_oppen_ineq_literals.contains(&(x, y)) {
-        return None;
-    }
-    solver_state.nelson_oppen_ineq_literals.insert((x, y));
-
-    let bool_sort = solver_state.context.bool_sort();
-
-    let lt = QualifiedIdentifier::simple(solver_state.context.allocate_symbol("<"));
-    let lt_term = solver_state.context.app(
-        lt,
-        vec![solver_state.get_term(x), solver_state.get_term(y)],
-        Some(bool_sort.clone()),
-    );
-
-    let gt = QualifiedIdentifier::simple(solver_state.context.allocate_symbol(">"));
-    let gt_term = solver_state.context.app(
-        gt,
-        vec![solver_state.get_term(x), solver_state.get_term(y)],
-        Some(bool_sort),
-    );
-
-    let eq_term = solver_state
-        .context
-        .eq(solver_state.get_term(x), solver_state.get_term(y));
-
-    let or = solver_state.context.or(vec![lt_term, gt_term, eq_term]);
-
-    Some(or)
-}

--- a/src/arithmetic/nelsonoppen.rs
+++ b/src/arithmetic/nelsonoppen.rs
@@ -2,83 +2,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::solver_state::SolverState;
-use yaspar_ir::ast::ATerm::*;
-use yaspar_ir::ast::FetchSort;
 use yaspar_ir::ast::{
-    ObjectAllocatorExt as _, Repr, StrAllocator, Term, TermAllocator, alg::QualifiedIdentifier,
+    ObjectAllocatorExt as _, StrAllocator, Term, TermAllocator, alg::QualifiedIdentifier,
 };
-
-pub fn nelson_oppen_clause(literal: i32, solver_state: &mut SolverState) -> Option<Term> {
-    let term = solver_state.get_term_from_lit(-literal);
-    match term.repr() {
-        Eq(x, y) => {
-            if x.get_sort(&mut solver_state.context).to_string() == "Int"
-                && y.get_sort(&mut solver_state.context).to_string() == "Int"
-            {
-                let bool_sort = solver_state.context.bool_sort();
-
-                let lt = QualifiedIdentifier::simple(solver_state.context.allocate_symbol("<"));
-                let lt_term = solver_state.context.app(
-                    lt,
-                    vec![x.clone(), y.clone()],
-                    Some(bool_sort.clone()),
-                );
-
-                let gt = QualifiedIdentifier::simple(solver_state.context.allocate_symbol(">"));
-                let gt_term =
-                    solver_state
-                        .context
-                        .app(gt, vec![x.clone(), y.clone()], Some(bool_sort));
-
-                let or = solver_state.context.or(vec![lt_term, gt_term, term]);
-
-                Some(or)
-            } else {
-                None
-            }
-        }
-        _ => None,
-    }
-}
-
-// pub fn nelson_oppen_clause_ineq(literal: i32, egraph: &mut Egraph) -> Option<Term> {
-//     let term = egraph.get_term_from_lit(-literal);
-//     // todo: sometimes literal can be in wrong polarity not sure why, but need to fix this
-//     let term_positive = if let Not(t) = term.repr() {t.clone()} else {term};
-//     match term_positive.repr() {
-//         App(f, terms, _) => {
-//             let f = f.to_string();
-//             assert!(f == "<" || f == ">" || f == ">=" || f == "<=");
-//             assert!(terms.len() == 2);
-//             let (x, y) = (&terms[0], &terms[1]);
-
-//             if egraph.nelson_oppen_ineq_literals.contains(&(x.uid(), y.uid())) {
-//                 return None
-//             }
-//             egraph.nelson_oppen_ineq_literals.insert((x.uid(), y.uid()));
-
-//             let bool_sort = egraph.context.bool_sort();
-
-//             let lt = QualifiedIdentifier::simple(egraph.context.allocate_symbol("<"));
-//             let lt_term = egraph.context.app(lt, vec![x.clone(), y.clone()], Some(bool_sort.clone()));
-
-//             let gt = QualifiedIdentifier::simple(egraph.context.allocate_symbol(">"));
-//             let gt_term = egraph.context.app(gt, vec![x.clone(), y.clone()], Some(bool_sort));
-
-//             let eq_term = egraph.context.eq(x.clone(), y.clone());
-
-//             let or = egraph.context.or(vec![lt_term, gt_term, eq_term]);
-
-//             // println!("(assert {or}) with lit {literal} and term {term_positive}");
-
-//             Some(or)
-
-//         },
-//         _ => {
-//             panic!("{} should be an inequality", term_positive);
-//         }
-//     }
-// }
 
 /// Build the three sub-terms (lt, gt, eq) for the trichotomy on (x, y).
 /// Returns None if the trichotomy has already been emitted for this pair.

--- a/src/arithmetic/z3lp.rs
+++ b/src/arithmetic/z3lp.rs
@@ -171,13 +171,25 @@ pub fn check_integer_constraints_satisfiable_z3(
             // Satisfiable - return None to indicate no conflict
             let model = solver.get_model().unwrap();
 
-            let mut model_hashmap: DeterministicHashMap<i64, DeterministicHashSet<u64>> =
+            let mut model_hashmap: DeterministicHashMap<IBig, DeterministicHashSet<u64>> =
                 DeterministicHashMap::new();
             for (var, value) in roots {
-                // todo: I think I can do this just for the roots I saved earlier
                 let model_val = model.eval(&value, true).unwrap();
-                let model_val_i64 = model_val.as_i64().unwrap_or(i64::MAX);
-                model_hashmap.entry(model_val_i64).or_default().insert(var);
+                let model_val_str = model_val.to_string();
+                let val: IBig = if model_val_str.starts_with("(- ") {
+                    let inner = &model_val_str[3..model_val_str.len() - 1];
+                    -inner.parse::<IBig>().unwrap_or_else(|e| {
+                        panic!(
+                            "Failed to parse Z3 model value inner '{}' from '{}': {}",
+                            inner, model_val_str, e
+                        )
+                    })
+                } else {
+                    model_val_str.parse::<IBig>().unwrap_or_else(|e| {
+                        panic!("Failed to parse Z3 model value '{}': {}", model_val_str, e)
+                    })
+                };
+                model_hashmap.entry(val).or_default().insert(var);
             }
             ArithResult::Sat(model_hashmap, LiaStats::new())
         }

--- a/src/cadical_propagator.rs
+++ b/src/cadical_propagator.rs
@@ -31,6 +31,8 @@ pub struct CustomExternalPropagator<'a> {
     pub arithmetic: ArithSolver, // whether we are doing arithmetic solving or not
     pub stats: SolverStats,
     pub pending: Option<PendingInstantiations>,
+    // TODO(nelson-oppen): used when we implement multi-conflict-per-round with budget
+    #[allow(dead_code)]
     pub trichotomies_per_round: usize,
 }
 
@@ -91,7 +93,6 @@ impl<'a> CustomExternalPropagator<'a> {
                 .insert_predecessor(&term_nnf, None, None, true);
             let term_cnf = term.cnf_tseitin(self.solver_state);
             for clause in term_cnf {
-                eprintln!("[TRICH] clause: {:?}", clause.0);
                 for lit in &clause.0 {
                     self.add_observed_variable(*lit);
                     self.add_lit_to_proof_tracer(*lit);
@@ -358,10 +359,6 @@ impl<'a> ExternalPropagator for CustomExternalPropagator<'a> {
         debug_println!(21, 0, "Starting arithmetic check",);
         self.stats.arith_checks += 1;
 
-        eprintln!("[cb_check_found_model] model contains 313? {} 314? {} 315? {}",
-            model.contains(&313) || model.contains(&-313),
-            model.contains(&314) || model.contains(&-314),
-            model.contains(&315) || model.contains(&-315));
         match check_integer_constraints_satisfiable(&self.arithmetic, model, self.solver_state) {
             ArithResult::Unsat(arithmetic_literals, arith_stats) => {
                 self.stats.arith.accumulate(&arith_stats);
@@ -383,10 +380,18 @@ impl<'a> ExternalPropagator for CustomExternalPropagator<'a> {
                 // emit trichotomy + conflict clauses for the involved pairs so CaDiCaL
                 // can force different eq/lt/gt choices. Always backtrack the probe merges
                 // so the egraph state stays consistent with the SAT trail.
+                // TODO(nelson-oppen): stop-at-first-conflict is simple but leaves
+                // information on the table. Consider collecting multiple conflicts per
+                // round and applying a trichotomies_per_round budget to bound work.
                 let probe_level = self.decision_level + 1;
-                let mut conflict_from_arith: Option<
-                    crate::egraphs::traits::Conflict<u32>,
-                > = None;
+                let mut conflict_from_arith: Option<crate::egraphs::traits::Conflict<u32>> = None;
+                // Map from canonical (egraph_id, egraph_id) pair -> (solver_uid, solver_uid)
+                // so we can look up probe pairs by egraph representation while emitting
+                // trichotomies with solver UIDs.
+                let mut probe_merged_pairs: DeterministicHashSet<(u32, u32)> =
+                    DeterministicHashSet::default();
+                let mut probe_pair_uids: std::collections::HashMap<(u32, u32), (u64, u64)> =
+                    std::collections::HashMap::new();
 
                 'outer: for set in literals.values() {
                     let mut t = set.iter();
@@ -400,16 +405,14 @@ impl<'a> ExternalPropagator for CustomExternalPropagator<'a> {
                         };
                         let x_e = self.solver_state.to_egraph_id(x);
                         let y_e = self.solver_state.to_egraph_id(y);
-                        if self.solver_state.egraph.find(x_e)
-                            == self.solver_state.egraph.find(y_e)
+                        if self.solver_state.egraph.find(x_e) == self.solver_state.egraph.find(y_e)
                         {
                             continue;
                         }
-                        let result = self.solver_state.egraph.assert_equal(
-                            x_e,
-                            y_e,
-                            probe_level,
-                        );
+                        let (lo_e, hi_e) = if x_e < y_e { (x_e, y_e) } else { (y_e, x_e) };
+                        probe_merged_pairs.insert((lo_e, hi_e));
+                        probe_pair_uids.insert((lo_e, hi_e), (x, y));
+                        let result = self.solver_state.egraph.assert_equal(x_e, y_e, probe_level);
                         if let Some(c) = result.conflict {
                             conflict_from_arith = Some(c);
                             break 'outer;
@@ -418,19 +421,15 @@ impl<'a> ExternalPropagator for CustomExternalPropagator<'a> {
                 }
 
                 if let Some(conflict) = conflict_from_arith {
-                    eprintln!("[ARITH PROBE] conflict.equalities={:?}, diseq_lit={:?}, disequality={:?}",
-                        conflict.equalities, conflict.diseq_lit, conflict.disequality);
-                    // Emit trichotomies for pairs in the conflict path (bounded by budget)
-                    let mut emitted = 0;
+                    // Emit trichotomies for probe-merged pairs that appear in the
+                    // conflict proof path. This registers the eq/lt/gt SAT literals
+                    // so make_eq below can find eq(x,y) for each pair.
                     for &(a, b) in &conflict.equalities {
-                        if emitted >= self.trichotomies_per_round {
-                            break;
+                        let (lo_e, hi_e) = if a < b { (a, b) } else { (b, a) };
+                        if probe_merged_pairs.contains(&(lo_e, hi_e)) {
+                            let (x_uid, y_uid) = probe_pair_uids[&(lo_e, hi_e)];
+                            self.emit_trichotomy_for_pair(x_uid, y_uid);
                         }
-                        let sa = self.solver_state.to_solver_uid(a);
-                        let sb = self.solver_state.to_solver_uid(b);
-                        let (lo, hi) = if sa < sb { (sa, sb) } else { (sb, sa) };
-                        self.emit_trichotomy_for_pair(lo, hi);
-                        emitted += 1;
                     }
 
                     // Build the blocking conflict clause: negation of the equalities
@@ -443,12 +442,6 @@ impl<'a> ExternalPropagator for CustomExternalPropagator<'a> {
                     if let Some(lit) = conflict.diseq_lit {
                         conflict_clause.push(-lit);
                     }
-                    eprintln!("[ARITH PROBE CONFLICT] clause={:?}, a[312]={} a[313]={} a[314]={} a[315]={}",
-                        conflict_clause,
-                        self.assignments.get(312).copied().unwrap_or(0),
-                        self.assignments.get(313).copied().unwrap_or(0),
-                        self.assignments.get(314).copied().unwrap_or(0),
-                        self.assignments.get(315).copied().unwrap_or(0));
                     for lit in &conflict_clause {
                         self.add_observed_variable(*lit);
                         self.add_lit_to_proof_tracer(*lit);

--- a/src/cadical_propagator.rs
+++ b/src/cadical_propagator.rs
@@ -5,6 +5,7 @@ use crate::arithmetic::lp::{ArithResult, ArithSolver, check_integer_constraints_
 use crate::arithmetic::nelsonoppen::nelson_oppen_trichotomy_terms;
 use crate::debug_println;
 use crate::egraphs::EgraphTrait;
+use crate::egraphs::traits::Conflict;
 use crate::log::is_important;
 use crate::proof::{SMTProofTracer, Theory};
 use crate::quantifiers::quantifier::QuantifierInstance::{Instantiation, Skolemization};
@@ -86,6 +87,12 @@ impl<'a> CustomExternalPropagator<'a> {
     /// Emit trichotomy clause (x<y ∨ x>y ∨ x=y) for a pair of solver-uid terms
     /// as a raw 3-literal disjunction (no Tseitin OR-gate). Registers the fresh
     /// lt/gt/eq literals as observed. No-op if the pair was already emitted.
+    ///
+    /// The `from_quantifier: true` flag on `insert_predecessor` (which becomes
+    /// `dynamic: true` on `register_term`) is *not* about quantifiers here — it
+    /// tells the egraph to find and merge with existing congruent terms, which
+    /// is what we want since these lt/gt/eq atoms may already exist in the
+    /// egraph from other sources.
     fn emit_trichotomy_for_pair(&mut self, x: u64, y: u64) {
         if let Some((lt_term, gt_term, eq_term)) =
             nelson_oppen_trichotomy_terms(x, y, self.solver_state)
@@ -381,6 +388,10 @@ impl<'a> ExternalPropagator for CustomExternalPropagator<'a> {
             }
             ArithResult::Sat(literals, arith_stats) => {
                 self.stats.arith.accumulate(&arith_stats);
+                assert!(
+                    self.max_arith_conflicts_per_round > 0,
+                    "max_arith_conflicts_per_round must be > 0"
+                );
                 // Model-based Nelson-Oppen probe: try to merge every pair of
                 // equal-model-value terms. Each merge gets its own fake decision
                 // level so a conflicting merge can be undone individually while
@@ -388,8 +399,8 @@ impl<'a> ExternalPropagator for CustomExternalPropagator<'a> {
                 // found this round, then backtrack the entire probe stack.
                 let base_level = self.decision_level;
                 let mut next_probe_level = base_level + 1;
-                let mut conflicts: Vec<crate::egraphs::traits::Conflict<u32>> = Vec::new();
-                // Canonical (egraph_id, egraph_id) pair -> (solver_uid, solver_uid).
+                let mut conflicts: Vec<Conflict<u32>> = Vec::new();
+                // Canonical (egraph_root, egraph_root) pair -> (solver_uid, solver_uid).
                 // Presence of a key = "we probe-merged this pair this round".
                 let mut probe_pair_uids: DeterministicHashMap<(u32, u32), (u64, u64)> =
                     DeterministicHashMap::default();
@@ -403,20 +414,25 @@ impl<'a> ExternalPropagator for CustomExternalPropagator<'a> {
                         } else {
                             (*term, *first)
                         };
-                        let x_e = self.solver_state.to_egraph_id(x);
-                        let y_e = self.solver_state.to_egraph_id(y);
-                        if self.solver_state.egraph.find(x_e) == self.solver_state.egraph.find(y_e)
+                        let x_root = self.solver_state.to_egraph_id(x);
+                        let y_root = self.solver_state.to_egraph_id(y);
+                        if self.solver_state.egraph.find(x_root)
+                            == self.solver_state.egraph.find(y_root)
                         {
                             continue;
                         }
-                        let (lo_e, hi_e) = if x_e < y_e { (x_e, y_e) } else { (y_e, x_e) };
-                        probe_pair_uids.insert((lo_e, hi_e), (x, y));
+                        let (lo_root, hi_root) = if x_root < y_root {
+                            (x_root, y_root)
+                        } else {
+                            (y_root, x_root)
+                        };
+                        probe_pair_uids.insert((lo_root, hi_root), (x, y));
                         let attempt_level = next_probe_level;
                         next_probe_level += 1;
-                        let result = self
-                            .solver_state
-                            .egraph
-                            .assert_equal(x_e, y_e, attempt_level);
+                        let result =
+                            self.solver_state
+                                .egraph
+                                .assert_equal(x_root, y_root, attempt_level);
                         if let Some(c) = result.conflict {
                             // Undo just this conflicting merge; keep earlier merges.
                             self.solver_state.egraph.backtrack_to(attempt_level - 1);
@@ -435,8 +451,8 @@ impl<'a> ExternalPropagator for CustomExternalPropagator<'a> {
                     // trichotomy has NOT already been emitted. Other probe-merge pairs
                     // fall back on make_eq allocating a bare eq literal.
                     let fresh_probe_pair = conflict.equalities.iter().rev().find_map(|&(a, b)| {
-                        let (lo_e, hi_e) = if a < b { (a, b) } else { (b, a) };
-                        let (x_uid, y_uid) = *probe_pair_uids.get(&(lo_e, hi_e))?;
+                        let (lo_root, hi_root) = if a < b { (a, b) } else { (b, a) };
+                        let (x_uid, y_uid) = *probe_pair_uids.get(&(lo_root, hi_root))?;
                         if self
                             .solver_state
                             .nelson_oppen_ineq_literals

--- a/src/cadical_propagator.rs
+++ b/src/cadical_propagator.rs
@@ -13,7 +13,7 @@ use crate::quantifiers::quantifier::{
 };
 use crate::solver_state::{SolverState, process_assignment};
 use crate::stats::SolverStats;
-use crate::utils::DeterministicHashSet;
+use crate::utils::{DeterministicHashMap, DeterministicHashSet};
 use cadical_sys::{CaDiCal, ExternalPropagator};
 use std::cell::RefCell;
 use std::rc::Rc;
@@ -32,7 +32,7 @@ pub struct CustomExternalPropagator<'a> {
     pub pending: Option<PendingInstantiations>,
     /// Max number of arithmetic-model conflicts to collect per cb_check_found_model call.
     /// Once reached, stop probing further pairs even if unprobed pairs remain.
-    pub trichotomies_per_round: usize,
+    pub max_arith_conflicts_per_round: usize,
 }
 
 impl<'a> CustomExternalPropagator<'a> {
@@ -389,11 +389,10 @@ impl<'a> ExternalPropagator for CustomExternalPropagator<'a> {
                 let base_level = self.decision_level;
                 let mut next_probe_level = base_level + 1;
                 let mut conflicts: Vec<crate::egraphs::traits::Conflict<u32>> = Vec::new();
-                // Map from canonical (egraph_id, egraph_id) pair -> (solver_uid, solver_uid)
-                let mut probe_merged_pairs: DeterministicHashSet<(u32, u32)> =
-                    DeterministicHashSet::default();
-                let mut probe_pair_uids: std::collections::HashMap<(u32, u32), (u64, u64)> =
-                    std::collections::HashMap::new();
+                // Canonical (egraph_id, egraph_id) pair -> (solver_uid, solver_uid).
+                // Presence of a key = "we probe-merged this pair this round".
+                let mut probe_pair_uids: DeterministicHashMap<(u32, u32), (u64, u64)> =
+                    DeterministicHashMap::default();
 
                 'outer: for set in literals.values() {
                     let mut t = set.iter();
@@ -411,7 +410,6 @@ impl<'a> ExternalPropagator for CustomExternalPropagator<'a> {
                             continue;
                         }
                         let (lo_e, hi_e) = if x_e < y_e { (x_e, y_e) } else { (y_e, x_e) };
-                        probe_merged_pairs.insert((lo_e, hi_e));
                         probe_pair_uids.insert((lo_e, hi_e), (x, y));
                         let attempt_level = next_probe_level;
                         next_probe_level += 1;
@@ -424,7 +422,7 @@ impl<'a> ExternalPropagator for CustomExternalPropagator<'a> {
                             self.solver_state.egraph.backtrack_to(attempt_level - 1);
                             next_probe_level = attempt_level;
                             conflicts.push(c);
-                            if conflicts.len() >= self.trichotomies_per_round {
+                            if conflicts.len() >= self.max_arith_conflicts_per_round {
                                 break 'outer;
                             }
                         }
@@ -438,10 +436,7 @@ impl<'a> ExternalPropagator for CustomExternalPropagator<'a> {
                     // fall back on make_eq allocating a bare eq literal.
                     let fresh_probe_pair = conflict.equalities.iter().rev().find_map(|&(a, b)| {
                         let (lo_e, hi_e) = if a < b { (a, b) } else { (b, a) };
-                        if !probe_merged_pairs.contains(&(lo_e, hi_e)) {
-                            return None;
-                        }
-                        let (x_uid, y_uid) = probe_pair_uids[&(lo_e, hi_e)];
+                        let (x_uid, y_uid) = *probe_pair_uids.get(&(lo_e, hi_e))?;
                         if self
                             .solver_state
                             .nelson_oppen_ineq_literals

--- a/src/cadical_propagator.rs
+++ b/src/cadical_propagator.rs
@@ -2,8 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::arithmetic::lp::{ArithResult, ArithSolver, check_integer_constraints_satisfiable};
-use crate::arithmetic::nelsonoppen::nelson_oppen_clause_pair;
-use crate::cnf::CNFConversion as _;
+use crate::arithmetic::nelsonoppen::nelson_oppen_trichotomy_terms;
 use crate::debug_println;
 use crate::egraphs::EgraphTrait;
 use crate::log::is_important;
@@ -31,8 +30,8 @@ pub struct CustomExternalPropagator<'a> {
     pub arithmetic: ArithSolver, // whether we are doing arithmetic solving or not
     pub stats: SolverStats,
     pub pending: Option<PendingInstantiations>,
-    // TODO(nelson-oppen): used when we implement multi-conflict-per-round with budget
-    #[allow(dead_code)]
+    /// Max number of arithmetic-model conflicts to collect per cb_check_found_model call.
+    /// Once reached, stop probing further pairs even if unprobed pairs remain.
     pub trichotomies_per_round: usize,
 }
 
@@ -87,18 +86,39 @@ impl<'a> CustomExternalPropagator<'a> {
     /// Emit trichotomy clauses (x=y ∨ x<y ∨ x>y) for a pair of solver-uid terms.
     /// Registers the fresh eq/lt/gt literals as observed variables.
     fn emit_trichotomy_for_pair(&mut self, x: u64, y: u64) {
-        if let Some(term) = nelson_oppen_clause_pair(x, y, self.solver_state) {
-            let term_nnf = term.nnf(self.solver_state);
-            self.solver_state
-                .insert_predecessor(&term_nnf, None, None, true);
-            let term_cnf = term.cnf_tseitin(self.solver_state);
-            for clause in term_cnf {
-                for lit in &clause.0 {
-                    self.add_observed_variable(*lit);
-                    self.add_lit_to_proof_tracer(*lit);
-                }
-                self.disequalities.borrow_mut().push(clause.0.clone());
+        if let Some((lt_term, gt_term, eq_term)) =
+            nelson_oppen_trichotomy_terms(x, y, self.solver_state)
+        {
+            // eprintln!(
+            //     "[TRICHOTOMY] for pair ({}, {}) i.e. ({}, {})",
+            //     x,
+            //     y,
+            //     self.solver_state.get_term(x),
+            //     self.solver_state.get_term(y)
+            // );
+            self.solver_state.insert_predecessor(&lt_term, None, None, true);
+            self.solver_state.insert_predecessor(&gt_term, None, None, true);
+            self.solver_state.insert_predecessor(&eq_term, None, None, true);
+            let lt_lit = self.solver_state.get_or_allocate_lit_for_term(&lt_term);
+            let gt_lit = self.solver_state.get_or_allocate_lit_for_term(&gt_term);
+            let eq_lit = self.solver_state.get_or_allocate_lit_for_term(&eq_term);
+            let clause = vec![lt_lit, gt_lit, eq_lit];
+            // eprintln!("  clause: [");
+            // for &lit in &clause {
+            //     eprintln!(
+            //         "    {}[{}],",
+            //         lit,
+            //         self.solver_state.get_term_from_lit(lit)
+            //     );
+            // }
+            // eprintln!("  ]");
+            for lit in &clause {
+                self.add_observed_variable(*lit);
+                self.add_lit_to_proof_tracer(*lit);
             }
+            self.disequalities.borrow_mut().push(clause);
+        } else {
+            // eprintln!("[TRICHOTOMY] SKIPPED (already emitted) for pair ({}, {})", x, y);
         }
     }
 
@@ -375,19 +395,15 @@ impl<'a> ExternalPropagator for CustomExternalPropagator<'a> {
             }
             ArithResult::Sat(literals, arith_stats) => {
                 self.stats.arith.accumulate(&arith_stats);
-                // Model-based Nelson-Oppen probe: hypothetically merge equal-model-value
-                // pairs in the egraph at a fake decision level. If an EUF conflict fires,
-                // emit trichotomy + conflict clauses for the involved pairs so CaDiCaL
-                // can force different eq/lt/gt choices. Always backtrack the probe merges
-                // so the egraph state stays consistent with the SAT trail.
-                // TODO(nelson-oppen): stop-at-first-conflict is simple but leaves
-                // information on the table. Consider collecting multiple conflicts per
-                // round and applying a trichotomies_per_round budget to bound work.
-                let probe_level = self.decision_level + 1;
-                let mut conflict_from_arith: Option<crate::egraphs::traits::Conflict<u32>> = None;
+                // Model-based Nelson-Oppen probe: try to merge every pair of
+                // equal-model-value terms. Each merge gets its own fake decision
+                // level so a conflicting merge can be undone individually while
+                // successful earlier merges stay in place. Collect all conflicts
+                // found this round, then backtrack the entire probe stack.
+                let base_level = self.decision_level;
+                let mut next_probe_level = base_level + 1;
+                let mut conflicts: Vec<crate::egraphs::traits::Conflict<u32>> = Vec::new();
                 // Map from canonical (egraph_id, egraph_id) pair -> (solver_uid, solver_uid)
-                // so we can look up probe pairs by egraph representation while emitting
-                // trichotomies with solver UIDs.
                 let mut probe_merged_pairs: DeterministicHashSet<(u32, u32)> =
                     DeterministicHashSet::default();
                 let mut probe_pair_uids: std::collections::HashMap<(u32, u32), (u64, u64)> =
@@ -396,7 +412,6 @@ impl<'a> ExternalPropagator for CustomExternalPropagator<'a> {
                 'outer: for set in literals.values() {
                     let mut t = set.iter();
                     let first = t.next().unwrap();
-
                     for term in t {
                         let (x, y) = if first < term {
                             (*first, *term)
@@ -412,28 +427,82 @@ impl<'a> ExternalPropagator for CustomExternalPropagator<'a> {
                         let (lo_e, hi_e) = if x_e < y_e { (x_e, y_e) } else { (y_e, x_e) };
                         probe_merged_pairs.insert((lo_e, hi_e));
                         probe_pair_uids.insert((lo_e, hi_e), (x, y));
-                        let result = self.solver_state.egraph.assert_equal(x_e, y_e, probe_level);
+                        let attempt_level = next_probe_level;
+                        next_probe_level += 1;
+                        let result =
+                            self.solver_state.egraph.assert_equal(x_e, y_e, attempt_level);
                         if let Some(c) = result.conflict {
-                            conflict_from_arith = Some(c);
-                            break 'outer;
+                            // Undo just this conflicting merge; keep earlier merges.
+                            self.solver_state.egraph.backtrack_to(attempt_level - 1);
+                            next_probe_level = attempt_level;
+                            conflicts.push(c);
+                            if conflicts.len() >= self.trichotomies_per_round {
+                                break 'outer;
+                            }
                         }
                     }
                 }
 
-                if let Some(conflict) = conflict_from_arith {
-                    // Emit trichotomies for probe-merged pairs that appear in the
-                    // conflict proof path. This registers the eq/lt/gt SAT literals
-                    // so make_eq below can find eq(x,y) for each pair.
-                    for &(a, b) in &conflict.equalities {
-                        let (lo_e, hi_e) = if a < b { (a, b) } else { (b, a) };
-                        if probe_merged_pairs.contains(&(lo_e, hi_e)) {
-                            let (x_uid, y_uid) = probe_pair_uids[&(lo_e, hi_e)];
-                            self.emit_trichotomy_for_pair(x_uid, y_uid);
+                // eprintln!(
+                //     "[ARITH PROBE] found {} conflict(s) this round",
+                //     conflicts.len()
+                // );
+
+                for (_i, conflict) in conflicts.iter().enumerate() {
+                    // let (d0, d1) = conflict.disequality;
+                    // let sd0 = self.solver_state.to_solver_uid(d0);
+                    // let sd1 = self.solver_state.to_solver_uid(d1);
+                    // eprintln!(
+                    //     "[CONFLICT #{}] disequality {}!={} i.e. {}!={} (diseq_lit={:?})",
+                    //     _i,
+                    //     d0,
+                    //     d1,
+                    //     self.solver_state.get_term(sd0),
+                    //     self.solver_state.get_term(sd1),
+                    //     conflict.diseq_lit,
+                    // );
+                    // eprintln!("  proof path equalities: [");
+                    // for (a, b) in &conflict.equalities {
+                    //     let sa = self.solver_state.to_solver_uid(*a);
+                    //     let sb = self.solver_state.to_solver_uid(*b);
+                    //     eprintln!(
+                    //         "    ({}={}) i.e. ({} = {}),",
+                    //         a,
+                    //         b,
+                    //         self.solver_state.get_term(sa),
+                    //         self.solver_state.get_term(sb),
+                    //     );
+                    // }
+                    // eprintln!("  ]");
+
+                    // Emit up to two trichotomies per conflict — walking backward
+                    // through the proof path, pick the last two probe-merged pairs
+                    // whose trichotomies have NOT already been emitted. Other
+                    // probe-merge pairs fall back on make_eq allocating a bare eq lit.
+                    const TRICHOTOMIES_PER_CONFLICT: usize = 2;
+                    let mut fresh_probe_pairs: Vec<(u64, u64)> = Vec::new();
+                    for &(a, b) in conflict.equalities.iter().rev() {
+                        if fresh_probe_pairs.len() >= TRICHOTOMIES_PER_CONFLICT {
+                            break;
                         }
+                        let (lo_e, hi_e) = if a < b { (a, b) } else { (b, a) };
+                        if !probe_merged_pairs.contains(&(lo_e, hi_e)) {
+                            continue;
+                        }
+                        let (x_uid, y_uid) = probe_pair_uids[&(lo_e, hi_e)];
+                        if self
+                            .solver_state
+                            .nelson_oppen_ineq_literals
+                            .contains(&(x_uid, y_uid))
+                        {
+                            continue;
+                        }
+                        fresh_probe_pairs.push((x_uid, y_uid));
+                    }
+                    for (x_uid, y_uid) in fresh_probe_pairs {
+                        self.emit_trichotomy_for_pair(x_uid, y_uid);
                     }
 
-                    // Build the blocking conflict clause: negation of the equalities
-                    // that formed the proof path + negated diseq_lit.
                     let mut conflict_clause: Vec<i32> = conflict
                         .equalities
                         .iter()
@@ -442,6 +511,17 @@ impl<'a> ExternalPropagator for CustomExternalPropagator<'a> {
                     if let Some(lit) = conflict.diseq_lit {
                         conflict_clause.push(-lit);
                     }
+
+                    // eprintln!("  conflict clause: [");
+                    // for &lit in &conflict_clause {
+                    //     eprintln!(
+                    //         "    {}[{}],",
+                    //         lit,
+                    //         self.solver_state.get_term_from_lit(lit)
+                    //     );
+                    // }
+                    // eprintln!("  ]");
+
                     for lit in &conflict_clause {
                         self.add_observed_variable(*lit);
                         self.add_lit_to_proof_tracer(*lit);
@@ -449,8 +529,8 @@ impl<'a> ExternalPropagator for CustomExternalPropagator<'a> {
                     self.disequalities.borrow_mut().push(conflict_clause);
                 }
 
-                // Always undo probe merges — they only live inside this call.
-                self.solver_state.egraph.backtrack_to(self.decision_level);
+                // Undo all remaining successful probe merges.
+                self.solver_state.egraph.backtrack_to(base_level);
             }
             ArithResult::None => {}
         }

--- a/src/cadical_propagator.rs
+++ b/src/cadical_propagator.rs
@@ -31,6 +31,7 @@ pub struct CustomExternalPropagator<'a> {
     pub arithmetic: ArithSolver, // whether we are doing arithmetic solving or not
     pub stats: SolverStats,
     pub pending: Option<PendingInstantiations>,
+    pub trichotomies_per_round: usize,
 }
 
 impl<'a> CustomExternalPropagator<'a> {
@@ -78,6 +79,25 @@ impl<'a> CustomExternalPropagator<'a> {
         );
         unsafe {
             (*self.solver).add_observed_var(abs_lit);
+        }
+    }
+
+    /// Emit trichotomy clauses (x=y ∨ x<y ∨ x>y) for a pair of solver-uid terms.
+    /// Registers the fresh eq/lt/gt literals as observed variables.
+    fn emit_trichotomy_for_pair(&mut self, x: u64, y: u64) {
+        if let Some(term) = nelson_oppen_clause_pair(x, y, self.solver_state) {
+            let term_nnf = term.nnf(self.solver_state);
+            self.solver_state
+                .insert_predecessor(&term_nnf, None, None, true);
+            let term_cnf = term.cnf_tseitin(self.solver_state);
+            for clause in term_cnf {
+                eprintln!("[TRICH] clause: {:?}", clause.0);
+                for lit in &clause.0 {
+                    self.add_observed_variable(*lit);
+                    self.add_lit_to_proof_tracer(*lit);
+                }
+                self.disequalities.borrow_mut().push(clause.0.clone());
+            }
         }
     }
 
@@ -338,6 +358,10 @@ impl<'a> ExternalPropagator for CustomExternalPropagator<'a> {
         debug_println!(21, 0, "Starting arithmetic check",);
         self.stats.arith_checks += 1;
 
+        eprintln!("[cb_check_found_model] model contains 313? {} 314? {} 315? {}",
+            model.contains(&313) || model.contains(&-313),
+            model.contains(&314) || model.contains(&-314),
+            model.contains(&315) || model.contains(&-315));
         match check_integer_constraints_satisfiable(&self.arithmetic, model, self.solver_state) {
             ArithResult::Unsat(arithmetic_literals, arith_stats) => {
                 self.stats.arith.accumulate(&arith_stats);
@@ -354,35 +378,86 @@ impl<'a> ExternalPropagator for CustomExternalPropagator<'a> {
             }
             ArithResult::Sat(literals, arith_stats) => {
                 self.stats.arith.accumulate(&arith_stats);
-                for set in literals.values() {
+                // Model-based Nelson-Oppen probe: hypothetically merge equal-model-value
+                // pairs in the egraph at a fake decision level. If an EUF conflict fires,
+                // emit trichotomy + conflict clauses for the involved pairs so CaDiCaL
+                // can force different eq/lt/gt choices. Always backtrack the probe merges
+                // so the egraph state stays consistent with the SAT trail.
+                let probe_level = self.decision_level + 1;
+                let mut conflict_from_arith: Option<
+                    crate::egraphs::traits::Conflict<u32>,
+                > = None;
+
+                'outer: for set in literals.values() {
                     let mut t = set.iter();
                     let first = t.next().unwrap();
 
                     for term in t {
-                        let pair = if first < term {
-                            (first, term)
+                        let (x, y) = if first < term {
+                            (*first, *term)
                         } else {
-                            (term, first)
+                            (*term, *first)
                         };
-
-                        if let Some(term) =
-                            nelson_oppen_clause_pair(*pair.0, *pair.1, self.solver_state)
+                        let x_e = self.solver_state.to_egraph_id(x);
+                        let y_e = self.solver_state.to_egraph_id(y);
+                        if self.solver_state.egraph.find(x_e)
+                            == self.solver_state.egraph.find(y_e)
                         {
-                            debug_println!(25, 0, "adding in the nelson oppen term {}", term);
-                            let term_nnf = term.nnf(self.solver_state);
-                            self.solver_state
-                                .insert_predecessor(&term_nnf, None, None, true);
-                            let term_cnf = term.cnf_tseitin(self.solver_state);
-                            for clause in term_cnf {
-                                for lit in &clause.0 {
-                                    self.add_observed_variable(*lit);
-                                    self.add_lit_to_proof_tracer(*lit);
-                                }
-                                self.disequalities.borrow_mut().push(clause.0.clone());
-                            }
+                            continue;
+                        }
+                        let result = self.solver_state.egraph.assert_equal(
+                            x_e,
+                            y_e,
+                            probe_level,
+                        );
+                        if let Some(c) = result.conflict {
+                            conflict_from_arith = Some(c);
+                            break 'outer;
                         }
                     }
                 }
+
+                if let Some(conflict) = conflict_from_arith {
+                    eprintln!("[ARITH PROBE] conflict.equalities={:?}, diseq_lit={:?}, disequality={:?}",
+                        conflict.equalities, conflict.diseq_lit, conflict.disequality);
+                    // Emit trichotomies for pairs in the conflict path (bounded by budget)
+                    let mut emitted = 0;
+                    for &(a, b) in &conflict.equalities {
+                        if emitted >= self.trichotomies_per_round {
+                            break;
+                        }
+                        let sa = self.solver_state.to_solver_uid(a);
+                        let sb = self.solver_state.to_solver_uid(b);
+                        let (lo, hi) = if sa < sb { (sa, sb) } else { (sb, sa) };
+                        self.emit_trichotomy_for_pair(lo, hi);
+                        emitted += 1;
+                    }
+
+                    // Build the blocking conflict clause: negation of the equalities
+                    // that formed the proof path + negated diseq_lit.
+                    let mut conflict_clause: Vec<i32> = conflict
+                        .equalities
+                        .iter()
+                        .map(|(a, b)| -self.solver_state.make_eq(*a, *b))
+                        .collect();
+                    if let Some(lit) = conflict.diseq_lit {
+                        conflict_clause.push(-lit);
+                    }
+                    eprintln!("[ARITH PROBE CONFLICT] clause={:?}, a[312]={} a[313]={} a[314]={} a[315]={}",
+                        conflict_clause,
+                        self.assignments.get(312).copied().unwrap_or(0),
+                        self.assignments.get(313).copied().unwrap_or(0),
+                        self.assignments.get(314).copied().unwrap_or(0),
+                        self.assignments.get(315).copied().unwrap_or(0));
+                    for lit in &conflict_clause {
+                        self.add_observed_variable(*lit);
+                        self.add_lit_to_proof_tracer(*lit);
+                    }
+                    self.disequalities.borrow_mut().push(conflict_clause);
+                }
+
+                // Always undo probe merges — they only live inside this call.
+                self.solver_state.egraph.backtrack_to(self.decision_level);
             }
             ArithResult::None => {}
         }

--- a/src/cadical_propagator.rs
+++ b/src/cadical_propagator.rs
@@ -83,42 +83,28 @@ impl<'a> CustomExternalPropagator<'a> {
         }
     }
 
-    /// Emit trichotomy clauses (x=y ∨ x<y ∨ x>y) for a pair of solver-uid terms.
-    /// Registers the fresh eq/lt/gt literals as observed variables.
+    /// Emit trichotomy clause (x<y ∨ x>y ∨ x=y) for a pair of solver-uid terms
+    /// as a raw 3-literal disjunction (no Tseitin OR-gate). Registers the fresh
+    /// lt/gt/eq literals as observed. No-op if the pair was already emitted.
     fn emit_trichotomy_for_pair(&mut self, x: u64, y: u64) {
         if let Some((lt_term, gt_term, eq_term)) =
             nelson_oppen_trichotomy_terms(x, y, self.solver_state)
         {
-            // eprintln!(
-            //     "[TRICHOTOMY] for pair ({}, {}) i.e. ({}, {})",
-            //     x,
-            //     y,
-            //     self.solver_state.get_term(x),
-            //     self.solver_state.get_term(y)
-            // );
-            self.solver_state.insert_predecessor(&lt_term, None, None, true);
-            self.solver_state.insert_predecessor(&gt_term, None, None, true);
-            self.solver_state.insert_predecessor(&eq_term, None, None, true);
+            self.solver_state
+                .insert_predecessor(&lt_term, None, None, true);
+            self.solver_state
+                .insert_predecessor(&gt_term, None, None, true);
+            self.solver_state
+                .insert_predecessor(&eq_term, None, None, true);
             let lt_lit = self.solver_state.get_or_allocate_lit_for_term(&lt_term);
             let gt_lit = self.solver_state.get_or_allocate_lit_for_term(&gt_term);
             let eq_lit = self.solver_state.get_or_allocate_lit_for_term(&eq_term);
             let clause = vec![lt_lit, gt_lit, eq_lit];
-            // eprintln!("  clause: [");
-            // for &lit in &clause {
-            //     eprintln!(
-            //         "    {}[{}],",
-            //         lit,
-            //         self.solver_state.get_term_from_lit(lit)
-            //     );
-            // }
-            // eprintln!("  ]");
             for lit in &clause {
                 self.add_observed_variable(*lit);
                 self.add_lit_to_proof_tracer(*lit);
             }
             self.disequalities.borrow_mut().push(clause);
-        } else {
-            // eprintln!("[TRICHOTOMY] SKIPPED (already emitted) for pair ({}, {})", x, y);
         }
     }
 
@@ -429,8 +415,10 @@ impl<'a> ExternalPropagator for CustomExternalPropagator<'a> {
                         probe_pair_uids.insert((lo_e, hi_e), (x, y));
                         let attempt_level = next_probe_level;
                         next_probe_level += 1;
-                        let result =
-                            self.solver_state.egraph.assert_equal(x_e, y_e, attempt_level);
+                        let result = self
+                            .solver_state
+                            .egraph
+                            .assert_equal(x_e, y_e, attempt_level);
                         if let Some(c) = result.conflict {
                             // Undo just this conflicting merge; keep earlier merges.
                             self.solver_state.egraph.backtrack_to(attempt_level - 1);
@@ -443,51 +431,15 @@ impl<'a> ExternalPropagator for CustomExternalPropagator<'a> {
                     }
                 }
 
-                // eprintln!(
-                //     "[ARITH PROBE] found {} conflict(s) this round",
-                //     conflicts.len()
-                // );
-
-                for (_i, conflict) in conflicts.iter().enumerate() {
-                    // let (d0, d1) = conflict.disequality;
-                    // let sd0 = self.solver_state.to_solver_uid(d0);
-                    // let sd1 = self.solver_state.to_solver_uid(d1);
-                    // eprintln!(
-                    //     "[CONFLICT #{}] disequality {}!={} i.e. {}!={} (diseq_lit={:?})",
-                    //     _i,
-                    //     d0,
-                    //     d1,
-                    //     self.solver_state.get_term(sd0),
-                    //     self.solver_state.get_term(sd1),
-                    //     conflict.diseq_lit,
-                    // );
-                    // eprintln!("  proof path equalities: [");
-                    // for (a, b) in &conflict.equalities {
-                    //     let sa = self.solver_state.to_solver_uid(*a);
-                    //     let sb = self.solver_state.to_solver_uid(*b);
-                    //     eprintln!(
-                    //         "    ({}={}) i.e. ({} = {}),",
-                    //         a,
-                    //         b,
-                    //         self.solver_state.get_term(sa),
-                    //         self.solver_state.get_term(sb),
-                    //     );
-                    // }
-                    // eprintln!("  ]");
-
-                    // Emit up to two trichotomies per conflict — walking backward
-                    // through the proof path, pick the last two probe-merged pairs
-                    // whose trichotomies have NOT already been emitted. Other
-                    // probe-merge pairs fall back on make_eq allocating a bare eq lit.
-                    const TRICHOTOMIES_PER_CONFLICT: usize = 2;
-                    let mut fresh_probe_pairs: Vec<(u64, u64)> = Vec::new();
-                    for &(a, b) in conflict.equalities.iter().rev() {
-                        if fresh_probe_pairs.len() >= TRICHOTOMIES_PER_CONFLICT {
-                            break;
-                        }
+                for conflict in &conflicts {
+                    // Emit at most one trichotomy per conflict — walking backward
+                    // through the proof path, pick the last probe-merged pair whose
+                    // trichotomy has NOT already been emitted. Other probe-merge pairs
+                    // fall back on make_eq allocating a bare eq literal.
+                    let fresh_probe_pair = conflict.equalities.iter().rev().find_map(|&(a, b)| {
                         let (lo_e, hi_e) = if a < b { (a, b) } else { (b, a) };
                         if !probe_merged_pairs.contains(&(lo_e, hi_e)) {
-                            continue;
+                            return None;
                         }
                         let (x_uid, y_uid) = probe_pair_uids[&(lo_e, hi_e)];
                         if self
@@ -495,11 +447,12 @@ impl<'a> ExternalPropagator for CustomExternalPropagator<'a> {
                             .nelson_oppen_ineq_literals
                             .contains(&(x_uid, y_uid))
                         {
-                            continue;
+                            None
+                        } else {
+                            Some((x_uid, y_uid))
                         }
-                        fresh_probe_pairs.push((x_uid, y_uid));
-                    }
-                    for (x_uid, y_uid) in fresh_probe_pairs {
+                    });
+                    if let Some((x_uid, y_uid)) = fresh_probe_pair {
                         self.emit_trichotomy_for_pair(x_uid, y_uid);
                     }
 
@@ -511,16 +464,6 @@ impl<'a> ExternalPropagator for CustomExternalPropagator<'a> {
                     if let Some(lit) = conflict.diseq_lit {
                         conflict_clause.push(-lit);
                     }
-
-                    // eprintln!("  conflict clause: [");
-                    // for &lit in &conflict_clause {
-                    //     eprintln!(
-                    //         "    {}[{}],",
-                    //         lit,
-                    //         self.solver_state.get_term_from_lit(lit)
-                    //     );
-                    // }
-                    // eprintln!("  ]");
 
                     for lit in &conflict_clause {
                         self.add_observed_variable(*lit);

--- a/src/cdcl.rs
+++ b/src/cdcl.rs
@@ -41,6 +41,7 @@ pub fn cdcl_decision_procedure(
     arithmetic: ArithSolver,
     timeout: u64,
     elevate: i32,
+    trichotomies_per_round: usize,
 ) -> (Status, SolverStats) {
     let mut solver = CaDiCal::new();
     assert!(
@@ -77,6 +78,7 @@ pub fn cdcl_decision_procedure(
         arithmetic,
         stats: SolverStats::new(),
         pending: None,
+        trichotomies_per_round,
     };
 
     solver.connect_external_propagator(&mut propagator);

--- a/src/cdcl.rs
+++ b/src/cdcl.rs
@@ -41,7 +41,7 @@ pub fn cdcl_decision_procedure(
     arithmetic: ArithSolver,
     timeout: u64,
     elevate: i32,
-    trichotomies_per_round: usize,
+    max_arith_conflicts_per_round: usize,
 ) -> (Status, SolverStats) {
     let mut solver = CaDiCal::new();
     assert!(
@@ -78,7 +78,7 @@ pub fn cdcl_decision_procedure(
         arithmetic,
         stats: SolverStats::new(),
         pending: None,
-        trichotomies_per_round,
+        max_arith_conflicts_per_round,
     };
 
     solver.connect_external_propagator(&mut propagator);

--- a/src/config.rs
+++ b/src/config.rs
@@ -50,5 +50,5 @@ pub struct Args {
     /// Maximum arithmetic-model conflicts to collect per cb_check_found_model call.
     /// usize::MAX = no cap; keep collecting until every probe pair has been tried.
     #[arg(long, default_value_t = usize::MAX)]
-    pub trichotomies_per_round: usize,
+    pub max_arith_conflicts_per_round: usize,
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -47,7 +47,8 @@ pub struct Args {
     /// Print solver statistics after solving
     #[arg(long, default_value_t = false)]
     pub stats: bool,
-    /// Maximum trichotomy clauses to emit per arithmetic SAT round
-    #[arg(long, default_value_t = 20)]
+    /// Maximum arithmetic-model conflicts to collect per cb_check_found_model call.
+    /// usize::MAX = no cap; keep collecting until every probe pair has been tried.
+    #[arg(long, default_value_t = usize::MAX)]
     pub trichotomies_per_round: usize,
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -47,4 +47,7 @@ pub struct Args {
     /// Print solver statistics after solving
     #[arg(long, default_value_t = false)]
     pub stats: bool,
+    /// Maximum trichotomy clauses to emit per arithmetic SAT round
+    #[arg(long, default_value_t = 20)]
+    pub trichotomies_per_round: usize,
 }

--- a/src/egraphs/basic/egraph.rs
+++ b/src/egraphs/basic/egraph.rs
@@ -214,10 +214,17 @@ pub struct Egraph {
     function_maps: DeterministicHashMap<String, Vec<(u32, Vec<u32>)>>,
     /// the current decision level of the SAT solver, useful to keep track for backtracking
     decision_level: usize,
-    /// keeps track of terms created by quantifier instantiation and their predecessors
-    predecessors_created_by_quantifiers: DeterministicHashMap<u32, DeterministicHashSet<u32>>,
-    /// if a quantifier instantiates (f t) and t = s, then we want to add (f.uid(), "f", [t.uid()])
-    union_to_eclass: DeterministicHashSet<u32>,
+    /// keeps track of terms created by quantifier instantiation and their predecessors.
+    /// Inner map: parent term id -> decision level at which the (child, parent) pair
+    /// was registered. Used by `backtrack_to` to skip re-registering entries that
+    /// were added at or below the target level (their predecessors are already
+    /// valid at that level and don't need refreshing).
+    predecessors_created_by_quantifiers:
+        DeterministicHashMap<u32, DeterministicHashMap<u32, usize>>,
+    /// if a quantifier instantiates (f t) and t = s, then we want to add (f.uid(), "f", [t.uid()]).
+    /// Value is the decision level at which the term was registered; entries added
+    /// at or below the backtrack target level are skipped during `backtrack_to`.
+    union_to_eclass: DeterministicHashMap<u32, usize>,
     /// Signature table: maps (op, [find(c1),...,find(cn)]) → term_id.
     /// Maintained in parallel with the existing congruence detection for now.
     sig_table: FastDeterministicHashMap<SigKey, u32>,
@@ -250,7 +257,7 @@ impl Egraph {
             function_maps: DeterministicHashMap::default(),
             decision_level: 0,
             predecessors_created_by_quantifiers: DeterministicHashMap::new(),
-            union_to_eclass: DeterministicHashSet::new(),
+            union_to_eclass: DeterministicHashMap::new(),
             sig_table: FastDeterministicHashMap::default(),
             sig_trail: Vec::new(),
         }
@@ -342,17 +349,10 @@ impl Egraph {
                     inner_term: child_uid,
                 };
 
-                match self.predecessors_created_by_quantifiers.get_mut(&child_uid) {
-                    Some(parents) => {
-                        parents.insert(id);
-                    }
-                    None => {
-                        let mut parents = DeterministicHashSet::new();
-                        parents.insert(id);
-                        self.predecessors_created_by_quantifiers
-                            .insert(child_uid, parents);
-                    }
-                };
+                self.predecessors_created_by_quantifiers
+                    .entry(child_uid)
+                    .or_default()
+                    .insert(id, self.decision_level);
 
                 self.predecessors[root as usize]
                     .entry(id)
@@ -373,7 +373,7 @@ impl Egraph {
         }
 
         if dynamic && !children.is_empty() {
-            self.union_to_eclass.insert(id);
+            self.union_to_eclass.insert(id, self.decision_level);
         }
 
         false
@@ -964,10 +964,16 @@ impl Egraph {
             }
         }
 
-        // Re-add predecessors created by quantifiers at their new roots
+        // Re-add predecessors created by quantifiers at their new roots.
+        // Skip entries added at or below `level`: their predecessor stamps are
+        // still valid (predecessor_level only got bumped for levels > `level`)
+        // and their roots didn't shift because of any pop above `level`.
         for (term, parents) in &self.predecessors_created_by_quantifiers.clone() {
             let current_ancestor = self.find(*term);
-            for parent in parents {
+            for (parent, added_at) in parents {
+                if *added_at <= level {
+                    continue;
+                }
                 let predecessor = Predecessor {
                     level,
                     hash: self.predecessor_hash,
@@ -978,9 +984,14 @@ impl Egraph {
             }
         }
 
-        // Re-do union_to_eclass via sig table probe
+        // Re-do union_to_eclass via sig table probe. Entries added at or below
+        // `level` were already reconciled with the sig_table at that level and
+        // their signatures are stable under this backtrack.
         let union_to_eclass_info = self.union_to_eclass.clone();
-        for term in union_to_eclass_info {
+        for (term, added_at) in union_to_eclass_info {
+            if added_at <= level {
+                continue;
+            }
             if let Some(sig) = self.compute_signature(term) {
                 if let Some(&existing) = self.sig_table.get(&sig) {
                     if self.find(existing) != self.find(term) {
@@ -995,7 +1006,7 @@ impl Egraph {
         // Clear at level 0
         if level == 0 {
             self.predecessors_created_by_quantifiers = DeterministicHashMap::new();
-            self.union_to_eclass = DeterministicHashSet::new();
+            self.union_to_eclass = DeterministicHashMap::new();
             self.proof_forest_backtrack_stack = vec![];
             self.sig_trail.clear();
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -180,7 +180,7 @@ fn main() -> Result<(), String> {
         args.arithmetic,
         args.timeout,
         args.elevate,
-        args.trichotomies_per_round,
+        args.max_arith_conflicts_per_round,
     );
 
     match return_value {

--- a/src/main.rs
+++ b/src/main.rs
@@ -180,6 +180,7 @@ fn main() -> Result<(), String> {
         args.arithmetic,
         args.timeout,
         args.elevate,
+        args.trichotomies_per_round,
     );
 
     match return_value {

--- a/src/solver_state.rs
+++ b/src/solver_state.rs
@@ -270,7 +270,8 @@ impl SolverState {
             let sx = self.to_solver_uid(x);
             let sy = self.to_solver_uid(y);
             let eq_term_class = self.context.eq(self.get_term(sx), self.get_term(sy));
-            self.get_lit_from_term(&eq_term_class)
+            self.insert_predecessor(&eq_term_class, None, None, true);
+            self.get_or_allocate_lit_for_term(&eq_term_class)
         }
     }
 


### PR DESCRIPTION
*Issue #, if available:* #110

*Description of changes:* We support nelson-oppen theory combination via interface lemmas. However, we aggressively introduce interface lemmas. For instance for if the arithmetic solver returns `sat` with a model `w=x=y=z=1`, we would learn the interface lemmas `w=x \/ w<x \/ w>x`, `w=y \/ w<y \/ w>y`, `w=z \/ w<z \/ w>z`.

However, we can make this more efficient by checking if these equalities violate the current state of the egraph, before learning an interference lemma


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
