### PR TITLE
[DRAFT] Theory propagation from egraph to SAT solver

### DIFF
--- a/src/cadical_propagator.rs
+++ b/src/cadical_propagator.rs
@@ -390,8 +390,10 @@ impl<'a> ExternalPropagator for CustomExternalPropagator<'a> {
         self.solver_state.egraph.backtrack_to(level);
 
         // Clear pending propagations — they refer to merges that may have been undone.
+        // Note: reason_clauses is NOT cleared here because CaDiCaL may request
+        // the reason for a previously-propagated literal during conflict analysis
+        // even after backtracking.
         self.pending_propagations.clear();
-        self.reason_clauses.clear();
 
         #[cfg(feature = "z3-solver")]
         {

--- a/src/cadical_propagator.rs
+++ b/src/cadical_propagator.rs
@@ -16,17 +16,23 @@ use crate::quantifiers::quantifier::{
 };
 use crate::solver_state::{SolverState, process_assignment};
 use crate::stats::SolverStats;
-use crate::utils::{DeterministicHashMap, DeterministicHashSet};
+use crate::utils::{DeterministicHashMap, DeterministicHashSet, FastDeterministicHashMap};
 use cadical_sys::{CaDiCal, ExternalPropagator};
 use std::cell::RefCell;
 use std::rc::Rc;
 
-/// A pending theory propagation: the literal to propagate and its reason clause.
-/// The reason clause is of the form `¬eq1 ∨ ¬eq2 ∨ ... ∨ propagated_lit`,
-/// where eq1, eq2, ... are the asserted equalities that explain why t1 = t2.
-pub struct PendingPropagation {
+/// A pending theory propagation whose explanation is built only if CaDiCaL
+/// requests it.
+pub(crate) struct PendingPropagation {
     pub lit: i32,
-    pub reason_clause: Vec<i32>,
+    pub t1: u32,
+    pub t2: u32,
+}
+
+pub(crate) enum PropagationReason {
+    Unexplained { t1: u32, t2: u32 },
+    Equalities(Vec<(u32, u32)>),
+    Clause(Vec<i32>),
 }
 
 /// Our implementation of a Cadical Propagator
@@ -48,10 +54,9 @@ pub struct CustomExternalPropagator<'a> {
     #[cfg(feature = "z3-solver")]
     pub z3_incremental: Option<Z3IncrementalState>,
     /// Pending theory propagations from the egraph. Drained via cb_propagate.
-    pub pending_propagations: Vec<PendingPropagation>,
-    /// Index into the reason clause currently being emitted by cb_add_reason_clause_lit.
-    /// Maps propagated literal -> reason clause literals.
-    pub reason_clauses: DeterministicHashMap<i32, Vec<i32>>,
+    pub(crate) pending_propagations: Vec<PendingPropagation>,
+    /// Lazy or materialized reason for each delivered propagation.
+    pub(crate) reason_clauses: FastDeterministicHashMap<i32, PropagationReason>,
 }
 
 impl<'a> CustomExternalPropagator<'a> {
@@ -156,6 +161,68 @@ impl<'a> CustomExternalPropagator<'a> {
             }
         }
     }
+
+    fn materialize_reason_clause(&mut self, propagated_lit: i32) {
+        let Some(reason) = self.reason_clauses.remove(&propagated_lit) else {
+            return;
+        };
+        let equalities = match reason {
+            PropagationReason::Unexplained { t1, t2 } => self
+                .solver_state
+                .egraph
+                .explain_equality(t1, t2)
+                .expect("propagated equality must still be explainable"),
+            PropagationReason::Equalities(equalities) => equalities,
+            PropagationReason::Clause(clause) => {
+                self.reason_clauses
+                    .insert(propagated_lit, PropagationReason::Clause(clause));
+                return;
+            }
+        };
+
+        let mut clause: Vec<i32> = equalities
+            .iter()
+            .map(|(a, b)| -self.solver_state.make_eq(*a, *b))
+            .collect();
+        clause.push(propagated_lit);
+        for &reason_lit in &clause {
+            self.add_observed_variable(reason_lit);
+            self.add_lit_to_proof_tracer(reason_lit);
+        }
+        self.reason_clauses
+            .insert(propagated_lit, PropagationReason::Clause(clause));
+    }
+
+    fn preserve_reasons_across_backtrack(&mut self, level: usize) {
+        let mut surviving = Vec::new();
+        let mut discarded = Vec::new();
+        for (&lit, reason) in &self.reason_clauses {
+            let index = lit.unsigned_abs() as usize;
+            let survives = index < self.assignments.len()
+                && self.assignments[index] != 0
+                && self.assignments[index].unsigned_abs() as usize <= level + 1;
+            if survives {
+                if let PropagationReason::Unexplained { t1, t2 } = reason {
+                    surviving.push((lit, *t1, *t2));
+                }
+            } else {
+                discarded.push(lit);
+            }
+        }
+
+        for (lit, t1, t2) in surviving {
+            let equalities = self
+                .solver_state
+                .egraph
+                .explain_equality(t1, t2)
+                .expect("surviving propagated equality must still be explainable");
+            self.reason_clauses
+                .insert(lit, PropagationReason::Equalities(equalities));
+        }
+        for lit in discarded {
+            self.reason_clauses.remove(&lit);
+        }
+    }
 }
 
 impl<'a> ExternalPropagator for CustomExternalPropagator<'a> {
@@ -225,30 +292,11 @@ impl<'a> ExternalPropagator for CustomExternalPropagator<'a> {
                     if abs_prop < self.assignments.len() && self.assignments[abs_prop] != 0 {
                         continue;
                     }
-                    // Build the reason clause: ¬eq1 ∨ ¬eq2 ∨ ... ∨ propagated_lit
-                    // The explanation is: which asserted equalities cause t1 = t2?
-                    if let Some(equalities) = self.solver_state.egraph.explain_equality(prop.t1, prop.t2) {
-                        let mut reason_clause: Vec<i32> = equalities
-                            .iter()
-                            .map(|(a, b)| -self.solver_state.make_eq(*a, *b))
-                            .collect();
-                        reason_clause.push(prop_lit);
-                        debug_println!(
-                            7,
-                            0,
-                            "PROPAGATOR: Queuing propagation of {} with reason {:?}",
-                            prop_lit,
-                            reason_clause
-                        );
-                        for &reason_lit in &reason_clause {
-                            self.add_observed_variable(reason_lit);
-                            self.add_lit_to_proof_tracer(reason_lit);
-                        }
-                        self.pending_propagations.push(PendingPropagation {
-                            lit: prop_lit,
-                            reason_clause,
-                        });
-                    }
+                    self.pending_propagations.push(PendingPropagation {
+                        lit: prop_lit,
+                        t1: prop.t1,
+                        t2: prop.t2,
+                    });
                 }
             }
 
@@ -366,6 +414,10 @@ impl<'a> ExternalPropagator for CustomExternalPropagator<'a> {
             self.decision_level,
             level
         );
+
+        // Preserve explanations only for propagated assignments that remain on
+        // CaDiCaL's trail. The egraph proof paths are about to be backtracked.
+        self.preserve_reasons_across_backtrack(level);
 
         // Reset solver-level assignments
         for i in 1..self.assignments.len() {
@@ -708,14 +760,14 @@ impl<'a> ExternalPropagator for CustomExternalPropagator<'a> {
     fn cb_propagate(&mut self) -> i32 {
         debug_println!(7, 0, "PROPAGATOR: Propagation callback invoked");
         if let Some(prop) = self.pending_propagations.pop() {
-            debug_println!(
-                7,
-                0,
-                "PROPAGATOR: Propagating literal {} with reason {:?}",
+            debug_println!(7, 0, "PROPAGATOR: Propagating literal {}", prop.lit);
+            self.reason_clauses.insert(
                 prop.lit,
-                prop.reason_clause
+                PropagationReason::Unexplained {
+                    t1: prop.t1,
+                    t2: prop.t2,
+                },
             );
-            self.reason_clauses.insert(prop.lit, prop.reason_clause);
             prop.lit
         } else {
             0
@@ -729,7 +781,10 @@ impl<'a> ExternalPropagator for CustomExternalPropagator<'a> {
             "PROPAGATOR: Adding reason clause for literal {}",
             propagated_lit
         );
-        if let Some(reason) = self.reason_clauses.get_mut(&propagated_lit) {
+        self.materialize_reason_clause(propagated_lit);
+        if let Some(PropagationReason::Clause(reason)) =
+            self.reason_clauses.get_mut(&propagated_lit)
+        {
             if let Some(lit) = reason.pop() {
                 lit
             } else {

--- a/src/cadical_propagator.rs
+++ b/src/cadical_propagator.rs
@@ -21,6 +21,14 @@ use cadical_sys::{CaDiCal, ExternalPropagator};
 use std::cell::RefCell;
 use std::rc::Rc;
 
+/// A pending theory propagation: the literal to propagate and its reason clause.
+/// The reason clause is of the form `¬eq1 ∨ ¬eq2 ∨ ... ∨ propagated_lit`,
+/// where eq1, eq2, ... are the asserted equalities that explain why t1 = t2.
+pub struct PendingPropagation {
+    pub lit: i32,
+    pub reason_clause: Vec<i32>,
+}
+
 /// Our implementation of a Cadical Propagator
 pub struct CustomExternalPropagator<'a> {
     pub decision_level: usize,
@@ -39,6 +47,11 @@ pub struct CustomExternalPropagator<'a> {
     /// Incremental Z3 arithmetic state — Some iff `arithmetic == ArithSolver::Z3Incremental`.
     #[cfg(feature = "z3-solver")]
     pub z3_incremental: Option<Z3IncrementalState>,
+    /// Pending theory propagations from the egraph. Drained via cb_propagate.
+    pub pending_propagations: Vec<PendingPropagation>,
+    /// Index into the reason clause currently being emitted by cb_add_reason_clause_lit.
+    /// Maps propagated literal -> reason clause literals.
+    pub reason_clauses: DeterministicHashMap<i32, Vec<i32>>,
 }
 
 impl<'a> CustomExternalPropagator<'a> {
@@ -201,6 +214,44 @@ impl<'a> ExternalPropagator for CustomExternalPropagator<'a> {
                 }
             }
 
+            // Drain theory propagations from the egraph.
+            {
+                use crate::egraphs::EgraphTrait;
+                let propagations = self.solver_state.egraph.drain_propagations();
+                for prop in propagations {
+                    let prop_lit = prop.lit;
+                    // Skip if the literal is already assigned
+                    let abs_prop = prop_lit.unsigned_abs() as usize;
+                    if abs_prop < self.assignments.len() && self.assignments[abs_prop] != 0 {
+                        continue;
+                    }
+                    // Build the reason clause: ¬eq1 ∨ ¬eq2 ∨ ... ∨ propagated_lit
+                    // The explanation is: which asserted equalities cause t1 = t2?
+                    if let Some(equalities) = self.solver_state.egraph.explain_equality(prop.t1, prop.t2) {
+                        let mut reason_clause: Vec<i32> = equalities
+                            .iter()
+                            .map(|(a, b)| -self.solver_state.make_eq(*a, *b))
+                            .collect();
+                        reason_clause.push(prop_lit);
+                        debug_println!(
+                            7,
+                            0,
+                            "PROPAGATOR: Queuing propagation of {} with reason {:?}",
+                            prop_lit,
+                            reason_clause
+                        );
+                        for &reason_lit in &reason_clause {
+                            self.add_observed_variable(reason_lit);
+                            self.add_lit_to_proof_tracer(reason_lit);
+                        }
+                        self.pending_propagations.push(PendingPropagation {
+                            lit: prop_lit,
+                            reason_clause,
+                        });
+                    }
+                }
+            }
+
             if let Some(negated_model_or_datatype_constraints) =
                 negated_model_or_datatype_constraints_opt
             {
@@ -337,6 +388,10 @@ impl<'a> ExternalPropagator for CustomExternalPropagator<'a> {
         // any congruence merges from `union_to_eclass` replay, so the queue
         // on return holds exactly the merges that survive at `level`.
         self.solver_state.egraph.backtrack_to(level);
+
+        // Clear pending propagations — they refer to merges that may have been undone.
+        self.pending_propagations.clear();
+        self.reason_clauses.clear();
 
         #[cfg(feature = "z3-solver")]
         {
@@ -650,21 +705,38 @@ impl<'a> ExternalPropagator for CustomExternalPropagator<'a> {
 
     fn cb_propagate(&mut self) -> i32 {
         debug_println!(7, 0, "PROPAGATOR: Propagation callback invoked");
-        // For now, no propagation
-        // This could deduce new assignments
-        0
+        if let Some(prop) = self.pending_propagations.pop() {
+            debug_println!(
+                7,
+                0,
+                "PROPAGATOR: Propagating literal {} with reason {:?}",
+                prop.lit,
+                prop.reason_clause
+            );
+            self.reason_clauses.insert(prop.lit, prop.reason_clause);
+            prop.lit
+        } else {
+            0
+        }
     }
 
-    fn cb_add_reason_clause_lit(&mut self, _propagated_lit: i32) -> i32 {
+    fn cb_add_reason_clause_lit(&mut self, propagated_lit: i32) -> i32 {
         debug_println!(
             7,
             0,
             "PROPAGATOR: Adding reason clause for literal {}",
-            _propagated_lit
+            propagated_lit
         );
-        // For now, no reason clauses
-        // This could explain propagations
-        0
+        if let Some(reason) = self.reason_clauses.get_mut(&propagated_lit) {
+            if let Some(lit) = reason.pop() {
+                lit
+            } else {
+                self.reason_clauses.remove(&propagated_lit);
+                0
+            }
+        } else {
+            0
+        }
     }
 
     fn cb_has_external_clause(&mut self, is_forgettable: &mut bool) -> bool {

--- a/src/cdcl.rs
+++ b/src/cdcl.rs
@@ -9,7 +9,7 @@ use crate::egraphs::EgraphTrait;
 use crate::proof::{SMTProofTracer, Theory};
 use crate::solver_state::SolverState;
 use crate::stats::SolverStats;
-use crate::utils::{DeterministicHashMap, DeterministicHashSet};
+use crate::utils::{DeterministicHashSet, FastDeterministicHashMap};
 use cadical_sys::{CaDiCal, Status, Terminator};
 use std::cell::RefCell;
 use std::collections::HashMap;
@@ -95,7 +95,7 @@ pub fn cdcl_decision_procedure(
         #[cfg(feature = "z3-solver")]
         z3_incremental,
         pending_propagations: Vec::new(),
-        reason_clauses: DeterministicHashMap::default(),
+        reason_clauses: FastDeterministicHashMap::default(),
     };
 
     solver.connect_external_propagator(&mut propagator);

--- a/src/cdcl.rs
+++ b/src/cdcl.rs
@@ -9,7 +9,7 @@ use crate::egraphs::EgraphTrait;
 use crate::proof::{SMTProofTracer, Theory};
 use crate::solver_state::SolverState;
 use crate::stats::SolverStats;
-use crate::utils::DeterministicHashSet;
+use crate::utils::{DeterministicHashMap, DeterministicHashSet};
 use cadical_sys::{CaDiCal, Status, Terminator};
 use std::cell::RefCell;
 use std::collections::HashMap;
@@ -94,6 +94,8 @@ pub fn cdcl_decision_procedure(
         max_arith_conflicts_per_round,
         #[cfg(feature = "z3-solver")]
         z3_incremental,
+        pending_propagations: Vec::new(),
+        reason_clauses: DeterministicHashMap::default(),
     };
 
     solver.connect_external_propagator(&mut propagator);

--- a/src/egraphs/basic/egraph.rs
+++ b/src/egraphs/basic/egraph.rs
@@ -8,7 +8,9 @@ use super::unionfind::ProofTracker;
 use crate::debug_println;
 use crate::egraphs::traits::{Conflict, EgraphResult, EgraphTrait, Lit, Propagation};
 use crate::log::is_important;
-use crate::utils::{DeterministicHashMap, DeterministicHashSet, FastDeterministicHashMap};
+use crate::utils::{
+    DeterministicHashMap, DeterministicHashSet, FastDeterministicHashMap, FastDeterministicHashSet,
+};
 use std::default::Default;
 use std::fmt;
 
@@ -20,17 +22,19 @@ type SigKey = (CanonicalOp, Children);
 /// (level, key, term_id, was_inserted)
 type SigTrailEntry = (usize, SigKey, u32, bool);
 
+type EqKey = (u32, u32);
+
 enum EqWatchTrailEntry {
     Registered {
         level: usize,
         atom: u32,
-        key: SigKey,
+        key: EqKey,
     },
     Rekeyed {
         level: usize,
         atom: u32,
-        old_key: SigKey,
-        new_key: SigKey,
+        old_key: EqKey,
+        new_key: EqKey,
     },
 }
 
@@ -264,10 +268,12 @@ pub struct Egraph {
     /// Equality watches indexed by their current canonical signature.
     /// Multiple atoms can share a signature after their operands merge, so each
     /// key stores every `(atom, lit)` watch for that signature.
-    eq_atom_lits: FastDeterministicHashMap<SigKey, Vec<(u32, i32)>>,
-    /// Current signature for each watched equality atom. This makes rekeying
-    /// affected watches local to predecessors of the class being merged/split.
-    eq_atom_signatures: FastDeterministicHashMap<u32, SigKey>,
+    eq_atom_lits: FastDeterministicHashMap<EqKey, Vec<(u32, i32)>>,
+    /// Current canonical operand pair for each watched equality atom.
+    eq_atom_signatures: FastDeterministicHashMap<u32, EqKey>,
+    /// Reverse index from an operand e-class root to watched equality atoms
+    /// whose canonical signature mentions that root.
+    eq_atoms_by_root: FastDeterministicHashMap<u32, FastDeterministicHashSet<u32>>,
     /// Trail for restoring the canonical equality-watch index on backtrack.
     eq_watch_trail: Vec<EqWatchTrailEntry>,
     /// Pending theory propagations to deliver to the SAT solver via cb_propagate.
@@ -308,6 +314,7 @@ impl Egraph {
             arithmetic_merge_queue: Vec::new(),
             eq_atom_lits: FastDeterministicHashMap::default(),
             eq_atom_signatures: FastDeterministicHashMap::default(),
+            eq_atoms_by_root: FastDeterministicHashMap::default(),
             eq_watch_trail: Vec::new(),
             propagation_queue: Vec::new(),
         }
@@ -979,7 +986,7 @@ impl Egraph {
                     self.move_eq_atom_watch(atom, &new_key, old_key);
                 }
                 EqWatchTrailEntry::Registered { atom, key, .. } => {
-                    if let Some(restored_key) = self.compute_signature(atom)
+                    if let Some(restored_key) = self.compute_eq_key(atom)
                         && restored_key != key
                     {
                         self.move_eq_atom_watch(atom, &key, restored_key);
@@ -1331,7 +1338,7 @@ impl Egraph {
             self.display_term(y_root)
         );
         self.make_root(y, proof_parent);
-        self.reindex_eq_atom_predecessors(y_root, level);
+        self.reindex_eq_atoms_for_root(y_root, level);
 
         // Early conflict check: x_root's existing disequalities may already be
         // violated now that y's class has been merged in.
@@ -1482,28 +1489,19 @@ impl Egraph {
         EgraphResult::ok()
     }
 
-    /// Look up equality atoms whose two operands are about to become equal by
-    /// merging the classes rooted at `x_root` and `y_root` (one operand in each
-    /// class). Such an atom `(= a b)` lives in the sig_table under
-    /// `(Eq, [x_root, y_root])` or the reverse, so two lookups on the pre-merge
-    /// roots find every newly-satisfied atom — including transitive merges that
-    /// an exact-operand-pair check would miss. Must be called BEFORE the merge
-    /// re-canonicalizes the sig_table. Returns (operand1, operand2, lit) tuples.
+    /// Look up equality atoms whose operands span the two classes being merged.
+    /// Equality is symmetric, so the canonical key is an unordered root pair.
+    /// Must be called before the watch index is rekeyed by the merge.
     fn eq_atom_propagations_for_merge(&self, x_root: u32, y_root: u32) -> Vec<(u32, u32, i32)> {
         if self.eq_atom_lits.is_empty() {
             return Vec::new();
         }
         let mut out = Vec::new();
-        for key in [
-            (CanonicalOp::Eq, Children::from_slice(&[x_root, y_root])),
-            (CanonicalOp::Eq, Children::from_slice(&[y_root, x_root])),
-        ] {
-            if let Some(watches) = self.eq_atom_lits.get(&key) {
-                for &(atom, lit) in watches {
-                    if let TermSlot::Term(e) = &self.terms[atom as usize] {
-                        let ch = e.children.as_slice();
-                        out.push((ch[0], ch[1], lit));
-                    }
+        if let Some(watches) = self.eq_atom_lits.get(&Self::eq_key(x_root, y_root)) {
+            for &(atom, lit) in watches {
+                if let TermSlot::Term(e) = &self.terms[atom as usize] {
+                    let ch = e.children.as_slice();
+                    out.push((ch[0], ch[1], lit));
                 }
             }
         }
@@ -1512,29 +1510,29 @@ impl Egraph {
 
     /// Rekey watched equality atoms whose signatures changed because `root`
     /// was merged into another class or restored by backtracking.
-    fn reindex_eq_atom_predecessors(&mut self, root: u32, level: usize) {
-        let atoms: Vec<u32> = self.predecessors[root as usize]
-            .keys()
-            .filter(|atom| self.eq_atom_signatures.contains_key(atom))
-            .copied()
-            .collect();
+    fn reindex_eq_atoms_for_root(&mut self, root: u32, level: usize) {
+        let atoms: Vec<u32> = self
+            .eq_atoms_by_root
+            .get(&root)
+            .map(|atoms| atoms.iter().copied().collect())
+            .unwrap_or_default();
         for atom in atoms {
             self.reindex_eq_atom(atom, level);
         }
     }
 
     fn reindex_eq_atom(&mut self, atom: u32, level: usize) {
-        let Some(old_key) = self.eq_atom_signatures.get(&atom).cloned() else {
+        let Some(old_key) = self.eq_atom_signatures.get(&atom).copied() else {
             return;
         };
-        let Some(new_key) = self.compute_signature(atom) else {
+        let Some(new_key) = self.compute_eq_key(atom) else {
             return;
         };
         if old_key == new_key {
             return;
         }
 
-        self.move_eq_atom_watch(atom, &old_key, new_key.clone());
+        self.move_eq_atom_watch(atom, &old_key, new_key);
         self.eq_watch_trail.push(EqWatchTrailEntry::Rekeyed {
             level,
             atom,
@@ -1543,7 +1541,7 @@ impl Egraph {
         });
     }
 
-    fn move_eq_atom_watch(&mut self, atom: u32, old_key: &SigKey, new_key: SigKey) {
+    fn move_eq_atom_watch(&mut self, atom: u32, old_key: &EqKey, new_key: EqKey) {
         let mut watch = None;
         let mut remove_old_key = false;
         if let Some(watches) = self.eq_atom_lits.get_mut(old_key) {
@@ -1560,12 +1558,48 @@ impl Egraph {
         }
 
         if let Some(watch) = watch {
-            self.eq_atom_lits
-                .entry(new_key.clone())
-                .or_default()
-                .push(watch);
+            self.remove_eq_atom_from_root_index(atom, old_key);
+            self.add_eq_atom_to_root_index(atom, &new_key);
+            self.eq_atom_lits.entry(new_key).or_default().push(watch);
             self.eq_atom_signatures.insert(atom, new_key);
         }
+    }
+
+    fn add_eq_atom_to_root_index(&mut self, atom: u32, key: &EqKey) {
+        for root in [key.0, key.1] {
+            self.eq_atoms_by_root.entry(root).or_default().insert(atom);
+        }
+    }
+
+    fn remove_eq_atom_from_root_index(&mut self, atom: u32, key: &EqKey) {
+        for root in [key.0, key.1] {
+            let remove_root = if let Some(atoms) = self.eq_atoms_by_root.get_mut(&root) {
+                atoms.remove(&atom);
+                atoms.is_empty()
+            } else {
+                false
+            };
+            if remove_root {
+                self.eq_atoms_by_root.remove(&root);
+            }
+        }
+    }
+
+    fn eq_key(a: u32, b: u32) -> EqKey {
+        if a <= b { (a, b) } else { (b, a) }
+    }
+
+    fn compute_eq_key(&self, atom: u32) -> Option<EqKey> {
+        let TermSlot::Term(entry) = &self.terms[atom as usize] else {
+            return None;
+        };
+        if entry.op != Op::Eq {
+            return None;
+        }
+        let [left, right] = entry.children.as_slice() else {
+            return None;
+        };
+        Some(Self::eq_key(self.find(*left), self.find(*right)))
     }
 
     /// Make vertex the root of its proof-forest tree.
@@ -1882,14 +1916,13 @@ impl EgraphTrait for Egraph {
         if self.eq_atom_signatures.contains_key(&eq_atom) {
             return;
         }
-        let Some(signature) = self.compute_signature(eq_atom) else {
-            return;
-        };
+        let signature = Self::eq_key(self.find(t1), self.find(t2));
         self.eq_atom_lits
-            .entry(signature.clone())
+            .entry(signature)
             .or_default()
             .push((eq_atom, lit));
-        self.eq_atom_signatures.insert(eq_atom, signature.clone());
+        self.add_eq_atom_to_root_index(eq_atom, &signature);
+        self.eq_atom_signatures.insert(eq_atom, signature);
         self.eq_watch_trail.push(EqWatchTrailEntry::Registered {
             level: self.decision_level,
             atom: eq_atom,

--- a/src/egraphs/basic/egraph.rs
+++ b/src/egraphs/basic/egraph.rs
@@ -239,12 +239,15 @@ pub struct Egraph {
     /// congruence-derived unions where either root was arithmetic-tagged.
     /// The incremental backend drains this to propagate equalities to Z3.
     arithmetic_merge_queue: Vec<(u32, u32)>,
-    /// Equality watches: maps an ordered pair (t1, t2) of egraph term IDs to
-    /// the SAT literal for the atom `(= t1 t2)`. When cc_union merges exactly
-    /// these two IDs (directly or via congruence), the literal is propagated.
-    /// Both orientations are stored for O(1) lookup.
-    eq_watches: FastDeterministicHashMap<(u32, u32), i32>,
+    /// Maps an equality-atom egraph term ID to its SAT literal. When a merge
+    /// makes the atom's two operands equal, the literal is propagated. Merges
+    /// are detected via the sig_table: an eq atom `(= a b)` lives in the
+    /// sig_table under `(Eq, [find(a), find(b)])`, so a single lookup on the
+    /// pre-merge roots finds any watched atom whose sides are about to unify —
+    /// including transitive merges, which an exact-operand-pair check misses.
+    eq_atom_lits: FastDeterministicHashMap<u32, i32>,
     /// Pending theory propagations to deliver to the SAT solver via cb_propagate.
+    /// Each entry is (operand1, operand2, lit) for explain_equality + delivery.
     propagation_queue: Vec<(u32, u32, i32)>,
 }
 
@@ -279,7 +282,7 @@ impl Egraph {
             sig_trail: Vec::new(),
             incremental_arithmetic: false,
             arithmetic_merge_queue: Vec::new(),
-            eq_watches: FastDeterministicHashMap::default(),
+            eq_atom_lits: FastDeterministicHashMap::default(),
             propagation_queue: Vec::new(),
         }
     }
@@ -1207,6 +1210,11 @@ impl Egraph {
             (x, y, x_root, y_root)
         };
 
+        // Look up watched equality atoms whose operands span these two classes,
+        // BEFORE the merge re-canonicalizes the sig_table. Queued at the end
+        // only once the merge has actually succeeded (no conflict).
+        let eq_atom_propagations = self.eq_atom_propagations_for_merge(x_root, y_root);
+
         // `mark_arithmetic` runs *after* `register_term` in
         // `insert_predecessor`, so a congruence merge here can precede tagging
         // on one side. If either root is tagged, queue the merge and upgrade
@@ -1405,20 +1413,46 @@ impl Egraph {
             self.display_term(x_root)
         );
 
-        // Check if this specific merge corresponds to a watched equality atom.
-        if let Some(&lit) = self.eq_watches.get(&(x, y)) {
+        for (a, b, lit) in eq_atom_propagations {
             debug_println!(
                 7,
                 0,
-                "EGRAPH PROPAGATION: {} and {} merged, propagating lit {}",
-                self.display_term(x),
-                self.display_term(y),
+                "EGRAPH PROPAGATION: ({} = {}) became true (operands merged), propagating lit {}",
+                self.display_term(a),
+                self.display_term(b),
                 lit
             );
-            self.propagation_queue.push((x, y, lit));
+            self.propagation_queue.push((a, b, lit));
         }
 
         EgraphResult::ok()
+    }
+
+    /// Look up equality atoms whose two operands are about to become equal by
+    /// merging the classes rooted at `x_root` and `y_root` (one operand in each
+    /// class). Such an atom `(= a b)` lives in the sig_table under
+    /// `(Eq, [x_root, y_root])` or the reverse, so two lookups on the pre-merge
+    /// roots find every newly-satisfied atom — including transitive merges that
+    /// an exact-operand-pair check would miss. Must be called BEFORE the merge
+    /// re-canonicalizes the sig_table. Returns (operand1, operand2, lit) tuples.
+    fn eq_atom_propagations_for_merge(&self, x_root: u32, y_root: u32) -> Vec<(u32, u32, i32)> {
+        if self.eq_atom_lits.is_empty() {
+            return Vec::new();
+        }
+        let mut out = Vec::new();
+        for key in [
+            (CanonicalOp::Eq, Children::from_slice(&[x_root, y_root])),
+            (CanonicalOp::Eq, Children::from_slice(&[y_root, x_root])),
+        ] {
+            if let Some(&atom) = self.sig_table.get(&key)
+                && let Some(&lit) = self.eq_atom_lits.get(&atom)
+                && let TermSlot::Term(e) = &self.terms[atom as usize]
+            {
+                let ch = e.children.as_slice();
+                out.push((ch[0], ch[1], lit));
+            }
+        }
+        out
     }
 
     /// Make vertex the root of its proof-forest tree.
@@ -1731,9 +1765,11 @@ impl EgraphTrait for Egraph {
         id
     }
 
-    fn register_eq(&mut self, t1: Self::TermId, t2: Self::TermId, lit: Lit) {
-        self.eq_watches.entry((t1, t2)).or_insert(lit);
-        self.eq_watches.entry((t2, t1)).or_insert(lit);
+    fn register_eq(&mut self, eq_atom: Self::TermId, _t1: Self::TermId, _t2: Self::TermId, lit: Lit) {
+        // `eq_atom` is the egraph term id of the `(= t1 t2)` atom itself. We
+        // detect its operands merging via the sig_table (see `eq_atom_lits`),
+        // so all we store here is atom_id -> lit.
+        self.eq_atom_lits.entry(eq_atom).or_insert(lit);
     }
 
     fn register_boolean_term(

--- a/src/egraphs/basic/egraph.rs
+++ b/src/egraphs/basic/egraph.rs
@@ -20,6 +20,28 @@ type SigKey = (CanonicalOp, Children);
 /// (level, key, term_id, was_inserted)
 type SigTrailEntry = (usize, SigKey, u32, bool);
 
+enum EqWatchTrailEntry {
+    Registered {
+        level: usize,
+        atom: u32,
+        key: SigKey,
+    },
+    Rekeyed {
+        level: usize,
+        atom: u32,
+        old_key: SigKey,
+        new_key: SigKey,
+    },
+}
+
+impl EqWatchTrailEntry {
+    fn level(&self) -> usize {
+        match self {
+            Self::Registered { level, .. } | Self::Rekeyed { level, .. } => *level,
+        }
+    }
+}
+
 impl fmt::Display for Egraph {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         writeln!(f, "=== Egraph Summary ===")?;
@@ -239,13 +261,15 @@ pub struct Egraph {
     /// congruence-derived unions where either root was arithmetic-tagged.
     /// The incremental backend drains this to propagate equalities to Z3.
     arithmetic_merge_queue: Vec<(u32, u32)>,
-    /// Maps an equality-atom egraph term ID to its SAT literal. When a merge
-    /// makes the atom's two operands equal, the literal is propagated. Merges
-    /// are detected via the sig_table: an eq atom `(= a b)` lives in the
-    /// sig_table under `(Eq, [find(a), find(b)])`, so a single lookup on the
-    /// pre-merge roots finds any watched atom whose sides are about to unify —
-    /// including transitive merges, which an exact-operand-pair check misses.
-    eq_atom_lits: FastDeterministicHashMap<u32, i32>,
+    /// Equality watches indexed by their current canonical signature.
+    /// Multiple atoms can share a signature after their operands merge, so each
+    /// key stores every `(atom, lit)` watch for that signature.
+    eq_atom_lits: FastDeterministicHashMap<SigKey, Vec<(u32, i32)>>,
+    /// Current signature for each watched equality atom. This makes rekeying
+    /// affected watches local to predecessors of the class being merged/split.
+    eq_atom_signatures: FastDeterministicHashMap<u32, SigKey>,
+    /// Trail for restoring the canonical equality-watch index on backtrack.
+    eq_watch_trail: Vec<EqWatchTrailEntry>,
     /// Pending theory propagations to deliver to the SAT solver via cb_propagate.
     /// Each entry is (operand1, operand2, lit) for explain_equality + delivery.
     propagation_queue: Vec<(u32, u32, i32)>,
@@ -283,6 +307,8 @@ impl Egraph {
             incremental_arithmetic: false,
             arithmetic_merge_queue: Vec::new(),
             eq_atom_lits: FastDeterministicHashMap::default(),
+            eq_atom_signatures: FastDeterministicHashMap::default(),
+            eq_watch_trail: Vec::new(),
             propagation_queue: Vec::new(),
         }
     }
@@ -935,6 +961,33 @@ impl Egraph {
             self.proof_forest_backtrack(backtrack_equality, y, y_root);
         }
 
+        // Restore equality-watch signatures after restoring union-find. Watches
+        // registered above the target level persist, but must be canonicalized
+        // against the restored roots.
+        while self
+            .eq_watch_trail
+            .last()
+            .is_some_and(|entry| entry.level() > level)
+        {
+            match self.eq_watch_trail.pop().unwrap() {
+                EqWatchTrailEntry::Rekeyed {
+                    atom,
+                    old_key,
+                    new_key,
+                    ..
+                } => {
+                    self.move_eq_atom_watch(atom, &new_key, old_key);
+                }
+                EqWatchTrailEntry::Registered { atom, key, .. } => {
+                    if let Some(restored_key) = self.compute_signature(atom)
+                        && restored_key != key
+                    {
+                        self.move_eq_atom_watch(atom, &key, restored_key);
+                    }
+                }
+            }
+        }
+
         // Replay sig_trail in reverse AFTER UF is restored.
         // Use the stored key directly — recomputing from find() would give the wrong key.
         while let Some((entry_level, _, _, _)) = self.sig_trail.last() {
@@ -1278,6 +1331,7 @@ impl Egraph {
             self.display_term(y_root)
         );
         self.make_root(y, proof_parent);
+        self.reindex_eq_atom_predecessors(y_root, level);
 
         // Early conflict check: x_root's existing disequalities may already be
         // violated now that y's class has been merged in.
@@ -1444,15 +1498,74 @@ impl Egraph {
             (CanonicalOp::Eq, Children::from_slice(&[x_root, y_root])),
             (CanonicalOp::Eq, Children::from_slice(&[y_root, x_root])),
         ] {
-            if let Some(&atom) = self.sig_table.get(&key)
-                && let Some(&lit) = self.eq_atom_lits.get(&atom)
-                && let TermSlot::Term(e) = &self.terms[atom as usize]
-            {
-                let ch = e.children.as_slice();
-                out.push((ch[0], ch[1], lit));
+            if let Some(watches) = self.eq_atom_lits.get(&key) {
+                for &(atom, lit) in watches {
+                    if let TermSlot::Term(e) = &self.terms[atom as usize] {
+                        let ch = e.children.as_slice();
+                        out.push((ch[0], ch[1], lit));
+                    }
+                }
             }
         }
         out
+    }
+
+    /// Rekey watched equality atoms whose signatures changed because `root`
+    /// was merged into another class or restored by backtracking.
+    fn reindex_eq_atom_predecessors(&mut self, root: u32, level: usize) {
+        let atoms: Vec<u32> = self.predecessors[root as usize]
+            .keys()
+            .filter(|atom| self.eq_atom_signatures.contains_key(atom))
+            .copied()
+            .collect();
+        for atom in atoms {
+            self.reindex_eq_atom(atom, level);
+        }
+    }
+
+    fn reindex_eq_atom(&mut self, atom: u32, level: usize) {
+        let Some(old_key) = self.eq_atom_signatures.get(&atom).cloned() else {
+            return;
+        };
+        let Some(new_key) = self.compute_signature(atom) else {
+            return;
+        };
+        if old_key == new_key {
+            return;
+        }
+
+        self.move_eq_atom_watch(atom, &old_key, new_key.clone());
+        self.eq_watch_trail.push(EqWatchTrailEntry::Rekeyed {
+            level,
+            atom,
+            old_key,
+            new_key,
+        });
+    }
+
+    fn move_eq_atom_watch(&mut self, atom: u32, old_key: &SigKey, new_key: SigKey) {
+        let mut watch = None;
+        let mut remove_old_key = false;
+        if let Some(watches) = self.eq_atom_lits.get_mut(old_key) {
+            if let Some(index) = watches
+                .iter()
+                .position(|(watched_atom, _)| *watched_atom == atom)
+            {
+                watch = Some(watches.swap_remove(index));
+            }
+            remove_old_key = watches.is_empty();
+        }
+        if remove_old_key {
+            self.eq_atom_lits.remove(old_key);
+        }
+
+        if let Some(watch) = watch {
+            self.eq_atom_lits
+                .entry(new_key.clone())
+                .or_default()
+                .push(watch);
+            self.eq_atom_signatures.insert(atom, new_key);
+        }
     }
 
     /// Make vertex the root of its proof-forest tree.
@@ -1765,11 +1878,29 @@ impl EgraphTrait for Egraph {
         id
     }
 
-    fn register_eq(&mut self, eq_atom: Self::TermId, _t1: Self::TermId, _t2: Self::TermId, lit: Lit) {
-        // `eq_atom` is the egraph term id of the `(= t1 t2)` atom itself. We
-        // detect its operands merging via the sig_table (see `eq_atom_lits`),
-        // so all we store here is atom_id -> lit.
-        self.eq_atom_lits.entry(eq_atom).or_insert(lit);
+    fn register_eq(&mut self, eq_atom: Self::TermId, t1: Self::TermId, t2: Self::TermId, lit: Lit) {
+        if self.eq_atom_signatures.contains_key(&eq_atom) {
+            return;
+        }
+        let Some(signature) = self.compute_signature(eq_atom) else {
+            return;
+        };
+        self.eq_atom_lits
+            .entry(signature.clone())
+            .or_default()
+            .push((eq_atom, lit));
+        self.eq_atom_signatures.insert(eq_atom, signature.clone());
+        self.eq_watch_trail.push(EqWatchTrailEntry::Registered {
+            level: self.decision_level,
+            atom: eq_atom,
+            key: signature,
+        });
+
+        // Dynamically-created equality atoms can be registered after their
+        // operands have already merged.
+        if self.find(t1) == self.find(t2) {
+            self.propagation_queue.push((t1, t2, lit));
+        }
     }
 
     fn register_boolean_term(
@@ -1877,5 +2008,94 @@ impl EgraphTrait for Egraph {
     ) -> Option<Vec<(Self::TermId, Self::TermId)>> {
         let mut tracker = ProofTracker::new();
         self.leastcommonancestor(t1, t2, &mut tracker)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn local(egraph: &mut Egraph, name: &str) -> u32 {
+        egraph.register_term(Op::Local(name.to_string()), &[], false)
+    }
+
+    fn watch_eq(egraph: &mut Egraph, left: u32, right: u32, lit: i32) {
+        let atom = egraph.register_term(Op::Eq, &[left, right], false);
+        egraph.register_eq(atom, left, right, lit);
+    }
+
+    #[test]
+    fn propagation_lookup_returns_all_watches_for_a_canonical_signature() {
+        let mut egraph = Egraph::new();
+        let a = local(&mut egraph, "a");
+        let b = local(&mut egraph, "b");
+        let c = local(&mut egraph, "c");
+        let d = local(&mut egraph, "d");
+        watch_eq(&mut egraph, a, b, 1);
+        watch_eq(&mut egraph, c, d, 2);
+
+        assert!(egraph.assert_equal(a, c).conflict.is_none());
+        assert!(egraph.assert_equal(b, d).conflict.is_none());
+        assert!(egraph.drain_propagations().is_empty());
+
+        assert!(egraph.assert_equal(a, b).conflict.is_none());
+        let mut lits: Vec<i32> = egraph
+            .drain_propagations()
+            .into_iter()
+            .map(|propagation| propagation.lit)
+            .collect();
+        lits.sort_unstable();
+        assert_eq!(lits, vec![1, 2]);
+    }
+
+    #[test]
+    fn propagation_index_is_rekeyed_on_backtrack() {
+        let mut egraph = Egraph::new();
+        let a = local(&mut egraph, "a");
+        let b = local(&mut egraph, "b");
+        let c = local(&mut egraph, "c");
+        watch_eq(&mut egraph, a, b, 7);
+
+        egraph.notify_new_decision_level();
+        assert!(egraph.assert_equal(c, a).conflict.is_none());
+        assert!(egraph.drain_propagations().is_empty());
+        egraph.backtrack_to(0);
+
+        assert!(egraph.assert_equal(a, b).conflict.is_none());
+        let propagations = egraph.drain_propagations();
+        assert_eq!(propagations.len(), 1);
+        assert_eq!(propagations[0].lit, 7);
+    }
+
+    #[test]
+    fn watch_registered_under_a_temporary_merge_is_rekeyed_on_backtrack() {
+        let mut egraph = Egraph::new();
+        let a = local(&mut egraph, "a");
+        let b = local(&mut egraph, "b");
+        let c = local(&mut egraph, "c");
+
+        egraph.notify_new_decision_level();
+        assert!(egraph.assert_equal(c, a).conflict.is_none());
+        watch_eq(&mut egraph, a, b, 9);
+        egraph.backtrack_to(0);
+
+        assert!(egraph.assert_equal(a, b).conflict.is_none());
+        let propagations = egraph.drain_propagations();
+        assert_eq!(propagations.len(), 1);
+        assert_eq!(propagations[0].lit, 9);
+    }
+
+    #[test]
+    fn registering_an_already_true_equality_queues_it_immediately() {
+        let mut egraph = Egraph::new();
+        let a = local(&mut egraph, "a");
+        let b = local(&mut egraph, "b");
+        assert!(egraph.assert_equal(a, b).conflict.is_none());
+
+        watch_eq(&mut egraph, a, b, 11);
+
+        let propagations = egraph.drain_propagations();
+        assert_eq!(propagations.len(), 1);
+        assert_eq!(propagations[0].lit, 11);
     }
 }

--- a/src/egraphs/basic/egraph.rs
+++ b/src/egraphs/basic/egraph.rs
@@ -239,11 +239,11 @@ pub struct Egraph {
     /// congruence-derived unions where either root was arithmetic-tagged.
     /// The incremental backend drains this to propagate equalities to Z3.
     arithmetic_merge_queue: Vec<(u32, u32)>,
-    /// Equality watches: maps an unordered pair {t1, t2} (stored as (min, max))
-    /// to the SAT literal that should be propagated when t1 and t2 become equal.
-    /// The keys are original (non-canonical) term IDs — we check at merge time
-    /// whether the two sides of a watched pair now share a root.
-    eq_watches: Vec<(u32, u32, i32)>,
+    /// Equality watches: maps an ordered pair (t1, t2) of egraph term IDs to
+    /// the SAT literal for the atom `(= t1 t2)`. When cc_union merges exactly
+    /// these two IDs (directly or via congruence), the literal is propagated.
+    /// Both orientations are stored for O(1) lookup.
+    eq_watches: FastDeterministicHashMap<(u32, u32), i32>,
     /// Pending theory propagations to deliver to the SAT solver via cb_propagate.
     propagation_queue: Vec<(u32, u32, i32)>,
 }
@@ -279,7 +279,7 @@ impl Egraph {
             sig_trail: Vec::new(),
             incremental_arithmetic: false,
             arithmetic_merge_queue: Vec::new(),
-            eq_watches: Vec::new(),
+            eq_watches: FastDeterministicHashMap::default(),
             propagation_queue: Vec::new(),
         }
     }
@@ -1405,30 +1405,20 @@ impl Egraph {
             self.display_term(x_root)
         );
 
-        self.check_eq_watches();
+        // Check if this specific merge corresponds to a watched equality atom.
+        if let Some(&lit) = self.eq_watches.get(&(x, y)) {
+            debug_println!(
+                7,
+                0,
+                "EGRAPH PROPAGATION: {} and {} merged, propagating lit {}",
+                self.display_term(x),
+                self.display_term(y),
+                lit
+            );
+            self.propagation_queue.push((x, y, lit));
+        }
 
         EgraphResult::ok()
-    }
-
-    /// Check all equality watches and queue propagations for any whose
-    /// two sides are now in the same equivalence class.
-    fn check_eq_watches(&mut self) {
-        for i in 0..self.eq_watches.len() {
-            let (t1, t2, lit) = self.eq_watches[i];
-            if self.find(t1) == self.find(t2)
-                && !self.propagation_queue.iter().any(|(_, _, l)| *l == lit)
-            {
-                debug_println!(
-                    7,
-                    0,
-                    "EGRAPH PROPAGATION: {} and {} merged, propagating lit {}",
-                    self.display_term(t1),
-                    self.display_term(t2),
-                    lit
-                );
-                self.propagation_queue.push((t1, t2, lit));
-            }
-        }
     }
 
     /// Make vertex the root of its proof-forest tree.
@@ -1742,9 +1732,8 @@ impl EgraphTrait for Egraph {
     }
 
     fn register_eq(&mut self, t1: Self::TermId, t2: Self::TermId, lit: Lit) {
-        if !self.eq_watches.iter().any(|(a, b, _)| (*a == t1 && *b == t2) || (*a == t2 && *b == t1)) {
-            self.eq_watches.push((t1, t2, lit));
-        }
+        self.eq_watches.entry((t1, t2)).or_insert(lit);
+        self.eq_watches.entry((t2, t1)).or_insert(lit);
     }
 
     fn register_boolean_term(

--- a/src/egraphs/basic/egraph.rs
+++ b/src/egraphs/basic/egraph.rs
@@ -6,7 +6,7 @@ use super::proofforest::*;
 use super::repr::{Children, Op, Pattern, PatternId, TermEntry, TermSlot};
 use super::unionfind::ProofTracker;
 use crate::debug_println;
-use crate::egraphs::traits::{Conflict, EgraphResult, EgraphTrait, Lit};
+use crate::egraphs::traits::{Conflict, EgraphResult, EgraphTrait, Lit, Propagation};
 use crate::log::is_important;
 use crate::utils::{DeterministicHashMap, DeterministicHashSet, FastDeterministicHashMap};
 use std::default::Default;
@@ -239,6 +239,13 @@ pub struct Egraph {
     /// congruence-derived unions where either root was arithmetic-tagged.
     /// The incremental backend drains this to propagate equalities to Z3.
     arithmetic_merge_queue: Vec<(u32, u32)>,
+    /// Equality watches: maps an unordered pair {t1, t2} (stored as (min, max))
+    /// to the SAT literal that should be propagated when t1 and t2 become equal.
+    /// The keys are original (non-canonical) term IDs — we check at merge time
+    /// whether the two sides of a watched pair now share a root.
+    eq_watches: Vec<(u32, u32, i32)>,
+    /// Pending theory propagations to deliver to the SAT solver via cb_propagate.
+    propagation_queue: Vec<(u32, u32, i32)>,
 }
 
 impl Default for Egraph {
@@ -272,6 +279,8 @@ impl Egraph {
             sig_trail: Vec::new(),
             incremental_arithmetic: false,
             arithmetic_merge_queue: Vec::new(),
+            eq_watches: Vec::new(),
+            propagation_queue: Vec::new(),
         }
     }
 
@@ -965,6 +974,9 @@ impl Egraph {
         // below) survive.
         self.arithmetic_merge_queue.clear();
 
+        // Propagation queue is also stale after backtrack.
+        self.propagation_queue.clear();
+
         // Re-do union_to_eclass via sig table probe. Entries added at or below
         // `level` were already reconciled with the sig_table at that level and
         // their signatures are stable under this backtrack.
@@ -1393,7 +1405,30 @@ impl Egraph {
             self.display_term(x_root)
         );
 
+        self.check_eq_watches();
+
         EgraphResult::ok()
+    }
+
+    /// Check all equality watches and queue propagations for any whose
+    /// two sides are now in the same equivalence class.
+    fn check_eq_watches(&mut self) {
+        for i in 0..self.eq_watches.len() {
+            let (t1, t2, lit) = self.eq_watches[i];
+            if self.find(t1) == self.find(t2)
+                && !self.propagation_queue.iter().any(|(_, _, l)| *l == lit)
+            {
+                debug_println!(
+                    7,
+                    0,
+                    "EGRAPH PROPAGATION: {} and {} merged, propagating lit {}",
+                    self.display_term(t1),
+                    self.display_term(t2),
+                    lit
+                );
+                self.propagation_queue.push((t1, t2, lit));
+            }
+        }
     }
 
     /// Make vertex the root of its proof-forest tree.
@@ -1706,8 +1741,10 @@ impl EgraphTrait for Egraph {
         id
     }
 
-    fn register_eq(&mut self, _t1: Self::TermId, _t2: Self::TermId, _lit: Lit) {
-        // TODO: watch-based equality propagation (future optimization)
+    fn register_eq(&mut self, t1: Self::TermId, t2: Self::TermId, lit: Lit) {
+        if !self.eq_watches.iter().any(|(a, b, _)| (*a == t1 && *b == t2) || (*a == t2 && *b == t1)) {
+            self.eq_watches.push((t1, t2, lit));
+        }
     }
 
     fn register_boolean_term(
@@ -1741,6 +1778,13 @@ impl EgraphTrait for Egraph {
 
     fn drain_arithmetic_equalities(&mut self) -> Vec<(Self::TermId, Self::TermId)> {
         std::mem::take(&mut self.arithmetic_merge_queue)
+    }
+
+    fn drain_propagations(&mut self) -> Vec<Propagation<Self::TermId>> {
+        std::mem::take(&mut self.propagation_queue)
+            .into_iter()
+            .map(|(t1, t2, lit)| Propagation { lit, t1, t2 })
+            .collect()
     }
 
     fn notify_new_decision_level(&mut self) {

--- a/src/egraphs/basic/egraph.rs
+++ b/src/egraphs/basic/egraph.rs
@@ -46,6 +46,32 @@ impl EqWatchTrailEntry {
     }
 }
 
+type BooleanWatch = (u32, i32);
+
+enum BooleanWatchTrailEntry {
+    Registered {
+        level: usize,
+        term: u32,
+        lit: i32,
+        indexed_root: Option<u32>,
+    },
+    Merged {
+        level: usize,
+        surviving_root: u32,
+        demoted_root: u32,
+        surviving_len: usize,
+        moved_count: usize,
+    },
+}
+
+impl BooleanWatchTrailEntry {
+    fn level(&self) -> usize {
+        match self {
+            Self::Registered { level, .. } | Self::Merged { level, .. } => *level,
+        }
+    }
+}
+
 impl fmt::Display for Egraph {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         writeln!(f, "=== Egraph Summary ===")?;
@@ -276,6 +302,16 @@ pub struct Egraph {
     eq_atoms_by_root: FastDeterministicHashMap<u32, FastDeterministicHashSet<u32>>,
     /// Trail for restoring the canonical equality-watch index on backtrack.
     eq_watch_trail: Vec<EqWatchTrailEntry>,
+    /// Egraph IDs of the distinguished Boolean constants.
+    boolean_constants: Option<(u32, u32)>,
+    /// Boolean SAT literals attached to their current non-constant e-class.
+    /// A class merged into true or false deliberately keeps its watches under
+    /// the demoted root so the constant class never accumulates them.
+    boolean_lits_by_root: FastDeterministicHashMap<u32, Vec<BooleanWatch>>,
+    /// Permanent registration index used to make registration idempotent.
+    boolean_term_lits: FastDeterministicHashMap<u32, i32>,
+    /// Trail for restoring Boolean watch ownership after union-find rollback.
+    boolean_watch_trail: Vec<BooleanWatchTrailEntry>,
     /// Pending theory propagations to deliver to the SAT solver via cb_propagate.
     /// Each entry is (operand1, operand2, lit) for explain_equality + delivery.
     propagation_queue: Vec<(u32, u32, i32)>,
@@ -316,6 +352,10 @@ impl Egraph {
             eq_atom_signatures: FastDeterministicHashMap::default(),
             eq_atoms_by_root: FastDeterministicHashMap::default(),
             eq_watch_trail: Vec::new(),
+            boolean_constants: None,
+            boolean_lits_by_root: FastDeterministicHashMap::default(),
+            boolean_term_lits: FastDeterministicHashMap::default(),
+            boolean_watch_trail: Vec::new(),
             propagation_queue: Vec::new(),
         }
     }
@@ -968,6 +1008,66 @@ impl Egraph {
             self.proof_forest_backtrack(backtrack_equality, y, y_root);
         }
 
+        // Restore Boolean watch ownership after union-find so registrations
+        // made under a temporary root can be re-homed using the restored root.
+        let mut restored_registrations = Vec::new();
+        while self
+            .boolean_watch_trail
+            .last()
+            .is_some_and(|entry| entry.level() > level)
+        {
+            match self.boolean_watch_trail.pop().unwrap() {
+                BooleanWatchTrailEntry::Registered {
+                    term,
+                    lit,
+                    indexed_root,
+                    ..
+                } => {
+                    let restored_root = self.boolean_watch_root(term);
+                    self.move_boolean_watch(term, lit, indexed_root, restored_root);
+                    if level > 0 {
+                        restored_registrations.push(BooleanWatchTrailEntry::Registered {
+                            level,
+                            term,
+                            lit,
+                            indexed_root: restored_root,
+                        });
+                    }
+                }
+                BooleanWatchTrailEntry::Merged {
+                    surviving_root,
+                    demoted_root,
+                    surviving_len,
+                    moved_count,
+                    ..
+                } => {
+                    let (watches, remove_surviving_root) = {
+                        let surviving_watches = self
+                            .boolean_lits_by_root
+                            .get_mut(&surviving_root)
+                            .expect("missing surviving Boolean watch class during rollback");
+                        assert_eq!(
+                            surviving_watches.len(),
+                            surviving_len + moved_count,
+                            "Boolean watches added after a merge were not rolled back first"
+                        );
+                        let watches = surviving_watches.split_off(surviving_len);
+                        (watches, surviving_watches.is_empty())
+                    };
+                    if remove_surviving_root {
+                        self.boolean_lits_by_root.remove(&surviving_root);
+                    }
+                    assert!(
+                        self.boolean_lits_by_root
+                            .insert(demoted_root, watches)
+                            .is_none(),
+                        "demoted Boolean watch class already existed during rollback"
+                    );
+                }
+            }
+        }
+        self.boolean_watch_trail.extend(restored_registrations);
+
         // Restore equality-watch signatures after restoring union-find. Watches
         // registered above the target level persist, but must be canonicalized
         // against the restored roots.
@@ -1270,6 +1370,12 @@ impl Egraph {
             (x, y, x_root, y_root)
         };
 
+        // Read Boolean watches before the demoted root stops being canonical.
+        // Constant classes never absorb watches; ordinary classes transfer
+        // ownership and trail the exact entries for rollback.
+        let boolean_propagations = self.boolean_propagations_for_merge(x_root, y_root);
+        self.merge_boolean_watches(x_root, y_root, level);
+
         // Look up watched equality atoms whose operands span these two classes,
         // BEFORE the merge re-canonicalizes the sig_table. Queued at the end
         // only once the merge has actually succeeded (no conflict).
@@ -1486,7 +1592,117 @@ impl Egraph {
             self.propagation_queue.push((a, b, lit));
         }
 
+        for (term, constant, lit) in boolean_propagations {
+            debug_println!(
+                7,
+                0,
+                "EGRAPH PROPAGATION: {} became equal to {}, propagating lit {}",
+                self.display_term(term),
+                self.display_term(constant),
+                lit
+            );
+            self.propagation_queue.push((term, constant, lit));
+        }
+
         EgraphResult::ok()
+    }
+
+    fn boolean_constant_value(&self, root: u32) -> Option<bool> {
+        let (true_term, false_term) = self.boolean_constants?;
+        if root == true_term {
+            Some(true)
+        } else if root == false_term {
+            Some(false)
+        } else {
+            None
+        }
+    }
+
+    fn boolean_watch_root(&self, term: u32) -> Option<u32> {
+        let root = self.find(term);
+        self.boolean_constant_value(root).is_none().then_some(root)
+    }
+
+    fn boolean_propagations_for_merge(
+        &self,
+        surviving_root: u32,
+        demoted_root: u32,
+    ) -> Vec<(u32, u32, i32)> {
+        let Some(value) = self.boolean_constant_value(surviving_root) else {
+            return Vec::new();
+        };
+        self.boolean_lits_by_root
+            .get(&demoted_root)
+            .into_iter()
+            .flatten()
+            .map(|&(term, lit)| (term, surviving_root, if value { lit } else { -lit }))
+            .collect()
+    }
+
+    fn merge_boolean_watches(&mut self, surviving_root: u32, demoted_root: u32, level: usize) {
+        if self.boolean_constant_value(surviving_root).is_some() {
+            return;
+        }
+        let Some(watches) = self.boolean_lits_by_root.remove(&demoted_root) else {
+            return;
+        };
+        let moved_count = watches.len();
+        let surviving_watches = self.boolean_lits_by_root.entry(surviving_root).or_default();
+        let surviving_len = surviving_watches.len();
+        surviving_watches.extend(watches);
+        if level > 0 {
+            self.boolean_watch_trail
+                .push(BooleanWatchTrailEntry::Merged {
+                    level,
+                    surviving_root,
+                    demoted_root,
+                    surviving_len,
+                    moved_count,
+                });
+        }
+    }
+
+    fn remove_boolean_watch(&mut self, root: u32, term: u32, lit: i32) {
+        let remove_root = {
+            let watches = self
+                .boolean_lits_by_root
+                .get_mut(&root)
+                .unwrap_or_else(|| panic!("missing Boolean watch root {root} during rollback"));
+            let index = watches
+                .iter()
+                .position(|watch| *watch == (term, lit))
+                .unwrap_or_else(|| {
+                    panic!(
+                        "missing Boolean watch ({term}, {lit}) under root {root} during rollback"
+                    )
+                });
+            watches.swap_remove(index);
+            watches.is_empty()
+        };
+        if remove_root {
+            self.boolean_lits_by_root.remove(&root);
+        }
+    }
+
+    fn move_boolean_watch(
+        &mut self,
+        term: u32,
+        lit: i32,
+        old_root: Option<u32>,
+        new_root: Option<u32>,
+    ) {
+        if old_root == new_root {
+            return;
+        }
+        if let Some(root) = old_root {
+            self.remove_boolean_watch(root, term, lit);
+        }
+        if let Some(root) = new_root {
+            self.boolean_lits_by_root
+                .entry(root)
+                .or_default()
+                .push((term, lit));
+        }
     }
 
     /// Look up equality atoms whose operands span the two classes being merged.
@@ -1936,13 +2152,42 @@ impl EgraphTrait for Egraph {
         }
     }
 
-    fn register_boolean_term(
-        &mut self,
-        op: Self::Op,
-        children: &[Self::TermId],
-        _lit: Lit,
-    ) -> Self::TermId {
-        self.register_term(op, children, false)
+    fn set_boolean_constants(&mut self, true_term: Self::TermId, false_term: Self::TermId) {
+        assert_ne!(true_term, false_term);
+        self.boolean_constants = Some((true_term, false_term));
+    }
+
+    fn register_boolean_term(&mut self, term: Self::TermId, lit: Lit) {
+        if let Some(&registered_lit) = self.boolean_term_lits.get(&term) {
+            debug_assert_eq!(registered_lit, lit);
+            return;
+        }
+
+        self.boolean_term_lits.insert(term, lit);
+        let indexed_root = self.boolean_watch_root(term);
+        if let Some(root) = indexed_root {
+            self.boolean_lits_by_root
+                .entry(root)
+                .or_default()
+                .push((term, lit));
+        } else {
+            let root = self.find(term);
+            let value = self
+                .boolean_constant_value(root)
+                .expect("Boolean watch without an index must be constant");
+            self.propagation_queue
+                .push((term, root, if value { lit } else { -lit }));
+        }
+
+        if self.decision_level > 0 {
+            self.boolean_watch_trail
+                .push(BooleanWatchTrailEntry::Registered {
+                    level: self.decision_level,
+                    term,
+                    lit,
+                    indexed_root,
+                });
+        }
     }
 
     fn mark_arithmetic(&mut self, term: Self::TermId) {
@@ -2055,6 +2300,146 @@ mod tests {
     fn watch_eq(egraph: &mut Egraph, left: u32, right: u32, lit: i32) {
         let atom = egraph.register_term(Op::Eq, &[left, right], false);
         egraph.register_eq(atom, left, right, lit);
+    }
+
+    fn boolean_constants(egraph: &mut Egraph) -> (u32, u32) {
+        let true_term = egraph.register_constant(Op::Constant("true".to_string()));
+        let false_term = egraph.register_constant(Op::Constant("false".to_string()));
+        egraph.set_boolean_constants(true_term, false_term);
+        (true_term, false_term)
+    }
+
+    #[test]
+    fn boolean_watch_propagates_when_term_becomes_true() {
+        let mut egraph = Egraph::new();
+        let (true_term, _) = boolean_constants(&mut egraph);
+        let term = local(&mut egraph, "p");
+        egraph.register_boolean_term(term, 17);
+
+        assert!(egraph.assert_equal(term, true_term).conflict.is_none());
+
+        let propagations = egraph.drain_propagations();
+        assert_eq!(propagations.len(), 1);
+        assert_eq!(propagations[0].lit, 17);
+        assert_eq!((propagations[0].t1, propagations[0].t2), (term, true_term));
+    }
+
+    #[test]
+    fn boolean_watch_propagates_negated_when_term_becomes_false() {
+        let mut egraph = Egraph::new();
+        let (_, false_term) = boolean_constants(&mut egraph);
+        let term = local(&mut egraph, "p");
+        egraph.register_boolean_term(term, 19);
+
+        assert!(egraph.assert_equal(term, false_term).conflict.is_none());
+
+        let propagations = egraph.drain_propagations();
+        assert_eq!(propagations.len(), 1);
+        assert_eq!(propagations[0].lit, -19);
+        assert_eq!((propagations[0].t1, propagations[0].t2), (term, false_term));
+    }
+
+    #[test]
+    fn ordinary_merge_transfers_all_boolean_watches_without_polluting_true() {
+        let mut egraph = Egraph::new();
+        let (true_term, _) = boolean_constants(&mut egraph);
+        let p = local(&mut egraph, "p");
+        let q = local(&mut egraph, "q");
+        egraph.register_boolean_term(p, 23);
+        egraph.register_boolean_term(q, 29);
+
+        assert!(egraph.assert_equal(p, q).conflict.is_none());
+        assert!(egraph.drain_propagations().is_empty());
+        assert!(egraph.assert_equal(q, true_term).conflict.is_none());
+
+        let mut lits: Vec<i32> = egraph
+            .drain_propagations()
+            .into_iter()
+            .map(|propagation| propagation.lit)
+            .collect();
+        lits.sort_unstable();
+        assert_eq!(lits, vec![23, 29]);
+        assert!(!egraph.boolean_lits_by_root.contains_key(&true_term));
+        assert_eq!(egraph.boolean_lits_by_root.get(&p).unwrap().len(), 2);
+    }
+
+    #[test]
+    fn boolean_watch_transfer_is_restored_on_backtrack() {
+        let mut egraph = Egraph::new();
+        let (true_term, _) = boolean_constants(&mut egraph);
+        let p = local(&mut egraph, "p");
+        let q = local(&mut egraph, "q");
+        egraph.register_boolean_term(p, 31);
+        egraph.register_boolean_term(q, 37);
+
+        egraph.notify_new_decision_level();
+        assert!(egraph.assert_equal(p, q).conflict.is_none());
+        egraph.backtrack_to(0);
+        assert!(egraph.assert_equal(p, true_term).conflict.is_none());
+
+        let propagations = egraph.drain_propagations();
+        assert_eq!(propagations.len(), 1);
+        assert_eq!(propagations[0].lit, 31);
+        assert_eq!(egraph.boolean_lits_by_root.get(&q).unwrap(), &vec![(q, 37)]);
+    }
+
+    #[test]
+    fn boolean_watch_registered_under_temporary_root_is_rehomed_on_backtrack() {
+        let mut egraph = Egraph::new();
+        let (true_term, _) = boolean_constants(&mut egraph);
+        let p = local(&mut egraph, "p");
+        let q = local(&mut egraph, "q");
+
+        egraph.notify_new_decision_level();
+        assert!(egraph.assert_equal(p, q).conflict.is_none());
+        egraph.register_boolean_term(q, 41);
+        egraph.backtrack_to(0);
+        assert!(egraph.assert_equal(q, true_term).conflict.is_none());
+
+        let propagations = egraph.drain_propagations();
+        assert_eq!(propagations.len(), 1);
+        assert_eq!(propagations[0].lit, 41);
+    }
+
+    #[test]
+    fn boolean_watch_registered_while_true_survives_backtrack() {
+        let mut egraph = Egraph::new();
+        let (true_term, _) = boolean_constants(&mut egraph);
+        let p = local(&mut egraph, "p");
+
+        egraph.notify_new_decision_level();
+        assert!(egraph.assert_equal(p, true_term).conflict.is_none());
+        egraph.register_boolean_term(p, 43);
+        assert_eq!(egraph.drain_propagations()[0].lit, 43);
+        egraph.backtrack_to(0);
+        assert!(egraph.assert_equal(p, true_term).conflict.is_none());
+
+        let propagations = egraph.drain_propagations();
+        assert_eq!(propagations.len(), 1);
+        assert_eq!(propagations[0].lit, 43);
+    }
+
+    #[test]
+    fn boolean_watch_registration_survives_staged_backtracks() {
+        let mut egraph = Egraph::new();
+        let (true_term, _) = boolean_constants(&mut egraph);
+        let p = local(&mut egraph, "p");
+        let q = local(&mut egraph, "q");
+
+        egraph.notify_new_decision_level();
+        assert!(egraph.assert_equal(p, q).conflict.is_none());
+        egraph.notify_new_decision_level();
+        egraph.register_boolean_term(q, 47);
+
+        egraph.backtrack_to(1);
+        egraph.backtrack_to(0);
+        assert!(egraph.assert_equal(p, true_term).conflict.is_none());
+        assert!(egraph.drain_propagations().is_empty());
+        assert!(egraph.assert_equal(q, true_term).conflict.is_none());
+
+        let propagations = egraph.drain_propagations();
+        assert_eq!(propagations.len(), 1);
+        assert_eq!(propagations[0].lit, 47);
     }
 
     #[test]

--- a/src/egraphs/mod.rs
+++ b/src/egraphs/mod.rs
@@ -7,4 +7,4 @@ pub mod traits;
 // Public re-exports (stable interface)
 pub use basic::egraph::Egraph;
 pub use basic::repr::{self, EgraphId, Op, Pattern, PatternId};
-pub use traits::{Conflict, EgraphResult, EgraphTrait, Lit};
+pub use traits::{Conflict, EgraphResult, EgraphTrait, Lit, Propagation};

--- a/src/egraphs/traits.rs
+++ b/src/egraphs/traits.rs
@@ -94,10 +94,11 @@ pub trait EgraphTrait {
     /// Compile a pattern for e-matching and return its PatternId.
     fn compile_pattern(&mut self, pattern: Pattern<Self::TermId>) -> PatternId;
 
-    /// Register an equality `t1 = t2` with its corresponding SAT literal.
-    /// Sets up a watch: when `t1` and `t2` become equal, `lit` is propagated.
-    /// When they become provably disequal, `-lit` is propagated.
-    fn register_eq(&mut self, t1: Self::TermId, t2: Self::TermId, lit: Lit);
+    /// Register an equality atom `(= t1 t2)` for theory propagation.
+    /// `eq_atom` is the term ID of the equality atom itself; `t1`/`t2` are its
+    /// operands. When `t1` and `t2` become equal in the egraph, `lit` is queued
+    /// for propagation to the SAT solver.
+    fn register_eq(&mut self, eq_atom: Self::TermId, t1: Self::TermId, t2: Self::TermId, lit: Lit);
 
     /// Register a boolean non-equality term with its SAT literal.
     /// When the term becomes equal to `true_term`, `lit` is propagated.

--- a/src/egraphs/traits.rs
+++ b/src/egraphs/traits.rs
@@ -100,15 +100,13 @@ pub trait EgraphTrait {
     /// for propagation to the SAT solver.
     fn register_eq(&mut self, eq_atom: Self::TermId, t1: Self::TermId, t2: Self::TermId, lit: Lit);
 
+    /// Identify the egraph terms used as the Boolean constants.
+    fn set_boolean_constants(&mut self, true_term: Self::TermId, false_term: Self::TermId);
+
     /// Register a boolean non-equality term with its SAT literal.
     /// When the term becomes equal to `true_term`, `lit` is propagated.
     /// When it becomes equal to `false_term`, `-lit` is propagated.
-    fn register_boolean_term(
-        &mut self,
-        op: Self::Op,
-        children: &[Self::TermId],
-        lit: Lit,
-    ) -> Self::TermId;
+    fn register_boolean_term(&mut self, term: Self::TermId, lit: Lit);
 
     /// Tag `term`'s class as arithmetic. When incremental arithmetic is on,
     /// any merge (direct or congruence-derived) where either pre-merge root

--- a/src/egraphs/traits.rs
+++ b/src/egraphs/traits.rs
@@ -14,6 +14,17 @@ use std::hash::Hash;
 /// Zero means "no decision" when returned from decision methods.
 pub type Lit = i32;
 
+/// A theory propagation: the egraph determined that `lit` must be true
+/// because terms `t1` and `t2` became equal (or a boolean term merged with true/false).
+#[derive(Debug, Clone)]
+pub struct Propagation<T> {
+    /// The SAT literal to propagate.
+    pub lit: Lit,
+    /// The two terms whose equality implies this literal.
+    pub t1: T,
+    pub t2: T,
+}
+
 /// Conflict explanation: the equalities that were asserted (and their
 /// congruence consequences) that together violate a disequality.
 /// T is a generic parameter for the Term type that we use
@@ -109,6 +120,10 @@ pub trait EgraphTrait {
     /// Drain arithmetic equalities produced by merges since the last drain.
     /// Callers must drain before advancing the decision level.
     fn drain_arithmetic_equalities(&mut self) -> Vec<(Self::TermId, Self::TermId)>;
+
+    /// Drain pending theory propagations. Each entry is a literal whose
+    /// watched equality became true in the egraph (both sides merged).
+    fn drain_propagations(&mut self) -> Vec<Propagation<Self::TermId>>;
 
     // --- Decision level ---
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -142,8 +142,8 @@ fn main() -> Result<(), String> {
         boolean_dt_constraints.extend(additional_constraints);
     }
 
-    // Register equality watches in the egraph for theory propagation.
-    sundance_smt::solver_state::register_equality_watches(&mut solver_state);
+    // Register Boolean theory watches after CNF has allocated all SAT literals.
+    sundance_smt::solver_state::register_theory_watches(&mut solver_state);
 
     // filtering prop_skeleton to get rid of -l l terms
     let prop_skeleton_filtered = prop_skeleton

--- a/src/main.rs
+++ b/src/main.rs
@@ -142,6 +142,9 @@ fn main() -> Result<(), String> {
         boolean_dt_constraints.extend(additional_constraints);
     }
 
+    // Register equality watches in the egraph for theory propagation.
+    sundance_smt::solver_state::register_equality_watches(&mut solver_state);
+
     // filtering prop_skeleton to get rid of -l l terms
     let prop_skeleton_filtered = prop_skeleton
         .iter()

--- a/src/solver_state.rs
+++ b/src/solver_state.rs
@@ -281,9 +281,9 @@ impl SolverState {
             if let Some(lit) = self.cnf_cache.var_map.get(&eq_yx.uid()).copied() {
                 return lit;
             }
-            self.insert_predecessor(&eq_xy, None, None, true);
+            let eq_atom = self.insert_predecessor(&eq_xy, None, None, true);
             let lit = self.get_or_allocate_lit_for_term(&eq_xy);
-            self.egraph.register_eq(x, y, lit);
+            self.egraph.register_eq(eq_atom, x, y, lit);
             lit
         }
     }
@@ -576,11 +576,14 @@ pub fn register_equality_watches(solver_state: &mut SolverState) {
         {
             let left_uid = left.uid();
             let right_uid = right.uid();
-            if let (Some(&eid_left), Some(&eid_right)) = (
+            if let (Some(&eq_atom), Some(&eid_left), Some(&eid_right)) = (
+                solver_state.id_map.get_by_left(&uid),
                 solver_state.id_map.get_by_left(&left_uid),
                 solver_state.id_map.get_by_left(&right_uid),
             ) {
-                solver_state.egraph.register_eq(eid_left, eid_right, lit);
+                solver_state
+                    .egraph
+                    .register_eq(eq_atom, eid_left, eid_right, lit);
             }
         }
     }

--- a/src/solver_state.rs
+++ b/src/solver_state.rs
@@ -243,11 +243,13 @@ impl SolverState {
     }
 
     pub fn get_or_allocate_lit_for_term(&mut self, term: &Term) -> i32 {
-        if let Some(lit) = self.get_lit_from_term_safe(term) {
+        let lit = if let Some(lit) = self.get_lit_from_term_safe(term) {
             lit
         } else {
             self.cnf_env().new_var_for_term(term)
-        }
+        };
+        self.register_theory_watch(term, lit);
+        lit
     }
 
     /// Convert an equality between two egraph IDs to a SAT literal.
@@ -347,6 +349,28 @@ impl SolverState {
         self.terms_list[false_uid as usize] = TermOption::Some(false_term.clone());
         self.id_map.insert(true_uid, true_egraph_id);
         self.id_map.insert(false_uid, false_egraph_id);
+        self.egraph
+            .set_boolean_constants(true_egraph_id, false_egraph_id);
+    }
+
+    fn register_theory_watch(&mut self, term: &Term, lit: i32) {
+        let uid = term.uid();
+        if uid == self.true_uid || uid == self.false_uid {
+            return;
+        }
+        let Some(&term_id) = self.id_map.get_by_left(&uid) else {
+            return;
+        };
+        if let Eq(left, right) = term.repr() {
+            if let (Some(&left_id), Some(&right_id)) = (
+                self.id_map.get_by_left(&left.uid()),
+                self.id_map.get_by_left(&right.uid()),
+            ) {
+                self.egraph.register_eq(term_id, left_id, right_id, lit);
+            }
+        } else {
+            self.egraph.register_boolean_term(term_id, lit);
+        }
     }
 
     /// Extract Op from a yaspar Term.
@@ -559,11 +583,10 @@ impl SolverState {
     }
 }
 
-/// Register all existing equality atoms (terms of the form `(= t1 t2)`) that
-/// have SAT literals as watches in the egraph. Call after CNF conversion is
-/// complete so that all literals are allocated.
-pub fn register_equality_watches(solver_state: &mut SolverState) {
-    use crate::egraphs::EgraphTrait;
+/// Register all existing Boolean SAT terms as egraph theory watches. Equality
+/// atoms use their operand signature; every other Boolean term is attached to
+/// its current e-class root.
+pub fn register_theory_watches(solver_state: &mut SolverState) {
     let var_map_entries: Vec<(u64, i32)> = solver_state
         .cnf_cache
         .var_map
@@ -571,22 +594,17 @@ pub fn register_equality_watches(solver_state: &mut SolverState) {
         .map(|(uid, lit)| (*uid, *lit))
         .collect();
     for (uid, lit) in var_map_entries {
-        if let Some(TermOption::Some(term)) = solver_state.terms_list.get(uid as usize).cloned()
-            && let Eq(left, right) = term.repr()
-        {
-            let left_uid = left.uid();
-            let right_uid = right.uid();
-            if let (Some(&eq_atom), Some(&eid_left), Some(&eid_right)) = (
-                solver_state.id_map.get_by_left(&uid),
-                solver_state.id_map.get_by_left(&left_uid),
-                solver_state.id_map.get_by_left(&right_uid),
-            ) {
-                solver_state
-                    .egraph
-                    .register_eq(eq_atom, eid_left, eid_right, lit);
-            }
-        }
+        let term = match solver_state.terms_list.get(uid as usize).cloned() {
+            Some(TermOption::Some(term) | TermOption::Uninitialized(term)) => term,
+            _ => continue,
+        };
+        solver_state.register_theory_watch(&term, lit);
     }
+}
+
+/// Backwards-compatible name for callers that only expect equality watches.
+pub fn register_equality_watches(solver_state: &mut SolverState) {
+    register_theory_watches(solver_state);
 }
 
 impl HasArena for SolverState {

--- a/src/solver_state.rs
+++ b/src/solver_state.rs
@@ -282,7 +282,9 @@ impl SolverState {
                 return lit;
             }
             self.insert_predecessor(&eq_xy, None, None, true);
-            self.get_or_allocate_lit_for_term(&eq_xy)
+            let lit = self.get_or_allocate_lit_for_term(&eq_xy);
+            self.egraph.register_eq(x, y, lit);
+            lit
         }
     }
 
@@ -553,6 +555,33 @@ impl SolverState {
                 polarity,
                 skolemized: false,
             });
+        }
+    }
+}
+
+/// Register all existing equality atoms (terms of the form `(= t1 t2)`) that
+/// have SAT literals as watches in the egraph. Call after CNF conversion is
+/// complete so that all literals are allocated.
+pub fn register_equality_watches(solver_state: &mut SolverState) {
+    use crate::egraphs::EgraphTrait;
+    let var_map_entries: Vec<(u64, i32)> = solver_state
+        .cnf_cache
+        .var_map
+        .iter()
+        .map(|(uid, lit)| (*uid, *lit))
+        .collect();
+    for (uid, lit) in var_map_entries {
+        if let Some(TermOption::Some(term)) = solver_state.terms_list.get(uid as usize).cloned()
+            && let Eq(left, right) = term.repr()
+        {
+            let left_uid = left.uid();
+            let right_uid = right.uid();
+            if let (Some(&eid_left), Some(&eid_right)) = (
+                solver_state.id_map.get_by_left(&left_uid),
+                solver_state.id_map.get_by_left(&right_uid),
+            ) {
+                solver_state.egraph.register_eq(eid_left, eid_right, lit);
+            }
         }
     }
 }


### PR DESCRIPTION
When the egraph merges two terms t1 and t2 (via direct assertion or congruence closure), and there exists an equality atom (= t1 t2) with a SAT literal, propagate that literal as true to CaDiCaL via the IPASIR-UP cb_propagate/cb_add_reason_clause_lit interface.

The reason clause is built from explain_equality, giving the minimal set of asserted equalities that caused the merge. This lets the SAT solver learn the implication without needing to branch on the equality atom.

Implementation:
- Add eq_watches and propagation_queue to Egraph
- Implement register_eq to install watches
- Fire watches in cc_union after successful merge
- Drain propagations in notify_assignment and deliver via cb_propagate
- Clear pending propagations on backtrack
- Register watches for all equality atoms after CNF conversion, and for dynamically created equalities in make_eq

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
