### PR TITLE
Enable release profile optimizations for LLVM

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,2 +1,5 @@
 [env]
 Z3_SYS_BUNDLED_DIR_OVERRIDE = { value = "z3", relative = true }
+
+[target.x86_64-unknown-linux-gnu]
+rustflags = ["-C", "target-cpu=native"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,6 +44,8 @@ harness = true
 
 [profile.release]
 debug = true
+lto = "fat"
+codegen-units = 1
 
 [lib]
 name = "sundance_smt"


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

- Add lto = "fat" and codegen-units = 1 to [profile.release]
- Add target-cpu=native rustflag for x86_64 targets

This leads to slower compile time, but slightly faster performance


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
