### PR TITLE
Migrate to yaspar-ir 2.7.5

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ bundled-z3 = ["z3-solver", "z3/bundled"]
 local-z3 = ["z3-solver"]
 
 [dependencies]
-yaspar-ir = "=2.7.2"
+yaspar-ir = "=2.7.5"
 sat-interface = "0.1.1"
 # Pin the elevate fork until upstream cadical-sys exposes CaDiCaL's elevate option.
 cadical-sys = { git = "https://github.com/amarshah1/cadical-sys.git", rev = "2f234ec95dd36ca74057691cf2fd4e8766a3c40f" }

--- a/src/egraphs/basic/egraph.rs
+++ b/src/egraphs/basic/egraph.rs
@@ -11,6 +11,7 @@ use crate::log::is_important;
 use crate::utils::{DeterministicHashMap, DeterministicHashSet, FastDeterministicHashMap};
 use std::default::Default;
 use std::fmt;
+use yaspar_ir::ast::Local;
 
 /// Key for the signature table: (operator, canonical children).
 type SigKey = (CanonicalOp, Children);
@@ -1473,9 +1474,9 @@ impl Egraph {
     /// Returns all valid variable assignments.
     fn match_patterns(
         &mut self,
-        assignment: &mut DeterministicHashMap<String, u32>,
+        assignment: &mut DeterministicHashMap<Local, u32>,
         pattern_term_pairs: &[(PatternId, Option<u32>)],
-    ) -> Vec<DeterministicHashMap<String, u32>> {
+    ) -> Vec<DeterministicHashMap<Local, u32>> {
         if pattern_term_pairs.is_empty() {
             return vec![assignment.clone()];
         }
@@ -1492,11 +1493,11 @@ impl Egraph {
     /// Match a single pattern against an optional ground term, then continue with remaining pairs.
     fn match_pattern_recursive(
         &mut self,
-        assignment: &mut DeterministicHashMap<String, u32>,
+        assignment: &mut DeterministicHashMap<Local, u32>,
         pattern: &Pattern,
         ground_hint: Option<u32>,
         remaining: &Vec<(PatternId, Option<u32>)>,
-    ) -> Vec<DeterministicHashMap<String, u32>> {
+    ) -> Vec<DeterministicHashMap<Local, u32>> {
         match pattern {
             Pattern::Var(name) => {
                 let ground = ground_hint.expect("Pattern::Var requires a ground term to bind");
@@ -1539,8 +1540,8 @@ impl Egraph {
         func_name: &str,
         sub_patterns: &[Pattern],
         remaining: &Vec<(PatternId, Option<u32>)>,
-        assignment: &mut DeterministicHashMap<String, u32>,
-    ) -> Vec<DeterministicHashMap<String, u32>> {
+        assignment: &mut DeterministicHashMap<Local, u32>,
+    ) -> Vec<DeterministicHashMap<Local, u32>> {
         let function_terms = match self.function_maps.get(func_name) {
             Some(terms) => terms.clone(),
             None => return vec![],
@@ -1579,11 +1580,11 @@ impl Egraph {
     /// Match sub-patterns against ground subterms, then continue with remaining pattern pairs.
     fn match_subpatterns(
         &mut self,
-        assignment: &mut DeterministicHashMap<String, u32>,
+        assignment: &mut DeterministicHashMap<Local, u32>,
         sub_patterns: &[Pattern],
         ground_subterms: &[u32],
         remaining: &Vec<(PatternId, Option<u32>)>,
-    ) -> Vec<DeterministicHashMap<String, u32>> {
+    ) -> Vec<DeterministicHashMap<Local, u32>> {
         if sub_patterns.is_empty() {
             return self.match_patterns(assignment, remaining);
         }
@@ -1784,7 +1785,7 @@ impl EgraphTrait for Egraph {
     fn match_triggers(
         &mut self,
         trigger_term_pairs: Vec<(PatternId, Option<Self::TermId>)>,
-    ) -> Vec<DeterministicHashMap<String, u32>> {
+    ) -> Vec<DeterministicHashMap<Local, u32>> {
         let mut assignment = DeterministicHashMap::default();
         self.match_patterns(&mut assignment, &trigger_term_pairs)
     }

--- a/src/egraphs/basic/repr.rs
+++ b/src/egraphs/basic/repr.rs
@@ -4,6 +4,8 @@
 //! Internal term representation for the Sundance egraph.
 //! These types are specific to our egraph implementation, not part of the generic trait.
 
+use yaspar_ir::ast::Local;
+
 /// Egraph-internal term ID. Uses u32 so the type checker catches accidental
 /// mixing with solver-level u64 UIDs.
 pub type EgraphId = u32;
@@ -29,7 +31,7 @@ pub enum Op {
     /// Distinct
     Distinct,
     /// Pattern variable (only used in e-matching, never registered)
-    Local(String),
+    Local(Local),
     /// Global constant (variable name)
     Constant(String),
 }
@@ -146,7 +148,7 @@ pub enum TermSlot {
 #[derive(Debug, Clone)]
 pub enum Pattern<T = EgraphId> {
     /// A variable to be bound during matching
-    Var(String),
+    Var(Local),
     /// A ground term already in the egraph — match by equivalence class
     Ground(T),
     /// A function application with sub-patterns

--- a/src/egraphs/traits.rs
+++ b/src/egraphs/traits.rs
@@ -9,6 +9,7 @@
 
 use crate::egraphs::repr::{Pattern, PatternId};
 use std::hash::Hash;
+use yaspar_ir::ast::Local;
 
 /// A SAT literal: positive means the variable is true, negative means false.
 /// Zero means "no decision" when returned from decision methods.
@@ -151,11 +152,11 @@ pub trait EgraphTrait {
     /// - `Some(t)` means the pattern must match in the same equivalence class as `t`
     /// - `None` means the pattern can match any term of the right function
     ///
-    /// Returns a list of substitution maps (variable name → matched term ID).
+    /// Returns a list of substitution maps (bound variable `Local` → matched term ID).
     fn match_triggers(
         &mut self,
         trigger_term_pairs: Vec<(PatternId, Option<Self::TermId>)>,
-    ) -> Vec<crate::utils::DeterministicHashMap<String, Self::TermId>>;
+    ) -> Vec<crate::utils::DeterministicHashMap<Local, Self::TermId>>;
 
     // --- Backtracking ---
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -76,7 +76,6 @@ fn main() -> Result<(), String> {
 
     solver_state.register_bool_constants(&true_term, &false_term);
 
-    let global_names = solver_state.context.all_defined_symbols();
     let mut nnf_terms = vec![];
     for assert in assertions {
         debug_println!(22, 0, "We have the assertion {} [{}]", assert, assert.uid());
@@ -84,7 +83,7 @@ fn main() -> Result<(), String> {
         // inline the let bindings
         let expanded_term = assert
             .let_elim(&mut solver_state.context)
-            .gsubst(global_names.clone(), &mut solver_state.context);
+            .gsubst_all(&mut solver_state.context);
         debug_println!(10, 0, "Expanded form: {}", expanded_term);
 
         let skolemized_term = expanded_term;

--- a/src/quantifiers/quantifier.rs
+++ b/src/quantifiers/quantifier.rs
@@ -17,7 +17,7 @@ use crate::solver_types::Polarity;
 use crate::utils::DeterministicHashMap;
 
 use crate::debug_println;
-use yaspar_ir::ast::{LetElim, Sort, Str, Substitute, Substitution, Term, TermAllocator};
+use yaspar_ir::ast::{LetElim, Local, Sort, Str, Substitute, Substitution, Term, TermAllocator};
 
 #[derive(Debug, Clone)]
 pub(crate) enum QuantifierInstance {
@@ -135,8 +135,8 @@ pub(crate) fn instantiate_quantifiers(
             }
 
             for subs_ids in list_assignments.iter() {
-                // Convert ID map to Term map for substitution
-                let subs: DeterministicHashMap<String, Term> = subs_ids
+                // Convert the (Local -> egraph id) map into a (Local -> Term) map for substitution
+                let subs: DeterministicHashMap<Local, Term> = subs_ids
                     .iter()
                     .map(|(k, v)| {
                         (
@@ -158,10 +158,7 @@ pub(crate) fn instantiate_quantifiers(
                     .insert(subs.clone());
 
                 let term = solver_state.get_term(body);
-                let substitution = Substitution::new(
-                    subs.iter().map(|(s, t)| (s, t.clone())),
-                    &mut solver_state.context,
-                );
+                let substitution = Substitution::new(subs);
                 let substituted_term = term.subst(&substitution, &mut solver_state.context);
                 deferred_instantiations.push_back(DeferredInstantiation {
                     substituted_term,

--- a/src/quantifiers/skolem.rs
+++ b/src/quantifiers/skolem.rs
@@ -4,7 +4,6 @@
 //! Skolemization of existential quantifiers
 
 use crate::debug_println;
-use std::collections::HashMap;
 use yaspar_ir::ast::ATerm::{Annotated, Exists, Forall};
 use yaspar_ir::ast::alg::QualifiedIdentifier;
 use yaspar_ir::ast::subst::{Substitute, Substitution};
@@ -23,7 +22,7 @@ pub fn skolemize(term: &Term, context: &mut Context, polarity: bool) -> (Term, V
             } else {
                 // Create a fresh skolem variable for each existentially quantified variable
                 debug_println!(6, 0, "We are skolemizing the term {}", term);
-                let mut skolem_substitutions = HashMap::new();
+                let mut skolem_substitutions = Substitution::empty();
 
                 let mut skolem_variables = vec![];
 
@@ -41,7 +40,9 @@ pub fn skolemize(term: &Term, context: &mut Context, polarity: bool) -> (Term, V
                     let skolem_id = QualifiedIdentifier::simple(skolem_symbol);
                     let skolem_term = context.global(skolem_id, Some(var_binding.2.clone()));
 
-                    skolem_substitutions.insert(var_binding.0.clone(), skolem_term);
+                    // Key the substitution on the bound variable's `Local` (id + symbol + sort)
+                    // so distinct variables that print identically never collide.
+                    skolem_substitutions.push(var_binding.clone().into(), skolem_term);
                 }
 
                 let deannotated_body = if let Annotated(inner_term, _) = body.repr() {
@@ -51,9 +52,7 @@ pub fn skolemize(term: &Term, context: &mut Context, polarity: bool) -> (Term, V
                     body
                 };
                 // Substitute the skolem variables into the body
-                // todo: substitution needs a builder
-                let substituted_term =
-                    deannotated_body.subst(&Substitution::new_str(skolem_substitutions), context);
+                let substituted_term = deannotated_body.subst(&skolem_substitutions, context);
 
                 let negated_substituted_term = context.not(substituted_term);
                 (negated_substituted_term, skolem_variables)
@@ -70,7 +69,7 @@ pub fn skolemize(term: &Term, context: &mut Context, polarity: bool) -> (Term, V
             } else {
                 // Create a fresh skolem variable for each existentially quantified variable
                 debug_println!(6, 0, "We are skolemizing the term {}", term);
-                let mut skolem_substitutions = HashMap::new();
+                let mut skolem_substitutions = Substitution::empty();
 
                 let mut skolem_variables = vec![];
 
@@ -88,7 +87,9 @@ pub fn skolemize(term: &Term, context: &mut Context, polarity: bool) -> (Term, V
                     let skolem_id = QualifiedIdentifier::simple(skolem_symbol);
                     let skolem_term = context.global(skolem_id, Some(var_binding.2.clone()));
 
-                    skolem_substitutions.insert(var_binding.0.clone(), skolem_term);
+                    // Key the substitution on the bound variable's `Local` (id + symbol + sort)
+                    // so distinct variables that print identically never collide.
+                    skolem_substitutions.push(var_binding.clone().into(), skolem_term);
                 }
 
                 let deannotated_body = if let Annotated(inner_term, _) = body.repr() {
@@ -98,9 +99,7 @@ pub fn skolemize(term: &Term, context: &mut Context, polarity: bool) -> (Term, V
                     body
                 };
                 // Substitute the skolem variables into the body
-                // todo: substitution needs a builder
-                let substituted_term =
-                    deannotated_body.subst(&Substitution::new_str(skolem_substitutions), context);
+                let substituted_term = deannotated_body.subst(&skolem_substitutions, context);
 
                 (substituted_term, skolem_variables)
             }

--- a/src/solver_state.rs
+++ b/src/solver_state.rs
@@ -13,8 +13,8 @@ use std::collections::{HashMap, HashSet};
 use yaspar_ir::ast::ATerm::*;
 use yaspar_ir::ast::alg::CheckIdentifier;
 use yaspar_ir::ast::{
-    Arena, Attribute, Context, FetchSort, HasArena, IdentifierKind, Monomorphization, Repr, Term,
-    TermAllocator,
+    Arena, Attribute, Context, FetchSort, HasArena, IdentifierKind, Local, Monomorphization, Repr,
+    Term, TermAllocator,
 };
 
 use crate::cnf::{CNFCache, CNFConversion, CNFEnv};
@@ -119,7 +119,7 @@ pub struct SolverState {
     pub quantifiers: Vec<Quantifier>,
 
     /// Tracks quantifier instantiations to avoid duplicates.
-    pub added_instantiations: HashMap<u64, HashSet<DeterministicHashMap<String, Term>>>,
+    pub added_instantiations: HashMap<u64, HashSet<DeterministicHashMap<Local, Term>>>,
 
     /// Precomputed datatype constructor/selector info.
     pub datatype_info: DatatypeInfo,
@@ -370,7 +370,7 @@ impl SolverState {
             }
             Global(qid, _) => Op::App(qid.id_str().get().to_string()),
             Constant(c, _) => Op::Constant(format!("{:?}", c)),
-            Local(local) => Op::Local(local.symbol.to_string()),
+            Local(local) => Op::Local(local.clone()),
             _ => panic!("extract_op: unsupported term type {:?}", term.repr()),
         }
     }
@@ -449,7 +449,7 @@ impl SolverState {
 
         let op = Self::extract_op(term);
         match &op {
-            Op::Local(name) => Pattern::Var(name.clone()),
+            Op::Local(local) => Pattern::Var(local.clone()),
             Op::Constant(_)
             | Op::App(_)
             | Op::Eq


### PR DESCRIPTION
The change includes avoiding using strings to represent names. Local variables are directly represented by `Local`s.

Closes #144 #136

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
