### PR TITLE
Per round statistics

### DIFF
--- a/src/cadical_propagator.rs
+++ b/src/cadical_propagator.rs
@@ -116,9 +116,9 @@ impl<'a> CustomExternalPropagator<'a> {
     }
 
     pub fn sync_external_stats(&mut self) {
-        self.stats.added_eqs = self.solver_state.egraph.added_eqs;
-        self.stats.mk_bool_vars = (self.solver_state.cnf_cache.next_var - 1) as u64;
-        self.stats.del_clauses = self.proof_tracer.borrow().deleted_clauses;
+        self.stats.egraph_merges = self.solver_state.egraph.stats.merges;
+        self.stats.bool_vars = (self.solver_state.cnf_cache.next_var - 1) as u64;
+        self.stats.deleted_clauses = self.proof_tracer.borrow().deleted_clauses;
         self.stats.dt_accessor_ax = self.solver_state.stat_dt_accessor_ax;
         self.stats.dt_constructor_ax = self.solver_state.stat_dt_constructor_ax;
         self.stats.dt_splits = self.solver_state.stat_dt_splits;
@@ -698,7 +698,7 @@ impl<'a> ExternalPropagator for CustomExternalPropagator<'a> {
         } else {
             // this is basically saying that the clause is not forgettable; cvc5 also does false
             *is_forgettable = false;
-            self.stats.mk_clauses += 1;
+            self.stats.clauses += 1;
             debug_println!(
                 4,
                 0,

--- a/src/cadical_propagator.rs
+++ b/src/cadical_propagator.rs
@@ -115,6 +115,15 @@ impl<'a> CustomExternalPropagator<'a> {
         }
     }
 
+    pub fn sync_external_stats(&mut self) {
+        self.stats.added_eqs = self.solver_state.egraph.added_eqs;
+        self.stats.mk_bool_vars = (self.solver_state.cnf_cache.next_var - 1) as u64;
+        self.stats.del_clauses = self.proof_tracer.borrow().deleted_clauses;
+        self.stats.dt_accessor_ax = self.solver_state.stat_dt_accessor_ax;
+        self.stats.dt_constructor_ax = self.solver_state.stat_dt_constructor_ax;
+        self.stats.dt_splits = self.solver_state.stat_dt_splits;
+    }
+
     fn apply_instances(
         &mut self,
         instances: &[crate::quantifiers::quantifier::QuantifierInstance],
@@ -374,6 +383,7 @@ impl<'a> ExternalPropagator for CustomExternalPropagator<'a> {
                 0,
                 "Trying to check model when the disequalities are not empty"
             );
+            self.stats.conflicts += 1;
             return false;
         }
 
@@ -391,6 +401,7 @@ impl<'a> ExternalPropagator for CustomExternalPropagator<'a> {
             } else {
                 self.pending = Some(pending);
             }
+            self.stats.conflicts += 1;
             return false;
         }
 
@@ -446,6 +457,7 @@ impl<'a> ExternalPropagator for CustomExternalPropagator<'a> {
                         arithmetic_literals
                     );
                     self.disequalities.borrow_mut().push(arithmetic_literals);
+                    self.stats.conflicts += 1;
                     return false;
                 }
             }
@@ -572,6 +584,7 @@ impl<'a> ExternalPropagator for CustomExternalPropagator<'a> {
         }
 
         if !self.disequalities.borrow().is_empty() {
+            self.stats.conflicts += 1;
             return false;
         }
 
@@ -581,6 +594,7 @@ impl<'a> ExternalPropagator for CustomExternalPropagator<'a> {
                 crate::datatypes::occurs_check::datatype_occurs_check(self.solver_state)
             {
                 self.disequalities.borrow_mut().push(conflict_clause);
+                self.stats.conflicts += 1;
                 return false;
             }
 
@@ -595,11 +609,14 @@ impl<'a> ExternalPropagator for CustomExternalPropagator<'a> {
                     }
                 }
                 self.disequalities.borrow_mut().extend(new_clauses);
+                self.stats.conflicts += 1;
                 return false;
             }
         }
 
         debug_println!(11, 0, "Starting quantifier instantiations");
+        self.sync_external_stats();
+        self.stats.begin_round();
         self.stats.instantiation_rounds += 1;
         let mut pending = instantiate_quantifiers(self.solver_state, &self.assignments);
 
@@ -626,6 +643,7 @@ impl<'a> ExternalPropagator for CustomExternalPropagator<'a> {
         }
 
         debug_println!(4, 0, "Returning false in cb_check_found_model");
+        self.stats.conflicts += 1;
         false
     }
 
@@ -680,6 +698,7 @@ impl<'a> ExternalPropagator for CustomExternalPropagator<'a> {
         } else {
             // this is basically saying that the clause is not forgettable; cvc5 also does false
             *is_forgettable = false;
+            self.stats.mk_clauses += 1;
             debug_println!(
                 4,
                 0,

--- a/src/cdcl.rs
+++ b/src/cdcl.rs
@@ -132,7 +132,7 @@ pub fn cdcl_decision_procedure(
 
     debug_println!(2, 1, "All clauses added, starting solver");
 
-    propagator.stats.mk_clauses += clauses.len() as u64 + boolean_dt_constraints.len() as u64;
+    propagator.stats.clauses += clauses.len() as u64 + boolean_dt_constraints.len() as u64;
 
     let result = solve(&mut solver);
 

--- a/src/cdcl.rs
+++ b/src/cdcl.rs
@@ -132,6 +132,8 @@ pub fn cdcl_decision_procedure(
 
     debug_println!(2, 1, "All clauses added, starting solver");
 
+    propagator.stats.mk_clauses += clauses.len() as u64 + boolean_dt_constraints.len() as u64;
+
     let result = solve(&mut solver);
 
     // Disconnect the proof tracer before dropping the propagator
@@ -156,6 +158,10 @@ pub fn cdcl_decision_procedure(
             debug_println!(2, 0, "eDRAT proof written to: {}", p.display());
         }
     }
+
+    // Harvest stats from solver_state, egraph, and proof tracer
+    propagator.sync_external_stats();
+    propagator.stats.finish();
     (result, propagator.stats)
 }
 

--- a/src/datatypes/axioms.rs
+++ b/src/datatypes/axioms.rs
@@ -66,6 +66,9 @@ pub fn find_datatype_axioms(
     {
         let tester_apps =
             learn_exactly_one_tester_clause(solver_state, term, &dt_dec, from_quantifier);
+        if !tester_apps.is_empty() {
+            solver_state.stat_dt_constructor_ax += 1;
+        }
         vector.extend(tester_apps);
     }
 
@@ -74,6 +77,9 @@ pub fn find_datatype_axioms(
     if !lazy_dt {
         let ctor_selector_clauses =
             learn_ctors_selector_clauses(solver_state, term, sort, &dt_dec, ddsmt, lazy_dt);
+        if !ctor_selector_clauses.is_empty() {
+            solver_state.stat_dt_accessor_ax += 1;
+        }
         vector.extend(ctor_selector_clauses);
     }
 
@@ -87,6 +93,9 @@ pub fn find_datatype_axioms(
     {
         let tester_clause =
             learn_tester_for_ctor_app(solver_state, term, f.id_str(), from_quantifier);
+        if !tester_clause.is_empty() {
+            solver_state.stat_dt_constructor_ax += 1;
+        }
         vector.extend(tester_clause);
 
         let selector_ctor_clauses = learn_selector_ctor_clause(
@@ -97,6 +106,9 @@ pub fn find_datatype_axioms(
             &dt_dec,
             from_quantifier,
         );
+        if !selector_ctor_clauses.is_empty() {
+            solver_state.stat_dt_accessor_ax += 1;
+        }
         vector.extend(selector_ctor_clauses);
     }
     vector

--- a/src/datatypes/occurs_check.rs
+++ b/src/datatypes/occurs_check.rs
@@ -175,6 +175,9 @@ pub fn generate_deferred_tester_clauses(solver_state: &mut SolverState) -> Vec<V
         };
 
         let clauses = learn_exactly_one_tester_clause(solver_state, &term, &dt_dec, false);
+        if !clauses.is_empty() {
+            solver_state.stat_dt_splits += 1;
+        }
         all_clauses.extend(clauses);
     }
 

--- a/src/egraphs/basic/egraph.rs
+++ b/src/egraphs/basic/egraph.rs
@@ -239,8 +239,15 @@ pub struct Egraph {
     /// congruence-derived unions where either root was arithmetic-tagged.
     /// The incremental backend drains this to propagate equalities to Z3.
     arithmetic_merge_queue: Vec<(u32, u32)>,
+    /// Accumulated egraph statistics.
+    pub stats: EgraphStats,
+}
+
+/// Statistics accumulated by the egraph.
+#[derive(Debug, Default, Clone)]
+pub struct EgraphStats {
     /// Number of successful equality merges (where roots differed).
-    pub added_eqs: u64,
+    pub merges: u64,
 }
 
 impl Default for Egraph {
@@ -274,7 +281,7 @@ impl Egraph {
             sig_trail: Vec::new(),
             incremental_arithmetic: false,
             arithmetic_merge_queue: Vec::new(),
-            added_eqs: 0,
+            stats: EgraphStats::default(),
         }
     }
 
@@ -1190,7 +1197,7 @@ impl Egraph {
             });
         }
 
-        self.added_eqs += 1;
+        self.stats.merges += 1;
 
         // Ensure the constant (if any) remains the root: make the constant
         // side "x" so that x_root stays as root after the union.

--- a/src/egraphs/basic/egraph.rs
+++ b/src/egraphs/basic/egraph.rs
@@ -245,9 +245,9 @@ pub struct Egraph {
 
 /// Statistics accumulated by the egraph.
 #[derive(Debug, Default, Clone)]
-pub struct EgraphStats {
+pub(crate) struct EgraphStats {
     /// Number of successful equality merges (where roots differed).
-    pub merges: u64,
+    pub(crate) merges: u64,
 }
 
 impl Default for Egraph {

--- a/src/egraphs/basic/egraph.rs
+++ b/src/egraphs/basic/egraph.rs
@@ -239,6 +239,8 @@ pub struct Egraph {
     /// congruence-derived unions where either root was arithmetic-tagged.
     /// The incremental backend drains this to propagate equalities to Z3.
     arithmetic_merge_queue: Vec<(u32, u32)>,
+    /// Number of successful equality merges (where roots differed).
+    pub added_eqs: u64,
 }
 
 impl Default for Egraph {
@@ -272,6 +274,7 @@ impl Egraph {
             sig_trail: Vec::new(),
             incremental_arithmetic: false,
             arithmetic_merge_queue: Vec::new(),
+            added_eqs: 0,
         }
     }
 
@@ -1186,6 +1189,8 @@ impl Egraph {
                 diseq_lit: None,
             });
         }
+
+        self.added_eqs += 1;
 
         // Ensure the constant (if any) remains the root: make the constant
         // side "x" so that x_root stays as root after the union.

--- a/src/egraphs/basic/egraph.rs
+++ b/src/egraphs/basic/egraph.rs
@@ -240,7 +240,7 @@ pub struct Egraph {
     /// The incremental backend drains this to propagate equalities to Z3.
     arithmetic_merge_queue: Vec<(u32, u32)>,
     /// Accumulated egraph statistics.
-    pub stats: EgraphStats,
+    pub(crate) stats: EgraphStats,
 }
 
 /// Statistics accumulated by the egraph.

--- a/src/proof/proof_callbacks.rs
+++ b/src/proof/proof_callbacks.rs
@@ -40,6 +40,7 @@ impl ProofTracer for SMTProofTracer {
     }
 
     fn delete_clause(&mut self, _id: u64, _redundant: bool, clause: &[i32]) {
+        self.deleted_clauses += 1;
         self.record_deletion(&clause.to_vec());
     }
 

--- a/src/proof/proof_tracer.rs
+++ b/src/proof/proof_tracer.rs
@@ -21,7 +21,7 @@ pub struct SMTProofTracer {
     symbol_table: HashMap<Str, Vec<(Sig, FunctionMeta)>>,
     instantiations_for_smt2: Vec<(Term, Vec<(Term, bool)>)>,
     /// Number of clauses deleted by CaDiCaL (for stats)
-    pub deleted_clauses: u64,
+    pub(crate) deleted_clauses: u64,
 }
 
 fn polarize_term(term: &Term, polarity: bool) -> Term {

--- a/src/proof/proof_tracer.rs
+++ b/src/proof/proof_tracer.rs
@@ -20,6 +20,8 @@ pub struct SMTProofTracer {
     sorts: HashMap<Str, SortDef>,
     symbol_table: HashMap<Str, Vec<(Sig, FunctionMeta)>>,
     instantiations_for_smt2: Vec<(Term, Vec<(Term, bool)>)>,
+    /// Number of clauses deleted by CaDiCaL (for stats)
+    pub deleted_clauses: u64,
 }
 
 fn polarize_term(term: &Term, polarity: bool) -> Term {
@@ -148,6 +150,7 @@ impl SMTProofTracer {
             sorts,
             symbol_table,
             instantiations_for_smt2: Vec::new(),
+            deleted_clauses: 0,
         }
     }
 

--- a/src/solver_state.rs
+++ b/src/solver_state.rs
@@ -150,6 +150,14 @@ pub struct SolverState {
 
     /// SAT literals for base-case constructor testers (used by cb_decide to prefer base cases)
     pub base_case_tester_lits: Vec<i32>,
+
+    // --- Stats counters (harvested into SolverStats at end of solve) ---
+    /// Number of datatype accessor axioms generated (selector projection axioms)
+    pub stat_dt_accessor_ax: u64,
+    /// Number of datatype constructor axioms generated (tester/exhaustiveness clauses)
+    pub stat_dt_constructor_ax: u64,
+    /// Number of datatype case splits (deferred tester clauses)
+    pub stat_dt_splits: u64,
 }
 
 impl SolverState {
@@ -181,6 +189,9 @@ impl SolverState {
             eager_skolem,
             egraph,
             base_case_tester_lits: vec![],
+            stat_dt_accessor_ax: 0,
+            stat_dt_constructor_ax: 0,
+            stat_dt_splits: 0,
         }
     }
 

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -7,7 +7,7 @@ use std::time::{Duration, Instant};
 use crate::arithmetic::lia::stats::Stats as LiaStats;
 
 /// Accumulated statistics from the arithmetic sub-solver
-#[derive(Debug, Default)]
+#[derive(Debug, Default, Clone)]
 pub struct ArithStats {
     /// Total number of simplex pivots across all arithmetic checks
     pub num_simplex_steps: usize,
@@ -20,6 +20,24 @@ impl ArithStats {
         self.num_simplex_steps += lia_stats.num_simplex_steps;
         self.num_lra_solve += lia_stats.num_lra_solve;
     }
+}
+
+/// Per-round statistics snapshot (deltas for a single QI round)
+#[derive(Debug, Clone)]
+pub struct RoundStats {
+    pub decisions: u64,
+    pub backtracks: u64,
+    pub conflicts: u64,
+    pub arith_checks: u64,
+    pub instantiations: u64,
+    pub added_eqs: u64,
+    pub mk_bool_vars: u64,
+    pub mk_clauses: u64,
+    pub del_clauses: u64,
+    pub dt_accessor_ax: u64,
+    pub dt_constructor_ax: u64,
+    pub dt_splits: u64,
+    pub arith: ArithStats,
 }
 
 /// Statistics about the solver run
@@ -40,6 +58,40 @@ pub struct SolverStats {
     pub instantiation_rounds: u64,
     /// Accumulated arithmetic sub-solver statistics
     pub arith: ArithStats,
+    /// Number of theory conflicts (cb_check_found_model returning false)
+    pub conflicts: u64,
+    /// Number of clauses created (initial + theory lemmas fed to CaDiCaL)
+    pub mk_clauses: u64,
+    /// Number of clauses deleted by CaDiCaL
+    pub del_clauses: u64,
+    /// Number of boolean variables allocated
+    pub mk_bool_vars: u64,
+    /// Number of equality merges in the egraph
+    pub added_eqs: u64,
+    /// Number of datatype accessor axioms (selector projections)
+    pub dt_accessor_ax: u64,
+    /// Number of datatype constructor axioms (tester/exhaustiveness)
+    pub dt_constructor_ax: u64,
+    /// Number of datatype case splits (deferred tester clauses)
+    pub dt_splits: u64,
+    /// Number of check-sat calls
+    pub num_checks: u64,
+    /// Per-round statistics (one entry per QI round)
+    pub per_round: Vec<RoundStats>,
+    // Snapshot of totals at the start of the current round
+    snapshot_decisions: u64,
+    snapshot_backtracks: u64,
+    snapshot_conflicts: u64,
+    snapshot_arith_checks: u64,
+    snapshot_instantiations: u64,
+    snapshot_added_eqs: u64,
+    snapshot_mk_bool_vars: u64,
+    snapshot_mk_clauses: u64,
+    snapshot_del_clauses: u64,
+    snapshot_dt_accessor_ax: u64,
+    snapshot_dt_constructor_ax: u64,
+    snapshot_dt_splits: u64,
+    snapshot_arith: ArithStats,
 }
 
 impl SolverStats {
@@ -52,11 +104,88 @@ impl SolverStats {
             instantiations: 0,
             instantiation_rounds: 0,
             arith: ArithStats::default(),
+            conflicts: 0,
+            mk_clauses: 0,
+            del_clauses: 0,
+            mk_bool_vars: 0,
+            added_eqs: 0,
+            dt_accessor_ax: 0,
+            dt_constructor_ax: 0,
+            dt_splits: 0,
+            num_checks: 1,
+            per_round: Vec::new(),
+            snapshot_decisions: 0,
+            snapshot_backtracks: 0,
+            snapshot_conflicts: 0,
+            snapshot_arith_checks: 0,
+            snapshot_instantiations: 0,
+            snapshot_added_eqs: 0,
+            snapshot_mk_bool_vars: 0,
+            snapshot_mk_clauses: 0,
+            snapshot_del_clauses: 0,
+            snapshot_dt_accessor_ax: 0,
+            snapshot_dt_constructor_ax: 0,
+            snapshot_dt_splits: 0,
+            snapshot_arith: ArithStats::default(),
         }
     }
 
     pub fn elapsed(&self) -> Duration {
         self.start_time.elapsed()
+    }
+
+    /// Call at the start of each QI round to close out the previous round
+    /// and begin tracking a new one.
+    pub fn begin_round(&mut self) {
+        if self.instantiation_rounds > 0 {
+            self.per_round.push(self.round_delta());
+        }
+        self.take_snapshot();
+    }
+
+    /// Flush the final in-progress round (call after solving completes).
+    pub fn finish(&mut self) {
+        if self.instantiation_rounds > 0 {
+            self.per_round.push(self.round_delta());
+        }
+    }
+
+    fn round_delta(&self) -> RoundStats {
+        RoundStats {
+            decisions: self.decisions - self.snapshot_decisions,
+            backtracks: self.backtracks - self.snapshot_backtracks,
+            conflicts: self.conflicts - self.snapshot_conflicts,
+            arith_checks: self.arith_checks - self.snapshot_arith_checks,
+            instantiations: self.instantiations - self.snapshot_instantiations,
+            added_eqs: self.added_eqs - self.snapshot_added_eqs,
+            mk_bool_vars: self.mk_bool_vars - self.snapshot_mk_bool_vars,
+            mk_clauses: self.mk_clauses - self.snapshot_mk_clauses,
+            del_clauses: self.del_clauses - self.snapshot_del_clauses,
+            dt_accessor_ax: self.dt_accessor_ax - self.snapshot_dt_accessor_ax,
+            dt_constructor_ax: self.dt_constructor_ax - self.snapshot_dt_constructor_ax,
+            dt_splits: self.dt_splits - self.snapshot_dt_splits,
+            arith: ArithStats {
+                num_simplex_steps: self.arith.num_simplex_steps
+                    - self.snapshot_arith.num_simplex_steps,
+                num_lra_solve: self.arith.num_lra_solve - self.snapshot_arith.num_lra_solve,
+            },
+        }
+    }
+
+    fn take_snapshot(&mut self) {
+        self.snapshot_decisions = self.decisions;
+        self.snapshot_backtracks = self.backtracks;
+        self.snapshot_conflicts = self.conflicts;
+        self.snapshot_arith_checks = self.arith_checks;
+        self.snapshot_instantiations = self.instantiations;
+        self.snapshot_added_eqs = self.added_eqs;
+        self.snapshot_mk_bool_vars = self.mk_bool_vars;
+        self.snapshot_mk_clauses = self.mk_clauses;
+        self.snapshot_del_clauses = self.del_clauses;
+        self.snapshot_dt_accessor_ax = self.dt_accessor_ax;
+        self.snapshot_dt_constructor_ax = self.dt_constructor_ax;
+        self.snapshot_dt_splits = self.dt_splits;
+        self.snapshot_arith = self.arith.clone();
     }
 }
 
@@ -72,6 +201,7 @@ impl fmt::Display for SolverStats {
         writeln!(f, "{{")?;
         writeln!(f, "  \"decisions\": {},", self.decisions)?;
         writeln!(f, "  \"backtracks\": {},", self.backtracks)?;
+        writeln!(f, "  \"conflicts\": {},", self.conflicts)?;
         writeln!(f, "  \"arith_checks\": {},", self.arith_checks)?;
         writeln!(f, "  \"instantiations\": {},", self.instantiations)?;
         writeln!(
@@ -79,6 +209,14 @@ impl fmt::Display for SolverStats {
             "  \"instantiation_rounds\": {},",
             self.instantiation_rounds
         )?;
+        writeln!(f, "  \"added_eqs\": {},", self.added_eqs)?;
+        writeln!(f, "  \"mk_bool_vars\": {},", self.mk_bool_vars)?;
+        writeln!(f, "  \"mk_clauses\": {},", self.mk_clauses)?;
+        writeln!(f, "  \"del_clauses\": {},", self.del_clauses)?;
+        writeln!(f, "  \"dt_accessor_ax\": {},", self.dt_accessor_ax)?;
+        writeln!(f, "  \"dt_constructor_ax\": {},", self.dt_constructor_ax)?;
+        writeln!(f, "  \"dt_splits\": {},", self.dt_splits)?;
+        writeln!(f, "  \"num_checks\": {},", self.num_checks)?;
         writeln!(f, "  \"arith\": {{")?;
         writeln!(
             f,
@@ -87,6 +225,47 @@ impl fmt::Display for SolverStats {
         )?;
         writeln!(f, "    \"lra_solve_calls\": {}", self.arith.num_lra_solve)?;
         writeln!(f, "  }},")?;
+        if !self.per_round.is_empty() {
+            writeln!(f, "  \"per_round\": [")?;
+            for (i, round) in self.per_round.iter().enumerate() {
+                writeln!(f, "    {{")?;
+                writeln!(f, "      \"round\": {},", i + 1)?;
+                writeln!(f, "      \"decisions\": {},", round.decisions)?;
+                writeln!(f, "      \"backtracks\": {},", round.backtracks)?;
+                writeln!(f, "      \"conflicts\": {},", round.conflicts)?;
+                writeln!(f, "      \"arith_checks\": {},", round.arith_checks)?;
+                writeln!(f, "      \"instantiations\": {},", round.instantiations)?;
+                writeln!(f, "      \"added_eqs\": {},", round.added_eqs)?;
+                writeln!(f, "      \"mk_bool_vars\": {},", round.mk_bool_vars)?;
+                writeln!(f, "      \"mk_clauses\": {},", round.mk_clauses)?;
+                writeln!(f, "      \"del_clauses\": {},", round.del_clauses)?;
+                writeln!(f, "      \"dt_accessor_ax\": {},", round.dt_accessor_ax)?;
+                writeln!(
+                    f,
+                    "      \"dt_constructor_ax\": {},",
+                    round.dt_constructor_ax
+                )?;
+                writeln!(f, "      \"dt_splits\": {},", round.dt_splits)?;
+                writeln!(f, "      \"arith\": {{")?;
+                writeln!(
+                    f,
+                    "        \"simplex_steps\": {},",
+                    round.arith.num_simplex_steps
+                )?;
+                writeln!(
+                    f,
+                    "        \"lra_solve_calls\": {}",
+                    round.arith.num_lra_solve
+                )?;
+                write!(f, "      }}")?;
+                if i + 1 < self.per_round.len() {
+                    writeln!(f, "\n    }},")?;
+                } else {
+                    writeln!(f, "\n    }}")?;
+                }
+            }
+            writeln!(f, "  ],")?;
+        }
         writeln!(f, "  \"solve_time\": {:.3}", elapsed.as_secs_f64())?;
         write!(f, "}}")
     }

--- a/src/stats.rs
+++ b/src/stats.rs
@@ -30,10 +30,10 @@ pub struct RoundStats {
     pub conflicts: u64,
     pub arith_checks: u64,
     pub instantiations: u64,
-    pub added_eqs: u64,
-    pub mk_bool_vars: u64,
-    pub mk_clauses: u64,
-    pub del_clauses: u64,
+    pub egraph_merges: u64,
+    pub bool_vars: u64,
+    pub clauses: u64,
+    pub deleted_clauses: u64,
     pub dt_accessor_ax: u64,
     pub dt_constructor_ax: u64,
     pub dt_splits: u64,
@@ -61,13 +61,13 @@ pub struct SolverStats {
     /// Number of theory conflicts (cb_check_found_model returning false)
     pub conflicts: u64,
     /// Number of clauses created (initial + theory lemmas fed to CaDiCaL)
-    pub mk_clauses: u64,
+    pub clauses: u64,
     /// Number of clauses deleted by CaDiCaL
-    pub del_clauses: u64,
+    pub deleted_clauses: u64,
     /// Number of boolean variables allocated
-    pub mk_bool_vars: u64,
-    /// Number of equality merges in the egraph
-    pub added_eqs: u64,
+    pub bool_vars: u64,
+    /// Number of equality merges in the egraph (where roots differed)
+    pub egraph_merges: u64,
     /// Number of datatype accessor axioms (selector projections)
     pub dt_accessor_ax: u64,
     /// Number of datatype constructor axioms (tester/exhaustiveness)
@@ -84,10 +84,10 @@ pub struct SolverStats {
     snapshot_conflicts: u64,
     snapshot_arith_checks: u64,
     snapshot_instantiations: u64,
-    snapshot_added_eqs: u64,
-    snapshot_mk_bool_vars: u64,
-    snapshot_mk_clauses: u64,
-    snapshot_del_clauses: u64,
+    snapshot_egraph_merges: u64,
+    snapshot_bool_vars: u64,
+    snapshot_clauses: u64,
+    snapshot_deleted_clauses: u64,
     snapshot_dt_accessor_ax: u64,
     snapshot_dt_constructor_ax: u64,
     snapshot_dt_splits: u64,
@@ -105,10 +105,10 @@ impl SolverStats {
             instantiation_rounds: 0,
             arith: ArithStats::default(),
             conflicts: 0,
-            mk_clauses: 0,
-            del_clauses: 0,
-            mk_bool_vars: 0,
-            added_eqs: 0,
+            clauses: 0,
+            deleted_clauses: 0,
+            bool_vars: 0,
+            egraph_merges: 0,
             dt_accessor_ax: 0,
             dt_constructor_ax: 0,
             dt_splits: 0,
@@ -119,10 +119,10 @@ impl SolverStats {
             snapshot_conflicts: 0,
             snapshot_arith_checks: 0,
             snapshot_instantiations: 0,
-            snapshot_added_eqs: 0,
-            snapshot_mk_bool_vars: 0,
-            snapshot_mk_clauses: 0,
-            snapshot_del_clauses: 0,
+            snapshot_egraph_merges: 0,
+            snapshot_bool_vars: 0,
+            snapshot_clauses: 0,
+            snapshot_deleted_clauses: 0,
             snapshot_dt_accessor_ax: 0,
             snapshot_dt_constructor_ax: 0,
             snapshot_dt_splits: 0,
@@ -157,10 +157,10 @@ impl SolverStats {
             conflicts: self.conflicts - self.snapshot_conflicts,
             arith_checks: self.arith_checks - self.snapshot_arith_checks,
             instantiations: self.instantiations - self.snapshot_instantiations,
-            added_eqs: self.added_eqs - self.snapshot_added_eqs,
-            mk_bool_vars: self.mk_bool_vars - self.snapshot_mk_bool_vars,
-            mk_clauses: self.mk_clauses - self.snapshot_mk_clauses,
-            del_clauses: self.del_clauses - self.snapshot_del_clauses,
+            egraph_merges: self.egraph_merges - self.snapshot_egraph_merges,
+            bool_vars: self.bool_vars - self.snapshot_bool_vars,
+            clauses: self.clauses - self.snapshot_clauses,
+            deleted_clauses: self.deleted_clauses - self.snapshot_deleted_clauses,
             dt_accessor_ax: self.dt_accessor_ax - self.snapshot_dt_accessor_ax,
             dt_constructor_ax: self.dt_constructor_ax - self.snapshot_dt_constructor_ax,
             dt_splits: self.dt_splits - self.snapshot_dt_splits,
@@ -178,10 +178,10 @@ impl SolverStats {
         self.snapshot_conflicts = self.conflicts;
         self.snapshot_arith_checks = self.arith_checks;
         self.snapshot_instantiations = self.instantiations;
-        self.snapshot_added_eqs = self.added_eqs;
-        self.snapshot_mk_bool_vars = self.mk_bool_vars;
-        self.snapshot_mk_clauses = self.mk_clauses;
-        self.snapshot_del_clauses = self.del_clauses;
+        self.snapshot_egraph_merges = self.egraph_merges;
+        self.snapshot_bool_vars = self.bool_vars;
+        self.snapshot_clauses = self.clauses;
+        self.snapshot_deleted_clauses = self.deleted_clauses;
         self.snapshot_dt_accessor_ax = self.dt_accessor_ax;
         self.snapshot_dt_constructor_ax = self.dt_constructor_ax;
         self.snapshot_dt_splits = self.dt_splits;
@@ -209,10 +209,10 @@ impl fmt::Display for SolverStats {
             "  \"instantiation_rounds\": {},",
             self.instantiation_rounds
         )?;
-        writeln!(f, "  \"added_eqs\": {},", self.added_eqs)?;
-        writeln!(f, "  \"mk_bool_vars\": {},", self.mk_bool_vars)?;
-        writeln!(f, "  \"mk_clauses\": {},", self.mk_clauses)?;
-        writeln!(f, "  \"del_clauses\": {},", self.del_clauses)?;
+        writeln!(f, "  \"egraph_merges\": {},", self.egraph_merges)?;
+        writeln!(f, "  \"bool_vars\": {},", self.bool_vars)?;
+        writeln!(f, "  \"clauses\": {},", self.clauses)?;
+        writeln!(f, "  \"deleted_clauses\": {},", self.deleted_clauses)?;
         writeln!(f, "  \"dt_accessor_ax\": {},", self.dt_accessor_ax)?;
         writeln!(f, "  \"dt_constructor_ax\": {},", self.dt_constructor_ax)?;
         writeln!(f, "  \"dt_splits\": {},", self.dt_splits)?;
@@ -235,10 +235,10 @@ impl fmt::Display for SolverStats {
                 writeln!(f, "      \"conflicts\": {},", round.conflicts)?;
                 writeln!(f, "      \"arith_checks\": {},", round.arith_checks)?;
                 writeln!(f, "      \"instantiations\": {},", round.instantiations)?;
-                writeln!(f, "      \"added_eqs\": {},", round.added_eqs)?;
-                writeln!(f, "      \"mk_bool_vars\": {},", round.mk_bool_vars)?;
-                writeln!(f, "      \"mk_clauses\": {},", round.mk_clauses)?;
-                writeln!(f, "      \"del_clauses\": {},", round.del_clauses)?;
+                writeln!(f, "      \"egraph_merges\": {},", round.egraph_merges)?;
+                writeln!(f, "      \"bool_vars\": {},", round.bool_vars)?;
+                writeln!(f, "      \"clauses\": {},", round.clauses)?;
+                writeln!(f, "      \"deleted_clauses\": {},", round.deleted_clauses)?;
                 writeln!(f, "      \"dt_accessor_ax\": {},", round.dt_accessor_ax)?;
                 writeln!(
                     f,


### PR DESCRIPTION
Add 9 new stats counters (added_eqs, conflicts, mk_bool_vars, mk_clauses, del_clauses, dt_accessor_ax, dt_constructor_ax, dt_splits, num_checks) to match z3's statistics output where feasible. All counters are also tracked per quantifier instantiation round, showing deltas for each round in the per_round array.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
