### PR TITLE
revert changes in #116

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -15,7 +15,7 @@ concurrency:
 jobs:
   check:
     name: Check
-    runs-on: ubuntu-latest
+    runs-on: macos-latest
     permissions:
       contents: read
     steps:
@@ -30,7 +30,7 @@ jobs:
       - uses: Swatinem/rust-cache@v2
 
       - name: Install build dependencies
-        run: sudo apt-get update && sudo apt-get install -y cmake
+        run: brew update && brew install cmake
 
       - name: Setup Z3
         uses: ./.github/actions/setup-z3
@@ -82,7 +82,7 @@ jobs:
 
   lints:
     name: Lints
-    runs-on: ubuntu-latest
+    runs-on: macos-latest
     permissions:
       contents: read
     steps:
@@ -99,7 +99,7 @@ jobs:
       - uses: Swatinem/rust-cache@v2
 
       - name: Install build dependencies
-        run: sudo apt-get update && sudo apt-get install -y cmake
+        run: brew update && brew install cmake
 
       - name: Setup Z3
         uses: ./.github/actions/setup-z3
@@ -117,7 +117,7 @@ jobs:
 
   docs:
     name: Documentation
-    runs-on: ubuntu-latest
+    runs-on: macos-latest
     permissions:
       contents: read
     steps:
@@ -131,7 +131,7 @@ jobs:
       - uses: Swatinem/rust-cache@v2
 
       - name: Install build dependencies
-        run: sudo apt-get update && sudo apt-get install -y cmake
+        run: brew update && brew install cmake
 
       - name: Setup Z3
         uses: ./.github/actions/setup-z3

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -5,7 +5,7 @@ on:
       - 'v[0-9]+.[0-9]+.[0-9]+'
 jobs:
   publish:
-    runs-on: ubuntu-latest
+    runs-on: macos-latest
     environment: release  # Optional: for enhanced security
     permissions:
       id-token: write     # Required for OIDC token exchange

--- a/src/solver_state.rs
+++ b/src/solver_state.rs
@@ -846,35 +846,15 @@ pub fn find_if_eq_diseq<'a>(
 ) -> Assertion {
     let hash = solver_state.current_hash;
     match term.repr() {
-        App(f, t, _)
-            if (matches!(f.get_kind(), Some(IdentifierKind::Is(_)))
-                || (f.get_kind().is_none() && f.id_str().get().starts_with("is-")))
-                && t.len() == 1
-                && sign =>
-        {
-            let ctor_name = if let Some(IdentifierKind::Is(sym)) = f.get_kind() {
-                Some(sym.clone())
-            } else {
-                let name = &f.id_str().get()[3..];
-                solver_state
-                    .datatype_info
-                    .constructors
-                    .keys()
-                    .find(|k| *k.get() == *name)
-                    .cloned()
-            };
-            if let Some(ctor_name) = ctor_name {
-                let inner_term = t[0].clone();
-                Assertion::Tester {
-                    ctor_name,
-                    inner_term,
-                    term: term.clone(),
-                }
-            } else {
-                Assertion::Other
+        App(f, t, _) if sign && let Some(IdentifierKind::Is(ctor_name)) = f.get_kind() => {
+            assert_eq!(t.len(), 1);
+            let inner_term = t[0].clone();
+            Assertion::Tester {
+                ctor_name,
+                inner_term,
+                term: term.clone(),
             }
         }
-
         Eq(left, right) => {
             if sign {
                 debug_println!(1, 2, "Creating equality assertion");


### PR DESCRIPTION
revert #116; yaspar-ir 2.7.5 now supports expansion of is-X to (_ is X), so testers are fully supported

*Issue #, if available:*

Closes #115

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
