### PR TITLE
Stage 1/N of an incremental interface to the internal arithmetic solver

### DIFF
--- a/src/arithmetic/lia/incremental.rs
+++ b/src/arithmetic/lia/incremental.rs
@@ -31,7 +31,7 @@
 //!
 //! # Scope / limitations of this first frontend
 //!
-//! - **LRA (rational) reasoning only.** Registered variables are integer-sorted, but
+//! - **LRA (Real) reasoning only.** Registered variables are integer-sorted, but
 //!   integrality is *not* enforced: [`IncrementalLraSolver::check`] may report `Sat`
 //!   for a system that has no integer solution. Sound integer reasoning
 //!   (branch-and-bound) is a later increment.
@@ -204,9 +204,11 @@ impl IncrementalLraSolver {
         }
 
         if let Some(def) = definition {
-            // Assert `new_var == def`, i.e. `new_var - def == 0`, as a fresh row. This
-            // is tautological (new_var is fresh), so it is never needed in a conflict
-            // core and is tracked with no literals.
+            // Assert `new_var == def`, i.e. `new_var - def == 0`, as a fresh row tracked with no
+            // SAT literal, since `new_var` is fresh and this equality never constrains previously
+            // registered variables on its own. This is sound only under the convention that UNSAT
+            // cores are reported relative to all active definitions/background equalities, not as a
+            // self-contained refutation over SAT literals alone.
             self.push_relation(
                 ArithConstraint::Eq(
                     ArithExpr::linear(vec![(var_id, IBig::from(1))], IBig::from(0)),
@@ -277,12 +279,8 @@ impl IncrementalLraSolver {
     /// [`Self::mark_model_var`]) appear in the buckets, keyed by their truncated
     /// integer model value. Variables that are unconstrained (never referenced by any
     /// pushed row) default to `0`.
-    pub fn check(&mut self) -> ArithCheckResult {
-        let decision = self
-            .solver
-            .solve()
-            .expect("lra-inc: unexpected solver error")
-            .decision;
+    pub fn check(&mut self) -> SolverResult<ArithCheckResult> {
+        let decision = self.solver.solve()?.decision;
         match decision {
             SolverDecision::FEASIBLE(assignment) => {
                 let mut buckets: DeterministicHashMap<IBig, DeterministicHashSet<VarId>> =
@@ -294,7 +292,7 @@ impl IncrementalLraSolver {
                     buckets.entry(ibig).or_default().insert(*var_id);
                 }
                 debug_println!(21, 0, "[lra-inc] SAT buckets={:?}", buckets);
-                ArithCheckResult::Sat(buckets)
+                Ok(ArithCheckResult::Sat(buckets))
             }
             SolverDecision::INFEASIBLE(conflict) => {
                 let lits: DeterministicHashSet<i32> = conflict
@@ -302,7 +300,7 @@ impl IncrementalLraSolver {
                     .flat_map(|var| self.slack_to_lits.get(var).into_iter().flatten().copied())
                     .collect();
                 debug_println!(21, 0, "[lra-inc] UNSAT core lits={:?}", lits);
-                ArithCheckResult::Unsat(lits.into_iter().collect())
+                Ok(ArithCheckResult::Unsat(lits.into_iter().collect()))
             }
             SolverDecision::UNKNOWN => {
                 // Pure LRA `solve` terminates in FEASIBLE/INFEASIBLE; treat an
@@ -317,7 +315,7 @@ impl IncrementalLraSolver {
                     let ibig = value.to_int().value().clone();
                     buckets.entry(ibig).or_default().insert(*var_id);
                 }
-                ArithCheckResult::Sat(buckets)
+                Ok(ArithCheckResult::Sat(buckets))
             }
         }
     }
@@ -417,7 +415,7 @@ mod tests {
     #[test]
     fn empty_system_is_sat() {
         let mut s = IncrementalLraSolver::new();
-        assert!(is_sat(&s.check()));
+        assert!(is_sat(&s.check().unwrap()));
     }
 
     #[test]
@@ -427,7 +425,7 @@ mod tests {
         // x <= 5
         s.push_constraint(ArithConstraint::Leq(term(x, 1), ArithExpr::constant(5)), 10)
             .unwrap();
-        assert!(is_sat(&s.check()));
+        assert!(is_sat(&s.check().unwrap()));
     }
 
     #[test]
@@ -440,7 +438,7 @@ mod tests {
         // x <= 1, lit 20
         s.push_constraint(ArithConstraint::Leq(term(x, 1), ArithExpr::constant(1)), 20)
             .unwrap();
-        match s.check() {
+        match s.check().unwrap() {
             ArithCheckResult::Unsat(core) => {
                 // Both tracking lits (negated) should appear in the conflict clause.
                 assert!(core.contains(&-10), "core {core:?} missing -10");
@@ -457,17 +455,32 @@ mod tests {
         // Level 0: x >= 5.
         s.push_constraint(ArithConstraint::Leq(ArithExpr::constant(5), term(x, 1)), 10)
             .unwrap();
-        assert!(is_sat(&s.check()));
+        assert!(is_sat(&s.check().unwrap()));
 
         // Level 1: add x <= 1, making the system infeasible.
         s.notify_new_decision_level();
         s.push_constraint(ArithConstraint::Leq(term(x, 1), ArithExpr::constant(1)), 20)
             .unwrap();
-        assert!(matches!(s.check(), ArithCheckResult::Unsat(_)));
+        assert!(matches!(s.check().unwrap(), ArithCheckResult::Unsat(_)));
 
         // Backtrack to level 0: the x <= 1 bound is relaxed and the system is feasible.
         s.notify_backtrack(0);
-        assert!(is_sat(&s.check()));
+        match s.check().unwrap() {
+            ArithCheckResult::Sat(buckets) => {
+                // Verify the popped x <= 1 bound is actually gone: only x >= 5 remains, so x's
+                // model value must be >= 5 (i.e. strictly above the relaxed upper bound of 1).
+                let x_val = buckets
+                    .iter()
+                    .find(|(_, vars)| vars.contains(&x))
+                    .map(|(val, _)| val.clone())
+                    .expect("x should appear in the model");
+                assert!(
+                    x_val >= IBig::from(5),
+                    "x = {x_val} should be >= 5 with the x <= 1 bound relaxed"
+                );
+            }
+            ArithCheckResult::Unsat(_) => panic!("expected SAT after backtrack"),
+        }
     }
 
     #[test]
@@ -480,23 +493,23 @@ mod tests {
         // Assert C at level 0; feasible on its own.
         s.push_constraint(ArithConstraint::Leq(ArithExpr::constant(5), term(x, 1)), 10)
             .unwrap();
-        assert!(is_sat(&s.check()));
+        assert!(is_sat(&s.check().unwrap()));
 
         // Push a decision level, assert D; C && D is infeasible.
         s.notify_new_decision_level();
         s.push_constraint(ArithConstraint::Leq(term(x, 1), ArithExpr::constant(1)), 20)
             .unwrap();
-        assert!(matches!(s.check(), ArithCheckResult::Unsat(_)));
+        assert!(matches!(s.check().unwrap(), ArithCheckResult::Unsat(_)));
 
         // Backtrack to where only C is asserted; D's bound is relaxed, so feasible again.
         s.notify_backtrack(0);
-        assert!(is_sat(&s.check()));
+        assert!(is_sat(&s.check().unwrap()));
 
         // Assert D again: re-asserting the previously-backtracked constraint must once
         // more render the system infeasible.
         s.push_constraint(ArithConstraint::Leq(term(x, 1), ArithExpr::constant(1)), 20)
             .unwrap();
-        assert!(matches!(s.check(), ArithCheckResult::Unsat(_)));
+        assert!(matches!(s.check().unwrap(), ArithCheckResult::Unsat(_)));
     }
 
     #[test]
@@ -513,7 +526,7 @@ mod tests {
         // Pin x == 4, so y must be 7.
         s.push_constraint(ArithConstraint::Eq(term(x, 1), ArithExpr::constant(4)), 10)
             .unwrap();
-        match s.check() {
+        match s.check().unwrap() {
             ArithCheckResult::Sat(buckets) => {
                 // x is 4, y is 7.
                 assert!(buckets.get(&IBig::from(4)).unwrap().contains(&x));
@@ -532,7 +545,7 @@ mod tests {
         s.push_equality(x, y, 10).unwrap();
         s.push_constraint(ArithConstraint::Eq(term(x, 1), ArithExpr::constant(9)), 20)
             .unwrap();
-        match s.check() {
+        match s.check().unwrap() {
             ArithCheckResult::Sat(buckets) => {
                 let nine = buckets.get(&IBig::from(9)).unwrap();
                 assert!(nine.contains(&x) && nine.contains(&y));
@@ -550,7 +563,7 @@ mod tests {
             .unwrap();
         s.push_constraint(ArithConstraint::Lt(ArithExpr::constant(3), term(x, 1)), 20)
             .unwrap();
-        assert!(matches!(s.check(), ArithCheckResult::Unsat(_)));
+        assert!(matches!(s.check().unwrap(), ArithCheckResult::Unsat(_)));
     }
 
     #[test]
@@ -568,7 +581,7 @@ mod tests {
             20,
         )
         .unwrap();
-        match s.check() {
+        match s.check().unwrap() {
             ArithCheckResult::Sat(buckets) => {
                 let all_reported: DeterministicHashSet<VarId> =
                     buckets.values().flatten().copied().collect();
@@ -579,7 +592,7 @@ mod tests {
         }
         // mark_model_var makes the hidden var appear.
         s.mark_model_var(hidden);
-        match s.check() {
+        match s.check().unwrap() {
             ArithCheckResult::Sat(buckets) => {
                 assert!(buckets.get(&IBig::from(2)).unwrap().contains(&hidden));
             }
@@ -601,7 +614,7 @@ mod tests {
             20,
         )
         .unwrap();
-        assert!(is_sat(&s.check()));
+        assert!(is_sat(&s.check().unwrap()));
         // L2: x <= -1, contradicts x >= 0.
         s.notify_new_decision_level();
         s.push_constraint(
@@ -609,10 +622,10 @@ mod tests {
             30,
         )
         .unwrap();
-        assert!(matches!(s.check(), ArithCheckResult::Unsat(_)));
+        assert!(matches!(s.check().unwrap(), ArithCheckResult::Unsat(_)));
         // Backtrack to L1: x <= -1 relaxed, but x <= 10 still active. Feasible.
         s.notify_backtrack(1);
-        assert!(is_sat(&s.check()));
+        assert!(is_sat(&s.check().unwrap()));
     }
 
     #[test]

--- a/src/arithmetic/lia/incremental.rs
+++ b/src/arithmetic/lia/incremental.rs
@@ -208,7 +208,10 @@ impl IncrementalLraSolver {
             // is tautological (new_var is fresh), so it is never needed in a conflict
             // core and is tracked with no literals.
             self.push_relation(
-                ArithConstraint::Eq(ArithExpr::linear(vec![(var_id, IBig::from(1))], IBig::from(0)), def),
+                ArithConstraint::Eq(
+                    ArithExpr::linear(vec![(var_id, IBig::from(1))], IBig::from(0)),
+                    def,
+                ),
                 None,
             )?;
         }
@@ -354,11 +357,7 @@ impl IncrementalLraSolver {
     /// Core of `push_constraint`/`push_equality`/definitions: lower a constraint
     /// `lhs ⋈ rhs` to a fresh slack row `Σ aᵢ xᵢ ⋈ c` and assert the implied bound(s)
     /// at the current decision level. `lit` is `None` for tautological definitions.
-    fn push_relation(
-        &mut self,
-        constraint: ArithConstraint,
-        lit: Option<i32>,
-    ) -> SolverResult<()> {
+    fn push_relation(&mut self, constraint: ArithConstraint, lit: Option<i32>) -> SolverResult<()> {
         // Normalize `lhs ⋈ rhs` to `(lhs.linear - rhs.linear) ⋈ (rhs.const - lhs.const)`.
         let (lhs, rhs, mk): (&ArithExpr, &ArithExpr, RelMk) = match &constraint {
             ArithConstraint::Leq(l, r) => (l, r, Rel::mk_le),
@@ -368,7 +367,8 @@ impl IncrementalLraSolver {
 
         let mut terms = self.expr_to_monomials(lhs, false)?;
         terms.extend(self.expr_to_monomials(rhs, true)?);
-        let rel_constant = Rational::from(rhs.constant.clone()) - Rational::from(lhs.constant.clone());
+        let rel_constant =
+            Rational::from(rhs.constant.clone()) - Rational::from(lhs.constant.clone());
         let rel = mk(terms, rel_constant);
 
         // Derive the QDelta bound(s) (handles strict-inequality δ adjustment) before
@@ -529,10 +529,16 @@ mod tests {
         let mut s = IncrementalLraSolver::new();
         let reported = s.register_var(None, true).unwrap();
         let hidden = s.register_var(None, false).unwrap();
-        s.push_constraint(ArithConstraint::Eq(term(reported, 1), ArithExpr::constant(1)), 10)
-            .unwrap();
-        s.push_constraint(ArithConstraint::Eq(term(hidden, 1), ArithExpr::constant(2)), 20)
-            .unwrap();
+        s.push_constraint(
+            ArithConstraint::Eq(term(reported, 1), ArithExpr::constant(1)),
+            10,
+        )
+        .unwrap();
+        s.push_constraint(
+            ArithConstraint::Eq(term(hidden, 1), ArithExpr::constant(2)),
+            20,
+        )
+        .unwrap();
         match s.check() {
             ArithCheckResult::Sat(buckets) => {
                 let all_reported: DeterministicHashSet<VarId> =
@@ -561,13 +567,19 @@ mod tests {
             .unwrap();
         // L1: x <= 10.
         s.notify_new_decision_level();
-        s.push_constraint(ArithConstraint::Leq(term(x, 1), ArithExpr::constant(10)), 20)
-            .unwrap();
+        s.push_constraint(
+            ArithConstraint::Leq(term(x, 1), ArithExpr::constant(10)),
+            20,
+        )
+        .unwrap();
         assert!(is_sat(&s.check()));
         // L2: x <= -1, contradicts x >= 0.
         s.notify_new_decision_level();
-        s.push_constraint(ArithConstraint::Leq(term(x, 1), ArithExpr::constant(-1)), 30)
-            .unwrap();
+        s.push_constraint(
+            ArithConstraint::Leq(term(x, 1), ArithExpr::constant(-1)),
+            30,
+        )
+        .unwrap();
         assert!(matches!(s.check(), ArithCheckResult::Unsat(_)));
         // Backtrack to L1: x <= -1 relaxed, but x <= 10 still active. Feasible.
         s.notify_backtrack(1);
@@ -596,8 +608,11 @@ mod tests {
         let mut s = IncrementalLraSolver::new();
         // VarId 99 was never registered.
         assert!(
-            s.push_constraint(ArithConstraint::Leq(term(99, 1), ArithExpr::constant(0)), 10)
-                .is_err()
+            s.push_constraint(
+                ArithConstraint::Leq(term(99, 1), ArithExpr::constant(0)),
+                10
+            )
+            .is_err()
         );
     }
 }

--- a/src/arithmetic/lia/incremental.rs
+++ b/src/arithmetic/lia/incremental.rs
@@ -1,0 +1,603 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Incremental frontend for the internal LRA solver.
+//!
+//! This module exposes an incremental, push/pop-driven API over the internal
+//! [`LRASolver`], operating on an abstract [`VarId`] namespace rather than on
+//! egraph ids or [`crate::solver_state::SolverState`]. It is the internal-solver
+//! analogue of [`crate::arithmetic::z3incremental::Z3IncrementalState`]: a
+//! persistent solver kept in sync with the SAT trail via decision-level push and
+//! backtrack, with constraints tracked by SAT literal so they can be cited in an
+//! unsat core.
+//!
+//! The functions here are shaped to eventually back an `IncrementalArithSolver`
+//! trait implementation. The trait itself is intentionally *not* defined yet; the
+//! data types ([`VarId`], [`ArithExpr`], [`ArithConstraint`], [`ArithCheckResult`])
+//! mirror the anticipated trait so they can be lifted into it later.
+//!
+//! # How it maps onto the incremental [`LRASolver`]
+//!
+//! - Each registered variable and each pushed constraint's *slack* is an internal
+//!   [`Var`]. A constraint `Σ aᵢ xᵢ ⋈ c` becomes a fresh slack row added to the
+//!   live tableau via [`LRASolver::add_relation`], plus a bound on that slack
+//!   asserted at the current decision level via
+//!   [`LRASolver::assert_lower`]/[`LRASolver::assert_upper`].
+//! - The tableau only ever grows (one row per pushed constraint). On backtrack the
+//!   popped constraint's slack simply has its bound relaxed to `(−∞, +∞)` by the
+//!   solver's bound trail — the row is never physically removed.
+//! - Decision levels are tracked by capturing an [`LRASolver::set_backtrack`] token
+//!   at each level boundary and replaying it via [`LRASolver::backtrack`].
+//!
+//! # Scope / limitations of this first frontend
+//!
+//! - **LRA (rational) reasoning only.** Registered variables are integer-sorted, but
+//!   integrality is *not* enforced: [`IncrementalLraSolver::check`] may report `Sat`
+//!   for a system that has no integer solution. Sound integer reasoning
+//!   (branch-and-bound) is a later increment.
+//! - **`div`/`mod` are unsupported.** An [`ArithExpr`] carrying `divs`/`mods` is
+//!   rejected with an error; Euclidean-constraint lowering is a later increment.
+//! - Model values are reported as [`IBig`] by truncating the rational assignment.
+
+use crate::arithmetic::lia::context::ConvContext;
+use crate::arithmetic::lia::linear_system::{Mon, Rel};
+use crate::arithmetic::lia::lra_solver::LRASolver;
+use crate::arithmetic::lia::solver_result::{SolverDecision, SolverError, SolverResult};
+use crate::arithmetic::lia::tableau::TableauKind;
+use crate::arithmetic::lia::types::Rational;
+use crate::arithmetic::lia::variables::{Owner, Var, VarInfo};
+use crate::debug_println;
+use crate::utils::{DeterministicHashMap, DeterministicHashSet};
+use dashu::integer::IBig;
+
+/// Opaque variable handle assigned by the solver via
+/// [`IncrementalLraSolver::register_var`].
+pub type VarId = u32;
+
+/// Constructor for a [`Rel`] from monomials and a constant (one of `Rel::mk_le`,
+/// `mk_lt`, `mk_eq`), selected per [`ArithConstraint`] variant.
+type RelMk = fn(Vec<Mon<Rational>>, Rational) -> Rel<Rational>;
+
+/// A linear expression: sum of `coeff * var` terms plus a constant, with optional
+/// `div`/`mod` terms (currently unsupported by this frontend).
+#[derive(Debug, Clone)]
+pub struct ArithExpr {
+    /// `(var, coefficient)` pairs.
+    pub terms: Vec<(VarId, IBig)>,
+    /// Constant addend.
+    pub constant: IBig,
+    /// `(numerator_var, denominator_var, coeff)` division terms. Unsupported.
+    pub divs: Vec<(VarId, VarId, IBig)>,
+    /// `(numerator_var, denominator_var, coeff)` modulo terms. Unsupported.
+    pub mods: Vec<(VarId, VarId, IBig)>,
+}
+
+impl ArithExpr {
+    /// Construct a pure-linear expression from terms and a constant (no div/mod).
+    pub fn linear(terms: Vec<(VarId, IBig)>, constant: IBig) -> Self {
+        Self {
+            terms,
+            constant,
+            divs: Vec::new(),
+            mods: Vec::new(),
+        }
+    }
+
+    /// Construct a constant expression.
+    pub fn constant(c: impl Into<IBig>) -> Self {
+        Self::linear(Vec::new(), c.into())
+    }
+
+    /// Return true if this expression uses div/mod terms (unsupported here).
+    fn has_div_mod(&self) -> bool {
+        !self.divs.is_empty() || !self.mods.is_empty()
+    }
+}
+
+/// A constraint between two linear expressions.
+#[derive(Debug, Clone)]
+pub enum ArithConstraint {
+    /// `lhs <= rhs`
+    Leq(ArithExpr, ArithExpr),
+    /// `lhs < rhs`
+    Lt(ArithExpr, ArithExpr),
+    /// `lhs == rhs`
+    Eq(ArithExpr, ArithExpr),
+}
+
+/// Result of [`IncrementalLraSolver::check`].
+#[derive(Debug)]
+pub enum ArithCheckResult {
+    /// Conflict: the conflict clause (negated asserted SAT literals), matching the
+    /// shape expected by the propagator's existing unsat-core handling.
+    Unsat(Vec<i32>),
+    /// Satisfiable: model-value → the set of `report_in_model` [`VarId`]s assigned
+    /// that (truncated integer) value.
+    Sat(DeterministicHashMap<IBig, DeterministicHashSet<VarId>>),
+}
+
+/// Incremental LRA frontend: a persistent [`LRASolver`] driven by push/pop of
+/// constraints keyed by SAT literal. See the module docs for the mapping onto the
+/// incremental solver and the current limitations.
+#[derive(Debug)]
+pub struct IncrementalLraSolver {
+    /// The persistent underlying solver. Seeded with one inert dummy row so the
+    /// (sparse) tableau always exists and can be grown via `add_relation`.
+    solver: LRASolver,
+    /// Next fresh internal [`Var`] id (shared by registered vars and slacks).
+    next_internal_id: usize,
+    /// Next fresh [`VarId`] handed to callers.
+    next_var_id: VarId,
+    /// `VarId` → internal solver [`Var`].
+    var_of: DeterministicHashMap<VarId, Var>,
+    /// `VarId`s to include in the model buckets on `check` SAT.
+    model_vars: DeterministicHashSet<VarId>,
+    /// Constraint slack [`Var`] → the (negated) SAT literals to cite if that slack
+    /// appears in a conflict. Definition rows are tautological and carry no lits.
+    slack_to_lits: DeterministicHashMap<Var, Vec<i32>>,
+    /// Current SAT decision level.
+    sat_level: usize,
+    /// `lra_tokens[l]` is the [`LRASolver::set_backtrack`] token captured at the
+    /// `l → l+1` decision-level boundary; replayed by `notify_backtrack`.
+    lra_tokens: Vec<usize>,
+}
+
+impl IncrementalLraSolver {
+    /// Create a fresh incremental solver.
+    pub fn new() -> Self {
+        // Seed the solver with a single inert dummy relation `s = d` over two
+        // unbounded variables, so the sparse tableau exists (a 0×0 tableau cannot be
+        // constructed) and every real relation is added via `add_relation`. The dummy
+        // slack/variable are unbounded, appear only in the dummy row, are never mapped
+        // to a `VarId`, and so never affect feasibility or the reported model.
+        let dummy_nonbasic = Var::int(0);
+        let dummy_slack = Var::int(1);
+        let basic = vec![VarInfo::new(dummy_slack, Owner::Basic(0))];
+        let non_basic = vec![VarInfo::new(dummy_nonbasic, Owner::NonBasic(0))];
+        let equations = vec![vec![Rational::ONE]];
+        let solver = LRASolver::from_eqs(
+            basic,
+            non_basic,
+            equations,
+            ConvContext::new(),
+            TableauKind::Sparse,
+        )
+        .expect("failed to build seed LRA solver");
+
+        Self {
+            solver,
+            next_internal_id: 2, // ids 0 and 1 reserved for the dummy seed
+            next_var_id: 0,
+            var_of: DeterministicHashMap::new(),
+            model_vars: DeterministicHashSet::default(),
+            slack_to_lits: DeterministicHashMap::new(),
+            sat_level: 0,
+            lra_tokens: Vec::new(),
+        }
+    }
+
+    /// Allocate a fresh internal integer [`Var`].
+    fn fresh_var(&mut self) -> Var {
+        let v = Var::int(self.next_internal_id);
+        self.next_internal_id += 1;
+        v
+    }
+
+    /// Register a fresh integer variable. If `definition` is `Some`, the equality
+    /// `new_var == definition` is asserted at the current decision level. If
+    /// `report_in_model` is true, the variable's value is included in the model
+    /// buckets returned by [`Self::check`] on SAT.
+    ///
+    /// Returns an error if `definition` uses unsupported `div`/`mod` terms or refers
+    /// to an unregistered variable.
+    pub fn register_var(
+        &mut self,
+        definition: Option<ArithExpr>,
+        report_in_model: bool,
+    ) -> SolverResult<VarId> {
+        let var_id = self.next_var_id;
+        self.next_var_id += 1;
+        let var = self.fresh_var();
+        self.var_of.insert(var_id, var);
+        if report_in_model {
+            self.model_vars.insert(var_id);
+        }
+
+        if let Some(def) = definition {
+            // Assert `new_var == def`, i.e. `new_var - def == 0`, as a fresh row. This
+            // is tautological (new_var is fresh), so it is never needed in a conflict
+            // core and is tracked with no literals.
+            self.push_relation(
+                ArithConstraint::Eq(ArithExpr::linear(vec![(var_id, IBig::from(1))], IBig::from(0)), def),
+                None,
+            )?;
+        }
+
+        Ok(var_id)
+    }
+
+    /// Mark an already-registered variable for model reporting. Idempotent.
+    pub fn mark_model_var(&mut self, var: VarId) {
+        self.model_vars.insert(var);
+    }
+
+    /// The SAT solver advanced to a new decision level.
+    pub fn notify_new_decision_level(&mut self) {
+        // If the previous `check` ended `Unsat`, clear it first: `set_backtrack` is a no-op
+        // while `Unsat`, which would capture a stale token and skip the assignment backup.
+        self.solver.clear_unsat_state();
+        // Capture a backtrack token for the level we are leaving so a later
+        // `notify_backtrack` can relax everything asserted above it.
+        let token = self.solver.set_backtrack();
+        self.lra_tokens.push(token);
+        self.sat_level += 1;
+        debug_println!(21, 0, "[lra-inc] new decision level {}", self.sat_level);
+    }
+
+    /// The SAT solver backtracked to `level`; undo everything pushed above it. The
+    /// popped constraints' slacks are relaxed to `(−∞, +∞)` by the bound trail; the
+    /// rows themselves persist (they are inert once unbounded).
+    pub fn notify_backtrack(&mut self, level: usize) {
+        if level >= self.sat_level {
+            return;
+        }
+        // `lra_tokens[level]` is the token captured at the `level → level+1` boundary;
+        // replaying it relaxes all bounds asserted at levels > `level`.
+        let token = self.lra_tokens[level];
+        self.solver.backtrack(token);
+        self.lra_tokens.truncate(level);
+        self.sat_level = level;
+        debug_println!(21, 0, "[lra-inc] backtrack to level {}", level);
+    }
+
+    /// Push a constraint tracked by SAT literal `lit`. On conflict, `lit` (negated)
+    /// is citable in the unsat core.
+    ///
+    /// Returns an error if either expression uses unsupported `div`/`mod` terms or
+    /// refers to an unregistered variable.
+    pub fn push_constraint(&mut self, constraint: ArithConstraint, lit: i32) -> SolverResult<()> {
+        self.push_relation(constraint, Some(lit))
+    }
+
+    /// Push an equality `a == b` tracked by SAT literal `lit`.
+    pub fn push_equality(&mut self, a: VarId, b: VarId, lit: i32) -> SolverResult<()> {
+        let constraint = ArithConstraint::Eq(
+            ArithExpr::linear(vec![(a, IBig::from(1))], IBig::from(0)),
+            ArithExpr::linear(vec![(b, IBig::from(1))], IBig::from(0)),
+        );
+        self.push_relation(constraint, Some(lit))
+    }
+
+    /// Check satisfiability of all currently-pushed constraints and definitions.
+    ///
+    /// On `Sat`, only variables registered with `report_in_model` (or marked via
+    /// [`Self::mark_model_var`]) appear in the buckets, keyed by their truncated
+    /// integer model value. Variables that are unconstrained (never referenced by any
+    /// pushed row) default to `0`.
+    pub fn check(&mut self) -> ArithCheckResult {
+        let decision = self
+            .solver
+            .solve()
+            .expect("lra-inc: unexpected solver error")
+            .decision;
+        match decision {
+            SolverDecision::FEASIBLE(assignment) => {
+                let mut buckets: DeterministicHashMap<IBig, DeterministicHashSet<VarId>> =
+                    DeterministicHashMap::new();
+                for var_id in self.model_vars.iter() {
+                    let var = self.var_of[var_id];
+                    let value = assignment.get(&var).cloned().unwrap_or(Rational::ZERO);
+                    let ibig = value.to_int().value().clone();
+                    buckets.entry(ibig).or_default().insert(*var_id);
+                }
+                debug_println!(21, 0, "[lra-inc] SAT buckets={:?}", buckets);
+                ArithCheckResult::Sat(buckets)
+            }
+            SolverDecision::INFEASIBLE(conflict) => {
+                let lits: DeterministicHashSet<i32> = conflict
+                    .iter()
+                    .flat_map(|var| self.slack_to_lits.get(var).into_iter().flatten().copied())
+                    .collect();
+                debug_println!(21, 0, "[lra-inc] UNSAT core lits={:?}", lits);
+                ArithCheckResult::Unsat(lits.into_iter().collect())
+            }
+            SolverDecision::UNKNOWN => {
+                // Pure LRA `solve` terminates in FEASIBLE/INFEASIBLE; treat an
+                // (unexpected) UNKNOWN conservatively as satisfiable, bucketing the
+                // current best-effort assignment.
+                let model = self.solver.get_rational_model().unwrap_or_default();
+                let mut buckets: DeterministicHashMap<IBig, DeterministicHashSet<VarId>> =
+                    DeterministicHashMap::new();
+                for var_id in self.model_vars.iter() {
+                    let var = self.var_of[var_id];
+                    let value = model.get(&var).cloned().unwrap_or(Rational::ZERO);
+                    let ibig = value.to_int().value().clone();
+                    buckets.entry(ibig).or_default().insert(*var_id);
+                }
+                ArithCheckResult::Sat(buckets)
+            }
+        }
+    }
+
+    /// Look up the internal [`Var`] for a `VarId`, erroring if it was never registered.
+    fn resolve(&self, var_id: VarId) -> SolverResult<Var> {
+        self.var_of
+            .get(&var_id)
+            .copied()
+            .ok_or_else(|| SolverError(format!("unregistered VarId {var_id}")))
+    }
+
+    /// Convert an [`ArithExpr`] to monomials with the given sign, erroring on
+    /// unsupported div/mod terms or unregistered variables.
+    fn expr_to_monomials(
+        &self,
+        expr: &ArithExpr,
+        negate: bool,
+    ) -> SolverResult<Vec<Mon<Rational>>> {
+        if expr.has_div_mod() {
+            return Err(SolverError(
+                "div/mod terms are not supported by the incremental LRA frontend".to_string(),
+            ));
+        }
+        let mut monomials = Vec::with_capacity(expr.terms.len());
+        for (var_id, coeff) in &expr.terms {
+            let var = self.resolve(*var_id)?;
+            let mut c = Rational::from(coeff.clone());
+            if negate {
+                c = -c;
+            }
+            monomials.push(Mon::new(c, var));
+        }
+        Ok(monomials)
+    }
+
+    /// Core of `push_constraint`/`push_equality`/definitions: lower a constraint
+    /// `lhs ⋈ rhs` to a fresh slack row `Σ aᵢ xᵢ ⋈ c` and assert the implied bound(s)
+    /// at the current decision level. `lit` is `None` for tautological definitions.
+    fn push_relation(
+        &mut self,
+        constraint: ArithConstraint,
+        lit: Option<i32>,
+    ) -> SolverResult<()> {
+        // Normalize `lhs ⋈ rhs` to `(lhs.linear - rhs.linear) ⋈ (rhs.const - lhs.const)`.
+        let (lhs, rhs, mk): (&ArithExpr, &ArithExpr, RelMk) = match &constraint {
+            ArithConstraint::Leq(l, r) => (l, r, Rel::mk_le),
+            ArithConstraint::Lt(l, r) => (l, r, Rel::mk_lt),
+            ArithConstraint::Eq(l, r) => (l, r, Rel::mk_eq),
+        };
+
+        let mut terms = self.expr_to_monomials(lhs, false)?;
+        terms.extend(self.expr_to_monomials(rhs, true)?);
+        let rel_constant = Rational::from(rhs.constant.clone()) - Rational::from(lhs.constant.clone());
+        let rel = mk(terms, rel_constant);
+
+        // Derive the QDelta bound(s) (handles strict-inequality δ adjustment) before
+        // the relation is moved into `add_relation`.
+        let bounds = rel.to_qdelta_bounds();
+
+        let slack = self.fresh_var();
+        self.solver.add_relation(rel, slack)?;
+
+        if let Some(lower) = bounds.lower {
+            self.solver.assert_lower(&slack, &lower)?;
+        }
+        if let Some(upper) = bounds.upper {
+            self.solver.assert_upper(&slack, &upper)?;
+        }
+
+        // Record the justification so the slack can be cited in a conflict. Constraints
+        // store the (negated) tracking lit, matching the existing unsat-core convention;
+        // definitions are tautological and store nothing.
+        if let Some(lit) = lit {
+            self.slack_to_lits.insert(slack, vec![-lit]);
+        }
+        Ok(())
+    }
+}
+
+impl Default for IncrementalLraSolver {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Helper: linear expr `coeff * var`.
+    fn term(var: VarId, coeff: i32) -> ArithExpr {
+        ArithExpr::linear(vec![(var, IBig::from(coeff))], IBig::from(0))
+    }
+
+    fn is_sat(r: &ArithCheckResult) -> bool {
+        matches!(r, ArithCheckResult::Sat(_))
+    }
+
+    #[test]
+    fn empty_system_is_sat() {
+        let mut s = IncrementalLraSolver::new();
+        assert!(is_sat(&s.check()));
+    }
+
+    #[test]
+    fn single_feasible_constraint() {
+        let mut s = IncrementalLraSolver::new();
+        let x = s.register_var(None, true).unwrap();
+        // x <= 5
+        s.push_constraint(ArithConstraint::Leq(term(x, 1), ArithExpr::constant(5)), 10)
+            .unwrap();
+        assert!(is_sat(&s.check()));
+    }
+
+    #[test]
+    fn conflicting_constraints_are_unsat_with_core() {
+        let mut s = IncrementalLraSolver::new();
+        let x = s.register_var(None, true).unwrap();
+        // x >= 5 (encoded as 5 <= x), lit 10
+        s.push_constraint(ArithConstraint::Leq(ArithExpr::constant(5), term(x, 1)), 10)
+            .unwrap();
+        // x <= 1, lit 20
+        s.push_constraint(ArithConstraint::Leq(term(x, 1), ArithExpr::constant(1)), 20)
+            .unwrap();
+        match s.check() {
+            ArithCheckResult::Unsat(core) => {
+                // Both tracking lits (negated) should appear in the conflict clause.
+                assert!(core.contains(&-10), "core {core:?} missing -10");
+                assert!(core.contains(&-20), "core {core:?} missing -20");
+            }
+            ArithCheckResult::Sat(_) => panic!("expected UNSAT"),
+        }
+    }
+
+    #[test]
+    fn backtrack_recovers_from_conflict() {
+        let mut s = IncrementalLraSolver::new();
+        let x = s.register_var(None, true).unwrap();
+        // Level 0: x >= 5.
+        s.push_constraint(ArithConstraint::Leq(ArithExpr::constant(5), term(x, 1)), 10)
+            .unwrap();
+        assert!(is_sat(&s.check()));
+
+        // Level 1: add x <= 1, making the system infeasible.
+        s.notify_new_decision_level();
+        s.push_constraint(ArithConstraint::Leq(term(x, 1), ArithExpr::constant(1)), 20)
+            .unwrap();
+        assert!(matches!(s.check(), ArithCheckResult::Unsat(_)));
+
+        // Backtrack to level 0: the x <= 1 bound is relaxed and the system is feasible.
+        s.notify_backtrack(0);
+        assert!(is_sat(&s.check()));
+    }
+
+    #[test]
+    fn definition_is_enforced_in_model() {
+        let mut s = IncrementalLraSolver::new();
+        let x = s.register_var(None, true).unwrap();
+        // y := x + 3
+        let y = s
+            .register_var(
+                Some(ArithExpr::linear(vec![(x, IBig::from(1))], IBig::from(3))),
+                true,
+            )
+            .unwrap();
+        // Pin x == 4, so y must be 7.
+        s.push_constraint(ArithConstraint::Eq(term(x, 1), ArithExpr::constant(4)), 10)
+            .unwrap();
+        match s.check() {
+            ArithCheckResult::Sat(buckets) => {
+                // x is 4, y is 7.
+                assert!(buckets.get(&IBig::from(4)).unwrap().contains(&x));
+                assert!(buckets.get(&IBig::from(7)).unwrap().contains(&y));
+            }
+            ArithCheckResult::Unsat(_) => panic!("expected SAT"),
+        }
+    }
+
+    #[test]
+    fn equality_constraint_ties_two_vars() {
+        let mut s = IncrementalLraSolver::new();
+        let x = s.register_var(None, true).unwrap();
+        let y = s.register_var(None, true).unwrap();
+        // x == y (via push_equality), and x == 9.
+        s.push_equality(x, y, 10).unwrap();
+        s.push_constraint(ArithConstraint::Eq(term(x, 1), ArithExpr::constant(9)), 20)
+            .unwrap();
+        match s.check() {
+            ArithCheckResult::Sat(buckets) => {
+                let nine = buckets.get(&IBig::from(9)).unwrap();
+                assert!(nine.contains(&x) && nine.contains(&y));
+            }
+            ArithCheckResult::Unsat(_) => panic!("expected SAT"),
+        }
+    }
+
+    #[test]
+    fn strict_inequality_conflict() {
+        let mut s = IncrementalLraSolver::new();
+        let x = s.register_var(None, true).unwrap();
+        // x < 3 and x > 3 (encoded as 3 < x): infeasible.
+        s.push_constraint(ArithConstraint::Lt(term(x, 1), ArithExpr::constant(3)), 10)
+            .unwrap();
+        s.push_constraint(ArithConstraint::Lt(ArithExpr::constant(3), term(x, 1)), 20)
+            .unwrap();
+        assert!(matches!(s.check(), ArithCheckResult::Unsat(_)));
+    }
+
+    #[test]
+    fn model_only_reports_marked_vars() {
+        let mut s = IncrementalLraSolver::new();
+        let reported = s.register_var(None, true).unwrap();
+        let hidden = s.register_var(None, false).unwrap();
+        s.push_constraint(ArithConstraint::Eq(term(reported, 1), ArithExpr::constant(1)), 10)
+            .unwrap();
+        s.push_constraint(ArithConstraint::Eq(term(hidden, 1), ArithExpr::constant(2)), 20)
+            .unwrap();
+        match s.check() {
+            ArithCheckResult::Sat(buckets) => {
+                let all_reported: DeterministicHashSet<VarId> =
+                    buckets.values().flatten().copied().collect();
+                assert!(all_reported.contains(&reported));
+                assert!(!all_reported.contains(&hidden));
+            }
+            ArithCheckResult::Unsat(_) => panic!("expected SAT"),
+        }
+        // mark_model_var makes the hidden var appear.
+        s.mark_model_var(hidden);
+        match s.check() {
+            ArithCheckResult::Sat(buckets) => {
+                assert!(buckets.get(&IBig::from(2)).unwrap().contains(&hidden));
+            }
+            ArithCheckResult::Unsat(_) => panic!("expected SAT"),
+        }
+    }
+
+    #[test]
+    fn nested_levels_backtrack_partially() {
+        let mut s = IncrementalLraSolver::new();
+        let x = s.register_var(None, true).unwrap();
+        // L0: x >= 0.
+        s.push_constraint(ArithConstraint::Leq(ArithExpr::constant(0), term(x, 1)), 10)
+            .unwrap();
+        // L1: x <= 10.
+        s.notify_new_decision_level();
+        s.push_constraint(ArithConstraint::Leq(term(x, 1), ArithExpr::constant(10)), 20)
+            .unwrap();
+        assert!(is_sat(&s.check()));
+        // L2: x <= -1, contradicts x >= 0.
+        s.notify_new_decision_level();
+        s.push_constraint(ArithConstraint::Leq(term(x, 1), ArithExpr::constant(-1)), 30)
+            .unwrap();
+        assert!(matches!(s.check(), ArithCheckResult::Unsat(_)));
+        // Backtrack to L1: x <= -1 relaxed, but x <= 10 still active. Feasible.
+        s.notify_backtrack(1);
+        assert!(is_sat(&s.check()));
+    }
+
+    #[test]
+    fn div_mod_expr_is_rejected() {
+        let mut s = IncrementalLraSolver::new();
+        let x = s.register_var(None, true).unwrap();
+        let d = s.register_var(None, false).unwrap();
+        let expr = ArithExpr {
+            terms: vec![],
+            constant: IBig::from(0),
+            divs: vec![(x, d, IBig::from(1))],
+            mods: vec![],
+        };
+        assert!(
+            s.push_constraint(ArithConstraint::Leq(expr, ArithExpr::constant(0)), 10)
+                .is_err()
+        );
+    }
+
+    #[test]
+    fn unregistered_var_is_rejected() {
+        let mut s = IncrementalLraSolver::new();
+        // VarId 99 was never registered.
+        assert!(
+            s.push_constraint(ArithConstraint::Leq(term(99, 1), ArithExpr::constant(0)), 10)
+                .is_err()
+        );
+    }
+}

--- a/src/arithmetic/lia/incremental.rs
+++ b/src/arithmetic/lia/incremental.rs
@@ -471,6 +471,35 @@ mod tests {
     }
 
     #[test]
+    fn assert_backtrack_reassert_constraint() {
+        // C: x >= 5 (encoded as 5 <= x). D: x <= 1. C alone is feasible; C && D is not.
+        // Exercises assert → backtrack → assert-again of the same constraint D.
+        let mut s = IncrementalLraSolver::new();
+        let x = s.register_var(None, true).unwrap();
+
+        // Assert C at level 0; feasible on its own.
+        s.push_constraint(ArithConstraint::Leq(ArithExpr::constant(5), term(x, 1)), 10)
+            .unwrap();
+        assert!(is_sat(&s.check()));
+
+        // Push a decision level, assert D; C && D is infeasible.
+        s.notify_new_decision_level();
+        s.push_constraint(ArithConstraint::Leq(term(x, 1), ArithExpr::constant(1)), 20)
+            .unwrap();
+        assert!(matches!(s.check(), ArithCheckResult::Unsat(_)));
+
+        // Backtrack to where only C is asserted; D's bound is relaxed, so feasible again.
+        s.notify_backtrack(0);
+        assert!(is_sat(&s.check()));
+
+        // Assert D again: re-asserting the previously-backtracked constraint must once
+        // more render the system infeasible.
+        s.push_constraint(ArithConstraint::Leq(term(x, 1), ArithExpr::constant(1)), 20)
+            .unwrap();
+        assert!(matches!(s.check(), ArithCheckResult::Unsat(_)));
+    }
+
+    #[test]
     fn definition_is_enforced_in_model() {
         let mut s = IncrementalLraSolver::new();
         let x = s.register_var(None, true).unwrap();

--- a/src/arithmetic/lia/linear_system.rs
+++ b/src/arithmetic/lia/linear_system.rs
@@ -607,7 +607,7 @@ impl Rel<Rational> {
     ///
     /// Replacing bounds for strict constraint types with non-strict bounds is done, as well as simply
     /// injecting rational bounds for already non-strict constraint types.
-    fn to_qdelta_bounds(&self) -> Bounds<QDelta> {
+    pub(crate) fn to_qdelta_bounds(&self) -> Bounds<QDelta> {
         let constant = self.constant.clone();
         match self.constraint_type {
             // non-strict relations are not adjusted by δ

--- a/src/arithmetic/lia/lra_solver.rs
+++ b/src/arithmetic/lia/lra_solver.rs
@@ -282,7 +282,8 @@ impl LRASolver {
                     SolverError(format!("add_relation: failed to grow tableau column: {e}"))
                 })?;
                 let new_idx = self.variables.len();
-                self.variables.push(VarInfo::new(v, Owner::NonBasic(new_col)));
+                self.variables
+                    .push(VarInfo::new(v, Owner::NonBasic(new_col)));
                 self.non_basic.push(new_idx);
                 self.var_to_idx.insert(v, new_idx);
             }
@@ -311,9 +312,10 @@ impl LRASolver {
         }
 
         // Step 3: grow the tableau by one row and write the non-zero coefficients.
-        let new_row = self.tableau.add_row().map_err(|e| {
-            SolverError(format!("add_relation: failed to grow tableau row: {e}"))
-        })?;
+        let new_row = self
+            .tableau
+            .add_row()
+            .map_err(|e| SolverError(format!("add_relation: failed to grow tableau row: {e}")))?;
         debug_assert_eq!(new_row, self.basic.len());
         for (c, coeff) in row.iter().enumerate() {
             if !coeff.is_zero() {
@@ -2191,7 +2193,9 @@ mod tests {
 
         // Slack is basic and owns the new row.
         let idx = *solver.var_to_idx.get(&slack).unwrap();
-        let new_row = solver.variables[idx].is_basic().expect("slack should be basic");
+        let new_row = solver.variables[idx]
+            .is_basic()
+            .expect("slack should be basic");
         assert_eq!(new_row, nrows_before);
 
         // β(slack) == β(x) + β(y).
@@ -2335,8 +2339,14 @@ mod tests {
         solver.add_relation(rel, slack).unwrap();
 
         // Bounds [-1, 5] contain 0, so the stuck slack is trivially feasible.
-        assert_eq!(solver.assert_lower(&slack, &(-1i32).into()).unwrap(), Some(true));
-        assert_eq!(solver.assert_upper(&slack, &5i32.into()).unwrap(), Some(true));
+        assert_eq!(
+            solver.assert_lower(&slack, &(-1i32).into()).unwrap(),
+            Some(true)
+        );
+        assert_eq!(
+            solver.assert_upper(&slack, &5i32.into()).unwrap(),
+            Some(true)
+        );
         assert!(matches!(
             solver.solve().unwrap().decision,
             SolverDecision::FEASIBLE(_)

--- a/src/arithmetic/lia/lra_solver.rs
+++ b/src/arithmetic/lia/lra_solver.rs
@@ -274,6 +274,16 @@ impl LRASolver {
             )));
         }
 
+        // The slack must be fresh with respect to `rel` too: if `rel` mentioned `slack`, Step 1
+        // would introduce it as a non-basic column and Step 5 would then register it again as a
+        // basic variable, producing duplicate `VarInfo`s and corrupting `var_to_idx`/basis. Callers
+        // constructing slacks via the incremental frontend never hit this, but guard explicitly.
+        if rel.terms_ref().iter().any(|term| term.var() == slack) {
+            return Err(SolverError(format!(
+                "add_relation: slack variable {slack:?} occurs in the relation's terms"
+            )));
+        }
+
         // Step 1: register any brand-new problem variables as unbounded non-basic columns.
         for term in rel.terms_ref() {
             let v = term.var();
@@ -453,9 +463,12 @@ impl LRASolver {
     /// post-date the snapshot are absent from the map and default to zero; their basic slack rows
     /// are then made consistent by the recomputation step.
     fn restore_assignment(&mut self) {
+        // Take the snapshot out of `self` so the loops below can mutably borrow `self` without
+        // cloning the map; it is put back at the end so repeated backtracks to the same level
+        // still see it.
         let previous_model = self
             .old_assignment
-            .clone()
+            .take()
             .expect("cannot restore assignment: no previous assignment exists");
         // Non-basics: take the snapshot value, or zero for variables added after the snapshot.
         for &idx in self.non_basic.iter() {
@@ -467,6 +480,7 @@ impl LRASolver {
             let val = self.calculate_assignment(row);
             self.variables[self.basic[row]].val = val;
         }
+        self.old_assignment = Some(previous_model);
     }
 
     /// Set a backtrack point and return the new backtrack level

--- a/src/arithmetic/lia/lra_solver.rs
+++ b/src/arithmetic/lia/lra_solver.rs
@@ -501,6 +501,20 @@ impl LRASolver {
         self.restore_assignment();
     }
 
+    /// Clear a terminal `Unsat` state back to `Unknown`, so the solver can be reused after a
+    /// conflicting [`Self::solve`] — e.g. by an incremental frontend that re-checks feasibility
+    /// once the SAT layer has backtracked and relaxed bounds. Does nothing unless the solver is
+    /// currently `Unsat`.
+    ///
+    /// This is deliberately *not* folded into [`Self::backtrack`]: the branch-and-bound layer
+    /// relies on [`Self::set_backtrack`] being a no-op while `Unsat`, so [`Self::backtrack`] must
+    /// leave that state intact. Callers that want the state cleared opt in explicitly.
+    pub fn clear_unsat_state(&mut self) {
+        if matches!(self.state, LRASolverState::Unsat) {
+            self.state = LRASolverState::Unknown;
+        }
+    }
+
     /// Restore the tableau structure (basis, non-basis, coefficients, and variable owners)
     /// from a saved snapshot. Used by try_unit_cube_test to undo pivots performed during
     /// speculative solving.

--- a/src/arithmetic/lia/lra_solver.rs
+++ b/src/arithmetic/lia/lra_solver.rs
@@ -13,6 +13,7 @@ use std::fmt;
 
 use crate::arithmetic::lia::bounds::Bounds;
 use crate::arithmetic::lia::context::ConvContext;
+use crate::arithmetic::lia::linear_system::Rel;
 use crate::arithmetic::lia::qdelta::QDelta;
 use crate::arithmetic::lia::solver_result::{
     Assignment, Conflict, SolverDecision, SolverError, SolverResult, SolverReturn,
@@ -243,6 +244,104 @@ impl LRASolver {
         Ok(())
     }
 
+    /// Incrementally extend a live, already-solved tableau with a new relation
+    /// `Σ aᵢ xᵢ ⋈ c`, represented by the fresh slack variable `slack`.
+    ///
+    /// The tableau only ever grows: rows are never removed, only relaxed on backtrack.
+    /// The slack is introduced as a **basic** variable owning a brand-new row, so it appears
+    /// only in that row and disturbs no existing non-basic variable's in-bounds status. Only the
+    /// homogeneous terms `Σ aᵢ xᵢ` are used to build the row; the slack is added **unbounded**.
+    /// The bound implied by `rel`'s constant/constraint type is applied separately by the caller
+    /// via [`Self::assert_lower`]/[`Self::assert_upper`].
+    ///
+    /// Because `rel` may mention variables that are currently basic (and rows must be expressed
+    /// over non-basic columns only), each basic variable `xᵢ` owning row `r` is substituted using
+    /// its own row: `xᵢ = Σ_c tableau[r][c]·nonbasicₖ`, so its contribution `aᵢ·xᵢ` adds
+    /// `aᵢ·tableau[r][c]` to column `c`. Non-basic variables contribute their coefficient directly.
+    /// Variables the solver has never seen are first introduced as unbounded non-basic columns.
+    ///
+    /// After this call the check-invariant holds (non-basics are in bounds; the new basic slack's
+    /// row is satisfied by construction and the slack is unbounded), so [`Self::is_valid`] is true
+    /// and feasibility of any subsequently asserted bound must be (re)checked via [`Self::solve`].
+    ///
+    /// `add_relation` does not touch the bound trail or backtrack level: the row persists across
+    /// all backtracks. The slack starts unbounded, so the first `assert_*` on it records the old
+    /// bound (`None`), and a later `backtrack` restores it to unbounded automatically.
+    pub fn add_relation(&mut self, rel: Rel<Rational>, slack: Var) -> SolverResult<()> {
+        if self.var_to_idx.contains_key(&slack) {
+            return Err(SolverError(format!(
+                "add_relation: slack variable {slack:?} already exists"
+            )));
+        }
+
+        // Step 1: register any brand-new problem variables as unbounded non-basic columns.
+        for term in rel.terms_ref() {
+            let v = term.var();
+            if !self.var_to_idx.contains_key(&v) {
+                let new_col = self.tableau.add_col().map_err(|e| {
+                    SolverError(format!("add_relation: failed to grow tableau column: {e}"))
+                })?;
+                let new_idx = self.variables.len();
+                self.variables.push(VarInfo::new(v, Owner::NonBasic(new_col)));
+                self.non_basic.push(new_idx);
+                self.var_to_idx.insert(v, new_idx);
+            }
+        }
+
+        // Step 2: build the new row over the current non-basic columns, substituting out any
+        // basic variables. Accumulate with `+=` so duplicate/uncombined terms are handled.
+        let ncols = self.non_basic.len();
+        let mut row = vec![Rational::ZERO; ncols];
+        for term in rel.terms_ref() {
+            let a = term.coeff_ref();
+            let idx = *self.var_to_idx.get(&term.var()).unwrap();
+            match self.variables[idx].owner {
+                Owner::NonBasic(c) => {
+                    row[c] += a;
+                }
+                Owner::Basic(r) => {
+                    for (c, entry) in row.iter_mut().enumerate() {
+                        let t = self.tableau.get(r, c)?;
+                        if !t.is_zero() {
+                            *entry += a * t;
+                        }
+                    }
+                }
+            }
+        }
+
+        // Step 3: grow the tableau by one row and write the non-zero coefficients.
+        let new_row = self.tableau.add_row().map_err(|e| {
+            SolverError(format!("add_relation: failed to grow tableau row: {e}"))
+        })?;
+        debug_assert_eq!(new_row, self.basic.len());
+        for (c, coeff) in row.iter().enumerate() {
+            if !coeff.is_zero() {
+                self.tableau.set_entry(new_row, c, coeff.clone())?;
+            }
+        }
+
+        // Step 4: compute β(slack) = Σ_c row[c]·β(nonbasic_c), so the new row is satisfied.
+        let mut beta = QDelta::ZERO;
+        for (c, coeff) in row.iter().enumerate() {
+            if !coeff.is_zero() {
+                beta += &(&self.variables[self.non_basic[c]].val * coeff);
+            }
+        }
+
+        // Step 5: register the slack as a new basic variable owning `new_row`.
+        let new_idx = self.variables.len();
+        let mut vinfo = VarInfo::new(slack, Owner::Basic(new_row));
+        vinfo.update_assignment(beta);
+        self.variables.push(vinfo);
+        self.basic.push(new_idx);
+        self.var_to_idx.insert(slack, new_idx);
+
+        // Feasibility of the extended system must be re-established by solve().
+        self.state = LRASolverState::Unknown;
+        Ok(())
+    }
+
     /// Assert a new lower bound for `x`
     ///
     /// Three possible returns:
@@ -341,15 +440,30 @@ impl LRASolver {
         self.old_assignment = Some(model);
     }
 
-    /// Restore a previous assignment when backtracking
+    /// Restore a previous assignment when backtracking.
+    ///
+    /// Restores each **non-basic** variable's value from the snapshot, then recomputes every
+    /// **basic** variable's value from the current tableau structure so the row equations hold by
+    /// construction. This is pivot-invariant: recomputing basics from the restored non-basics
+    /// reproduces the snapshot point exactly on the unchanged-structure case (so it is
+    /// behavior-preserving for the existing branch-and-bound usage), while also remaining correct
+    /// when rows/columns were added since the snapshot was taken (`add_relation`). Variables that
+    /// post-date the snapshot are absent from the map and default to zero; their basic slack rows
+    /// are then made consistent by the recomputation step.
     fn restore_assignment(&mut self) {
         let previous_model = self
             .old_assignment
-            .as_ref()
+            .clone()
             .expect("cannot restore assignment: no previous assignment exists");
-        for (var, ass) in previous_model.iter() {
-            let var_info_idx = self.var_to_idx.get(var).unwrap(); // if var isn't a key, it's is a bug
-            self.variables[*var_info_idx].val = ass.clone();
+        // Non-basics: take the snapshot value, or zero for variables added after the snapshot.
+        for &idx in self.non_basic.iter() {
+            let var = self.variables[idx].var;
+            self.variables[idx].val = previous_model.get(&var).cloned().unwrap_or(QDelta::ZERO);
+        }
+        // Basics: recompute from the (possibly re-pivoted / grown) tableau so equations hold.
+        for row in 0..self.basic.len() {
+            let val = self.calculate_assignment(row);
+            self.variables[self.basic[row]].val = val;
         }
     }
 
@@ -1067,7 +1181,6 @@ impl LRASolver {
 
     /// Calculate the assignment to a basic variable at `row` required in order to make its
     /// corresponding row equation true.
-    #[allow(dead_code)]
     fn calculate_assignment(&self, row: usize) -> QDelta {
         let mut rhs = QDelta::ZERO;
         for (col, non_basic_idx) in self.non_basic.iter().enumerate() {
@@ -1205,6 +1318,7 @@ mod tests {
     use super::*;
     use crate::arithmetic::lia::bounds::Bounds;
     use crate::arithmetic::lia::context::ConvContext;
+    use crate::arithmetic::lia::linear_system::Mon;
     use crate::arithmetic::lia::tableau::TableauKind;
     use crate::arithmetic::lia::tableau_dense::TableauDense;
     use crate::arithmetic::lia::variables::{Var, VarInfo};
@@ -2009,6 +2123,332 @@ mod tests {
             lhs2
         );
 
+        assert!(solver.is_valid());
+    }
+
+    // ─── incremental add_relation tests (sparse tableau) ─────────────────────────
+    //
+    // These exercise extending a live, solved tableau with a new slack row, then
+    // relaxing the slack's bounds to unbounded on backtrack rather than physically
+    // removing the row.
+
+    /// Build a small feasible sparse system with two unbounded non-basic variables and
+    /// one bounded slack:
+    ///
+    ///    |  x  y
+    /// ---+-------
+    /// s1 |  1  1     2 <= s1        (i.e. x + y >= 2)
+    ///
+    /// x = Var::real(10), y = Var::real(11), s1 = Var::real(1).
+    fn ex_sum_sparse() -> LRASolver {
+        let basic =
+            vec![VarInfo::new(Var::real(1), Owner::Basic(0)).with_bounds(Bounds::above_of(2))];
+        let non_basic = vec![
+            VarInfo::new(Var::real(10), Owner::NonBasic(0)), // x, unbounded
+            VarInfo::new(Var::real(11), Owner::NonBasic(1)), // y, unbounded
+        ];
+        let equations = vec![vec![rbig!(1), rbig!(1)]];
+        let ctx = ConvContext::default();
+        LRASolver::from_eqs(basic, non_basic, equations, ctx, TableauKind::Sparse).unwrap()
+    }
+
+    #[test]
+    fn add_relation_grows_sparse_tableau() {
+        let mut solver = ex_sum_sparse();
+        assert!(matches!(
+            solver.solve().unwrap().decision,
+            SolverDecision::FEASIBLE(_)
+        ));
+
+        let nrows_before = solver.tableau.nrows();
+        let ncols_before = solver.tableau.ncols();
+
+        // Add s_new = x + y (a second slack over the same, existing, non-basic variables).
+        let slack = Var::real(2);
+        let rel = Rel::mk_ge(
+            vec![Mon::new(1, Var::real(10)), Mon::new(1, Var::real(11))],
+            0,
+        );
+        solver.add_relation(rel, slack).unwrap();
+
+        // One new row, no new columns (x, y already present).
+        assert_eq!(solver.tableau.nrows(), nrows_before + 1);
+        assert_eq!(solver.tableau.ncols(), ncols_before);
+
+        // Slack is basic and owns the new row.
+        let idx = *solver.var_to_idx.get(&slack).unwrap();
+        let new_row = solver.variables[idx].is_basic().expect("slack should be basic");
+        assert_eq!(new_row, nrows_before);
+
+        // β(slack) == β(x) + β(y).
+        let x_val = solver.variables[solver.non_basic[0]].val.clone();
+        let y_val = solver.variables[solver.non_basic[1]].val.clone();
+        assert_eq!(solver.variables[idx].val, &x_val + &y_val);
+
+        // Slack is unbounded and the check-invariant holds immediately after add.
+        assert!(solver.variables[idx].is_totally_unbounded());
+        assert!(solver.is_valid());
+    }
+
+    #[test]
+    fn add_relation_substitutes_basic_var() {
+        // Use the ex_5_6 system with an extensible tableau, then pivot so an original
+        // variable (x) becomes basic.
+        let basic = vec![
+            VarInfo::new(Var::real(1), Owner::Basic(0)).with_bounds(Bounds::above_of(2)),
+            VarInfo::new(Var::real(2), Owner::Basic(1)).with_bounds(Bounds::above_of(0)),
+            VarInfo::new(Var::real(3), Owner::Basic(2)).with_bounds(Bounds::above_of(1)),
+        ];
+        let non_basic = vec![
+            VarInfo::new(Var::real(4), Owner::NonBasic(0)), // x
+            VarInfo::new(Var::real(5), Owner::NonBasic(1)), // y
+        ];
+        let equations = vec![
+            vec![rbig!(1), rbig!(1)],
+            vec![rbig!(2), rbig!(-1)],
+            vec![rbig!(-1), rbig!(2)],
+        ];
+        let ctx = ConvContext::default();
+        let mut solver =
+            LRASolver::from_eqs(basic, non_basic, equations, ctx, TableauKind::Sparse).unwrap();
+        assert!(matches!(
+            solver.solve().unwrap().decision,
+            SolverDecision::FEASIBLE(_)
+        ));
+
+        // Ensure x (Var::real(4)) is basic: if not already, pivot s1(row 0) with x(col of x).
+        let x_idx = *solver.var_to_idx.get(&Var::real(4)).unwrap();
+        if let Some(col) = solver.variables[x_idx].is_non_basic() {
+            // pivot the first basic row against x's column (coeff is nonzero in row 0)
+            let val = solver.variables[solver.non_basic[col]].val.clone();
+            solver.pivot_and_update(0, col, &val).unwrap();
+        }
+        assert!(
+            solver.variables[x_idx].is_basic().is_some(),
+            "x should be basic for this test"
+        );
+
+        // Add a relation referencing the now-basic x: s_new = x. This exercises the
+        // Owner::Basic(r) substitution branch (x is replaced by its row over non-basics).
+        let slack = Var::real(6);
+        let rel = Rel::mk_ge(vec![Mon::new(1, Var::real(4))], 0);
+        solver.add_relation(rel, slack).unwrap();
+
+        // The written row must equal x's row (since s_new = x = <x's row over non-basics>).
+        let x_row = solver.variables[x_idx].is_basic().unwrap();
+        let slack_idx = *solver.var_to_idx.get(&slack).unwrap();
+        let slack_row = solver.variables[slack_idx].is_basic().unwrap();
+        for c in 0..solver.non_basic.len() {
+            assert_eq!(
+                solver.tableau.get(slack_row, c).unwrap(),
+                solver.tableau.get(x_row, c).unwrap(),
+                "substituted row must match x's row at column {c}"
+            );
+        }
+        // β(slack) == β(x).
+        assert_eq!(solver.variables[slack_idx].val, solver.variables[x_idx].val);
+        assert!(solver.is_valid());
+    }
+
+    #[test]
+    fn add_relation_new_variable() {
+        let mut solver = ex_sum_sparse();
+        assert!(matches!(
+            solver.solve().unwrap().decision,
+            SolverDecision::FEASIBLE(_)
+        ));
+        let ncols_before = solver.tableau.ncols();
+
+        // Add s_new = x + z, where z (Var::real(20)) is brand new.
+        let z = Var::real(20);
+        let slack = Var::real(2);
+        let rel = Rel::mk_ge(vec![Mon::new(1, Var::real(10)), Mon::new(1, z)], 0);
+        solver.add_relation(rel, slack).unwrap();
+
+        // One new column for z.
+        assert_eq!(solver.tableau.ncols(), ncols_before + 1);
+        let z_idx = *solver.var_to_idx.get(&z).unwrap();
+        assert!(
+            solver.variables[z_idx].is_non_basic().is_some(),
+            "z should be a new non-basic variable"
+        );
+        assert!(solver.variables[z_idx].is_totally_unbounded());
+        assert!(solver.is_valid());
+    }
+
+    #[test]
+    fn add_relation_all_zero_row() {
+        let mut solver = ex_sum_sparse();
+        assert!(matches!(
+            solver.solve().unwrap().decision,
+            SolverDecision::FEASIBLE(_)
+        ));
+
+        // s_new = x - x, which cancels to the all-zero row.
+        let slack = Var::real(2);
+        let rel = Rel::mk_ge(
+            vec![Mon::new(1, Var::real(10)), Mon::new(-1, Var::real(10))],
+            0,
+        );
+        solver.add_relation(rel, slack).unwrap();
+
+        // The new row is all zero and β(slack) == 0.
+        let slack_idx = *solver.var_to_idx.get(&slack).unwrap();
+        let slack_row = solver.variables[slack_idx].is_basic().unwrap();
+        for c in 0..solver.non_basic.len() {
+            assert!(solver.tableau.get(slack_row, c).unwrap().is_zero());
+        }
+        assert_eq!(solver.variables[slack_idx].val, QDelta::ZERO);
+        assert!(solver.is_valid());
+
+        // Asserting slack >= 1 makes the (stuck-at-0) slack infeasible with no valid pivot.
+        assert_eq!(solver.assert_lower(&slack, &1i32.into()).unwrap(), None);
+        assert!(matches!(
+            solver.solve().unwrap().decision,
+            SolverDecision::INFEASIBLE(_)
+        ));
+    }
+
+    #[test]
+    fn add_relation_all_zero_row_feasible_bounds() {
+        let mut solver = ex_sum_sparse();
+        solver.solve().unwrap();
+        let slack = Var::real(2);
+        let rel = Rel::mk_ge(
+            vec![Mon::new(1, Var::real(10)), Mon::new(-1, Var::real(10))],
+            0,
+        );
+        solver.add_relation(rel, slack).unwrap();
+
+        // Bounds [-1, 5] contain 0, so the stuck slack is trivially feasible.
+        assert_eq!(solver.assert_lower(&slack, &(-1i32).into()).unwrap(), Some(true));
+        assert_eq!(solver.assert_upper(&slack, &5i32.into()).unwrap(), Some(true));
+        assert!(matches!(
+            solver.solve().unwrap().decision,
+            SolverDecision::FEASIBLE(_)
+        ));
+    }
+
+    /// Assert a bound on a freshly added slack, let simplex pivot the slack out of the
+    /// basis, then backtrack — the slack's bounds must relax to (−∞, +∞) with no
+    /// linear-algebra work, and the solver must land in a valid state even though the
+    /// slack is now non-basic.
+    #[test]
+    fn add_relation_pivot_then_backtrack_relaxes_slack() {
+        let mut solver = ex_sum_sparse();
+        assert!(matches!(
+            solver.solve().unwrap().decision,
+            SolverDecision::FEASIBLE(_)
+        ));
+
+        // Add s_new = x + y and register it, then take the backtrack snapshot AFTER the add
+        // (the intended DPLL(T) order: the snapshot includes the slack).
+        let slack = Var::real(2);
+        let rel = Rel::mk_ge(
+            vec![Mon::new(1, Var::real(10)), Mon::new(1, Var::real(11))],
+            0,
+        );
+        solver.add_relation(rel, slack).unwrap();
+        assert!(solver.is_valid());
+        let slack_idx = *solver.var_to_idx.get(&slack).unwrap();
+        assert!(solver.variables[slack_idx].is_basic().is_some());
+
+        let level = solver.set_backtrack();
+
+        // Assert slack >= 5. The slack starts basic at β = β(x)+β(y) = 0 < 5, so simplex must
+        // pivot it against an unbounded non-basic (x or y) to satisfy the bound.
+        assert_eq!(solver.assert_lower(&slack, &5i32.into()).unwrap(), None);
+        assert!(matches!(
+            solver.solve().unwrap().decision,
+            SolverDecision::FEASIBLE(_)
+        ));
+        assert!(
+            solver.variables[slack_idx].is_non_basic().is_some(),
+            "slack should have drifted to non-basic via the feasibility pivot"
+        );
+
+        // Backtrack: the slack's lower bound (previously None) is restored, i.e. relaxed to -inf.
+        solver.backtrack(level);
+        assert!(
+            solver.variables[slack_idx].is_totally_unbounded(),
+            "backtrack must relax the popped slack to (-inf, +inf)"
+        );
+        // Pivots are NOT undone — the slack is still non-basic.
+        assert!(solver.variables[slack_idx].is_non_basic().is_some());
+        // ...yet the check-invariant holds, with zero linear algebra on the backtrack path.
+        assert!(solver.is_valid());
+    }
+
+    /// Regression guard for the `restore_assignment` robustness fix: set the backtrack point
+    /// BEFORE `add_relation`, then assert / solve (pivot) / backtrack past the add. The snapshot
+    /// does not contain the slack, but recomputing basics from restored non-basics keeps the
+    /// solver valid.
+    #[test]
+    fn add_relation_before_backtrack_gap() {
+        let mut solver = ex_sum_sparse();
+        assert!(matches!(
+            solver.solve().unwrap().decision,
+            SolverDecision::FEASIBLE(_)
+        ));
+
+        // Snapshot BEFORE adding the relation.
+        let level = solver.set_backtrack();
+
+        let slack = Var::real(2);
+        let rel = Rel::mk_ge(
+            vec![Mon::new(1, Var::real(10)), Mon::new(1, Var::real(11))],
+            0,
+        );
+        solver.add_relation(rel, slack).unwrap();
+        assert_eq!(solver.assert_lower(&slack, &5i32.into()).unwrap(), None);
+        assert!(matches!(
+            solver.solve().unwrap().decision,
+            SolverDecision::FEASIBLE(_)
+        ));
+
+        // Backtrack past the add. The slack post-dates the snapshot; restore_assignment must
+        // still leave the solver in a consistent state.
+        solver.backtrack(level);
+        assert!(solver.is_valid());
+    }
+
+    /// A feasible system is checked, then a new relation is added whose asserted bound makes
+    /// the system infeasible; backtracking over the assertion must return the solver to a
+    /// feasible state.
+    #[test]
+    fn add_relation_infeasible_then_backtrack_feasible() {
+        // ex_sum_sparse: s1 = x + y with s1 >= 2, x/y unbounded.
+        let mut solver = ex_sum_sparse();
+        assert!(matches!(
+            solver.solve().unwrap().decision,
+            SolverDecision::FEASIBLE(_)
+        ));
+
+        // Add s_new = x + y (the same combination as s1), then snapshot.
+        let slack = Var::real(2);
+        let rel = Rel::mk_le(
+            vec![Mon::new(1, Var::real(10)), Mon::new(1, Var::real(11))],
+            0,
+        );
+        solver.add_relation(rel, slack).unwrap();
+        assert!(solver.is_valid());
+
+        let level = solver.set_backtrack();
+
+        // Assert s_new <= 1. Since s_new = x + y = s1 and s1 >= 2, this is infeasible.
+        assert_eq!(solver.assert_upper(&slack, &1i32.into()).unwrap(), None);
+        assert!(matches!(
+            solver.solve().unwrap().decision,
+            SolverDecision::INFEASIBLE(_)
+        ));
+
+        // Backtracking relaxes the s_new bound; the system is feasible again.
+        solver.backtrack(level);
+        assert!(solver.variables[*solver.var_to_idx.get(&slack).unwrap()].is_totally_unbounded());
+        assert!(matches!(
+            solver.solve().unwrap().decision,
+            SolverDecision::FEASIBLE(_)
+        ));
         assert!(solver.is_valid());
     }
 }

--- a/src/arithmetic/lia/mod.rs
+++ b/src/arithmetic/lia/mod.rs
@@ -11,6 +11,7 @@ pub mod config;
 pub mod context;
 pub mod equality_elim;
 pub mod frontend;
+pub mod incremental;
 pub mod linear_system;
 pub mod lira_solver;
 pub mod lra_solver;

--- a/src/arithmetic/lia/sparse.rs
+++ b/src/arithmetic/lia/sparse.rs
@@ -149,16 +149,6 @@ impl<V: Zero + Clone + fmt::Debug> Matrix<V> {
         self.cols.len() - 1
     }
 
-    /// Iterate over the non-zero `(col, &value)` entries of a row.
-    ///
-    /// Returns an empty iterator if `row` is out of bounds.
-    pub fn row_entries(&self, row: usize) -> impl Iterator<Item = (usize, &V)> {
-        self.rows
-            .get(row)
-            .into_iter()
-            .flat_map(|r| r.iter().map(|(c, v)| (*c, v)))
-    }
-
     /// Perform a pivot operation on the NxM matrix at the specified row and column.
     ///
     /// The pivot transforms matrix elements according to:

--- a/src/arithmetic/lia/sparse.rs
+++ b/src/arithmetic/lia/sparse.rs
@@ -131,6 +131,34 @@ impl<V: Zero + Clone + fmt::Debug> Matrix<V> {
         self.cols.get(col).map_or(0, |c| c.len())
     }
 
+    /// Append an empty row to the matrix, returning its index (= the old `nrows`).
+    ///
+    /// Used to grow the tableau incrementally when a new relation (slack row) is added
+    /// to a live simplex solver. Insert entries afterwards with [`Self::update_or_insert`].
+    pub fn add_row(&mut self) -> usize {
+        self.rows.push(FxHashMap::default());
+        self.rows.len() - 1
+    }
+
+    /// Append an empty column to the matrix, returning its index (= the old `ncols`).
+    ///
+    /// Used to grow the tableau incrementally when a relation introduces a variable the
+    /// solver has not seen before. Insert entries afterwards with [`Self::update_or_insert`].
+    pub fn add_col(&mut self) -> usize {
+        self.cols.push(FxHashMap::default());
+        self.cols.len() - 1
+    }
+
+    /// Iterate over the non-zero `(col, &value)` entries of a row.
+    ///
+    /// Returns an empty iterator if `row` is out of bounds.
+    pub fn row_entries(&self, row: usize) -> impl Iterator<Item = (usize, &V)> {
+        self.rows
+            .get(row)
+            .into_iter()
+            .flat_map(|r| r.iter().map(|(c, v)| (*c, v)))
+    }
+
     /// Perform a pivot operation on the NxM matrix at the specified row and column.
     ///
     /// The pivot transforms matrix elements according to:

--- a/src/arithmetic/lia/tableau.rs
+++ b/src/arithmetic/lia/tableau.rs
@@ -78,6 +78,36 @@ where
             .filter(|r| self.get(*r, col).is_ok_and(|v| !v.is_zero()))
             .count()
     }
+
+    /// Append an empty row, returning its index (= the old `nrows`).
+    ///
+    /// Supports incremental extension of a live tableau. The default implementation
+    /// errors; backends that support growth (currently only the sparse tableau) override it.
+    fn add_row(&mut self) -> TableauResult<usize> {
+        Err(TableauError(
+            "add_row is not supported by this tableau backend".to_string(),
+        ))
+    }
+
+    /// Append an empty column, returning its index (= the old `ncols`).
+    ///
+    /// Supports incremental extension of a live tableau. The default implementation
+    /// errors; backends that support growth (currently only the sparse tableau) override it.
+    fn add_col(&mut self) -> TableauResult<usize> {
+        Err(TableauError(
+            "add_col is not supported by this tableau backend".to_string(),
+        ))
+    }
+
+    /// Set a single entry (insert/update, or remove when `val` is zero).
+    ///
+    /// Used together with [`Self::add_row`]/[`Self::add_col`] to write the coefficients of a
+    /// newly added row. The default implementation errors; growth-capable backends override it.
+    fn set_entry(&mut self, _row: usize, _col: usize, _val: Rational) -> TableauResult<()> {
+        Err(TableauError(
+            "set_entry is not supported by this tableau backend".to_string(),
+        ))
+    }
 }
 
 /// Enum-dispatched tableau that selects between dense and sparse at runtime.
@@ -149,6 +179,34 @@ impl Tableau for TableauImpl {
         match self {
             TableauImpl::Dense(t) => t.col_nnz(col),
             TableauImpl::Sparse(t) => t.col_nnz(col),
+        }
+    }
+
+    fn add_row(&mut self) -> TableauResult<usize> {
+        match self {
+            // Dense growth is unsupported (Array2D is fixed-size); use the erroring default.
+            TableauImpl::Dense(_) => Err(TableauError(
+                "add_row is not supported by the dense tableau backend".to_string(),
+            )),
+            TableauImpl::Sparse(t) => Tableau::add_row(t),
+        }
+    }
+
+    fn add_col(&mut self) -> TableauResult<usize> {
+        match self {
+            TableauImpl::Dense(_) => Err(TableauError(
+                "add_col is not supported by the dense tableau backend".to_string(),
+            )),
+            TableauImpl::Sparse(t) => Tableau::add_col(t),
+        }
+    }
+
+    fn set_entry(&mut self, row: usize, col: usize, val: Rational) -> TableauResult<()> {
+        match self {
+            TableauImpl::Dense(_) => Err(TableauError(
+                "set_entry is not supported by the dense tableau backend".to_string(),
+            )),
+            TableauImpl::Sparse(t) => Tableau::set_entry(t, row, col, val),
         }
     }
 }

--- a/src/arithmetic/lia/tableau_sparse.rs
+++ b/src/arithmetic/lia/tableau_sparse.rs
@@ -73,11 +73,6 @@ impl TableauSparse {
             .map_err(|e| TableauError(e.0))
     }
 
-    /// Iterate over the non-zero `(col, &coefficient)` entries of a row.
-    pub fn row_entries(&self, row: usize) -> impl Iterator<Item = (usize, &Rational)> {
-        self.matrix.row_entries(row)
-    }
-
     /// Convert this sparse tableau to a dense tableau.
     ///
     /// Used in tests to compare the equivalence of the sparse/dense pivot algorithms.

--- a/src/arithmetic/lia/tableau_sparse.rs
+++ b/src/arithmetic/lia/tableau_sparse.rs
@@ -51,6 +51,33 @@ impl TableauSparse {
         self.matrix.ncols()
     }
 
+    /// Append an empty row, returning its index (= the old `nrows`).
+    ///
+    /// Grows the tableau to accommodate a new basic (slack) variable's row.
+    pub fn add_row(&mut self) -> usize {
+        self.matrix.add_row()
+    }
+
+    /// Append an empty column, returning its index (= the old `ncols`).
+    ///
+    /// Grows the tableau to accommodate a new non-basic variable's column.
+    pub fn add_col(&mut self) -> usize {
+        self.matrix.add_col()
+    }
+
+    /// Set a single entry, inserting, updating, or (if `val` is zero) removing it.
+    pub fn set_entry(&mut self, row: usize, col: usize, val: Rational) -> TableauResult<()> {
+        self.matrix
+            .update_or_insert(row, col, val)
+            .map(|_| ())
+            .map_err(|e| TableauError(e.0))
+    }
+
+    /// Iterate over the non-zero `(col, &coefficient)` entries of a row.
+    pub fn row_entries(&self, row: usize) -> impl Iterator<Item = (usize, &Rational)> {
+        self.matrix.row_entries(row)
+    }
+
     /// Convert this sparse tableau to a dense tableau.
     ///
     /// Used in tests to compare the equivalence of the sparse/dense pivot algorithms.
@@ -97,6 +124,18 @@ impl Tableau for TableauSparse {
 
     fn col_nnz(&self, col: usize) -> usize {
         self.matrix.col_nnz(col)
+    }
+
+    fn add_row(&mut self) -> TableauResult<usize> {
+        Ok(TableauSparse::add_row(self))
+    }
+
+    fn add_col(&mut self) -> TableauResult<usize> {
+        Ok(TableauSparse::add_col(self))
+    }
+
+    fn set_entry(&mut self, row: usize, col: usize, val: Rational) -> TableauResult<()> {
+        TableauSparse::set_entry(self, row, col, val)
     }
 }
 


### PR DESCRIPTION
*Issue #, if available:* https://github.com/yaspar-org/Sundance-SMT/issues/103

*Description of changes:*

Before this change, the internal arithmetic solver is purely one-shot and is only called once a full model is obtained by the SAT solver.

This change adds the ability to push and pop linear (in)equalities to the internal arithmetic solver. This is accomplished by growing the underlying tableau when constraints are pushed, and relaxing their bounds to +-infinity (unbounded) when popped. This technique is sound and simple to implement, but it means that the tableau grows monotonically so there is a memory and pivot time cost. This can be eliminated later by backtracking over tableau additions if profiling shows regression.

There is a new frontend for the LRA solver which exposes the increment features. It is not yet wired up to anything in the main solver, but there are several unit tests exercising various push/pop patterns. The new frontend can be used to implement an incremental arithmetic solver trait in the future.


----
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
