### PR TITLE
Defer congruence closure until egraph rebuild

### DIFF
--- a/src/cadical_propagator.rs
+++ b/src/cadical_propagator.rs
@@ -106,18 +106,21 @@ impl<'a> CustomExternalPropagator<'a> {
         self.queue_theory_clause(clause, Theory::Background);
     }
 
-    fn rebuild_egraph(&mut self) {
+    fn rebuild_egraph(&mut self) -> bool {
+        let mut found_conflict = false;
         loop {
             let result = self.solver_state.egraph.rebuild();
             // The basic backend never propagates literals, only conflicts.
             debug_assert!(result.propagations.is_empty());
             if let Some(conflict) = result.conflict {
+                found_conflict = true;
                 self.queue_egraph_conflict(&conflict);
             } else {
                 break;
             }
         }
         self.sync_new_vars();
+        found_conflict
     }
 
     fn rebuild_egraph_and_arithmetic(&mut self) {
@@ -307,9 +310,15 @@ impl<'a> ExternalPropagator for CustomExternalPropagator<'a> {
                 self.queue_egraph_conflict(&conflict);
                 continue;
             }
+            if self.rebuild_egraph() {
+                continue;
+            }
 
             let negated_model_or_datatype_constraints_opt =
                 process_assignment(*lit, self.solver_state, self.decision_level);
+            if self.rebuild_egraph() {
+                continue;
+            }
 
             // Drain merges triggered by this assignment, then push the lit
             // itself if it's arithmetic.

--- a/src/cadical_propagator.rs
+++ b/src/cadical_propagator.rs
@@ -120,6 +120,15 @@ impl<'a> CustomExternalPropagator<'a> {
         self.sync_new_vars();
     }
 
+    fn rebuild_egraph_and_arithmetic(&mut self) {
+        self.rebuild_egraph();
+        #[cfg(feature = "z3-solver")]
+        if let Some(z3) = self.z3_incremental.as_mut() {
+            z3.drain_merge_queue(self.solver_state);
+        }
+        self.sync_new_vars();
+    }
+
     /// Register any new CNF variables created since the last sync.
     pub fn sync_new_vars(&mut self) {
         let next = self.solver_state.cnf_cache.next_var;
@@ -384,10 +393,13 @@ impl<'a> ExternalPropagator for CustomExternalPropagator<'a> {
                 }
             }
         }
-        self.rebuild_egraph();
+        self.rebuild_egraph_and_arithmetic();
     }
 
     fn notify_new_decision_level(&mut self) {
+        // Congruence merges must be stamped at the level where their causes
+        // were introduced, not at the level of the next SAT decision.
+        self.rebuild_egraph_and_arithmetic();
         self.stats.decisions += 1;
         debug_println!(
             11,
@@ -440,19 +452,15 @@ impl<'a> ExternalPropagator for CustomExternalPropagator<'a> {
 
         self.decision_level = level;
 
-        // `backtrack_to` clears the arithmetic queue at entry then re-fires
-        // any congruence merges from `union_to_eclass` replay, so the queue
-        // on return holds exactly the merges that survive at `level`.
         self.solver_state.egraph.backtrack_to(level);
 
         #[cfg(feature = "z3-solver")]
-        {
-            if let Some(z3) = self.z3_incremental.as_mut() {
-                z3.notify_backtrack(level);
-                z3.drain_merge_queue(self.solver_state);
-            }
+        if let Some(z3) = self.z3_incremental.as_mut() {
+            z3.notify_backtrack(level);
         }
-        self.sync_new_vars();
+        // Recompute congruence closure at the restored level before any
+        // client observes roots or arithmetic equalities.
+        self.rebuild_egraph_and_arithmetic();
 
         debug_println!(16, 0, "Ending backtracking at level {}", level);
         debug_println!(11, 0, "{}", self.solver_state.egraph);
@@ -472,7 +480,7 @@ impl<'a> ExternalPropagator for CustomExternalPropagator<'a> {
             self.write_trail_line(model);
         }
 
-        self.rebuild_egraph();
+        self.rebuild_egraph_and_arithmetic();
         debug_println!(
             24,
             0,
@@ -604,17 +612,24 @@ impl<'a> ExternalPropagator for CustomExternalPropagator<'a> {
                         // merge can be undone individually if it conflicts.
                         self.solver_state.egraph.notify_new_decision_level();
                         probe_level += 1;
-                        let conflict = self
+                        let mut conflict = self
                             .solver_state
                             .egraph
                             .assert_equal(x_root, y_root)
                             .conflict;
+                        if conflict.is_none() {
+                            conflict = self.solver_state.egraph.rebuild().conflict;
+                        }
                         // Probe merges are speculative — discard queue entries
                         // so they don't leak into Z3IncrementalState.
                         let _ = self.solver_state.egraph.drain_arithmetic_equalities();
                         if let Some(c) = conflict {
                             self.solver_state.egraph.backtrack_to(probe_level - 1);
                             probe_level -= 1;
+                            let rebuild = self.solver_state.egraph.rebuild();
+                            debug_assert!(rebuild.conflict.is_none());
+                            debug_assert!(rebuild.propagations.is_empty());
+                            let _ = self.solver_state.egraph.drain_arithmetic_equalities();
                             conflicts.push(c);
                             if conflicts.len() >= self.max_arith_conflicts_per_round {
                                 break 'outer;
@@ -650,27 +665,13 @@ impl<'a> ExternalPropagator for CustomExternalPropagator<'a> {
                 }
                 self.sync_new_vars();
 
-                // Dynamic registration still cannot return conflicts directly.
-                // Materialize those while speculative equality proofs exist.
+                // Close terms registered while speculative equality proofs exist.
                 self.rebuild_egraph();
 
-                // Undo remaining probe merges. `backtrack_to` may repopulate
-                // the queue via `union_to_eclass` re-firing (e.g. from the
-                // trichotomy terms just registered); drain those into Z3.
+                // Undo remaining probe merges. Backtracking invalidates the
+                // signature cache; the next rebuild restores closure.
                 self.solver_state.egraph.backtrack_to(base_level);
-                #[cfg(feature = "z3-solver")]
-                {
-                    if let Some(z3) = self.z3_incremental.as_mut() {
-                        z3.drain_merge_queue(self.solver_state);
-                    } else {
-                        self.solver_state.egraph.drain_arithmetic_equalities();
-                    }
-                }
-                #[cfg(not(feature = "z3-solver"))]
-                {
-                    self.solver_state.egraph.drain_arithmetic_equalities();
-                }
-                self.sync_new_vars();
+                self.rebuild_egraph_and_arithmetic();
             }
             ArithResult::None => {}
         }
@@ -710,7 +711,7 @@ impl<'a> ExternalPropagator for CustomExternalPropagator<'a> {
         let mut pending = instantiate_quantifiers(self.solver_state, &self.assignments);
 
         if pending.is_empty() {
-            self.rebuild_egraph();
+            self.rebuild_egraph_and_arithmetic();
             if !self.disequalities.borrow().is_empty() {
                 self.stats.conflicts += 1;
                 return false;
@@ -766,7 +767,7 @@ impl<'a> ExternalPropagator for CustomExternalPropagator<'a> {
     }
 
     fn cb_propagate(&mut self) -> i32 {
-        self.rebuild_egraph();
+        self.rebuild_egraph_and_arithmetic();
         0
     }
 

--- a/src/egraphs/basic/egraph.rs
+++ b/src/egraphs/basic/egraph.rs
@@ -17,11 +17,6 @@ use yaspar_ir::ast::Local;
 /// Key for the signature table: (operator, canonical children).
 type SigKey = (CanonicalOp, Children);
 
-/// Trail entry for undoing sig_table modifications on backtrack.
-/// Stores the actual key used, so undo doesn't depend on UF state.
-/// (level, key, term_id, was_inserted)
-type SigTrailEntry = (usize, SigKey, u32, bool);
-
 /// A Boolean value attached to an e-class and its SAT witness. Constants use zero.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 struct BoolClassAssignment<T> {
@@ -234,15 +229,14 @@ pub struct Egraph {
     /// valid at that level and don't need refreshing).
     predecessors_created_by_quantifiers:
         DeterministicHashMap<u32, DeterministicHashMap<u32, usize>>,
-    /// if a quantifier instantiates (f t) and t = s, then we want to add (f.uid(), "f", [t.uid()]).
-    /// Value is the decision level at which the term was registered; entries added
-    /// at or below the backtrack target level are skipped during `backtrack_to`.
-    union_to_eclass: DeterministicHashMap<u32, usize>,
-    /// Signature table: maps (op, [find(c1),...,find(cn)]) → term_id.
-    /// Maintained in parallel with the existing congruence detection for now.
+    /// Signature table for the last completed rebuild.
     sig_table: FastDeterministicHashMap<SigKey, u32>,
-    /// Trail for backtracking the sig_table.
-    sig_trail: Vec<SigTrailEntry>,
+    /// Last rebuilt signature for each term.
+    term_signatures: Vec<Option<SigKey>>,
+    /// Terms whose canonical signatures may have changed.
+    pending_congruence: Vec<u32>,
+    /// Membership set for `pending_congruence`.
+    pending_congruence_set: FastDeterministicHashSet<u32>,
     /// Whether to collect arithmetic-relevant merges for an incremental
     /// arithmetic backend.
     incremental_arithmetic: bool,
@@ -262,9 +256,6 @@ pub struct Egraph {
     /// term ID. Keyed on the pair so re-queuing the same merge dedups for free;
     /// the value is the decision level at which it was queued (for backtracking).
     pending_merges: DeterministicHashMap<(u32, u32), usize>,
-    /// Deferred conflicts from APIs that cannot return an `EgraphResult`, with
-    /// the decision level at which each was detected.
-    pending_conflicts: Vec<(usize, Conflict<u32>)>,
     /// Boolean value and its SAT witness, stored only on e-class roots.
     bool_assignments: Vec<Option<BoolClassAssignment<u32>>>,
     /// Root-assignment changes to undo on SAT backtracking.
@@ -306,9 +297,10 @@ impl Egraph {
             function_maps: DeterministicHashMap::default(),
             decision_level: 0,
             predecessors_created_by_quantifiers: DeterministicHashMap::new(),
-            union_to_eclass: DeterministicHashMap::new(),
             sig_table: FastDeterministicHashMap::default(),
-            sig_trail: Vec::new(),
+            term_signatures: vec![None],
+            pending_congruence: Vec::new(),
+            pending_congruence_set: FastDeterministicHashSet::default(),
             incremental_arithmetic: false,
             arithmetic_merge_queue: Vec::new(),
             merge_tf: vec![false],
@@ -316,7 +308,6 @@ impl Egraph {
             merge_tf_class_trail: Vec::new(),
             merge_tf_upgrades: Vec::new(),
             pending_merges: DeterministicHashMap::new(),
-            pending_conflicts: Vec::new(),
             bool_assignments: vec![None],
             bool_assignment_trail: Vec::new(),
             stats: EgraphStats::default(),
@@ -355,8 +346,7 @@ impl Egraph {
     /// Register a single term in the egraph
     /// Sets up terms_list, proof_forest, predecessors, function_maps for this term.
     /// Register a single term (non-recursive). Children must already be registered.
-    /// If `dynamic` is true, calls find_and_union_to_eclass to merge with any
-    /// existing congruent term (needed for quantifier instantiation and datatype axioms).
+    /// Congruence is deferred until `rebuild`.
     /// Returns true if the term was already registered.
     fn register_term_internal(&mut self, id: u32, op: Op, children: &[u32], dynamic: bool) -> bool {
         self.ensure_capacity(id);
@@ -421,25 +411,7 @@ impl Egraph {
             }
         }
 
-        // Insert into sig_table; if dynamic and sig already exists, merge via congruence.
-        if let Some(sig) = self.compute_signature(id) {
-            if let Some(&existing) = self.sig_table.get(&sig) {
-                if dynamic
-                    && self.find(existing) != self.find(id)
-                    && let Some(conflict) = self
-                        .congruence_merge(existing, id, self.decision_level)
-                        .conflict
-                {
-                    self.pending_conflicts.push((self.decision_level, conflict));
-                }
-            } else {
-                self.sig_table_insert(sig, id, self.decision_level);
-            }
-        }
-
-        if dynamic && !children.is_empty() {
-            self.union_to_eclass.insert(id, self.decision_level);
-        }
+        self.enqueue_congruence(id);
 
         false
     }
@@ -469,6 +441,8 @@ impl Egraph {
                 .resize(self.merge_tf_class.len() * 2, None);
             self.bool_assignments
                 .resize(self.bool_assignments.len() * 2, None);
+            self.term_signatures
+                .resize(self.term_signatures.len() * 2, None);
         }
     }
 
@@ -666,10 +640,60 @@ impl Egraph {
         Some((op, Children::from_slice(&canonical_children)))
     }
 
-    /// Insert a term into the sig_table, recording a trail entry for backtracking.
-    fn sig_table_insert(&mut self, key: SigKey, term_id: u32, level: usize) {
-        self.sig_table.insert(key.clone(), term_id);
-        self.sig_trail.push((level, key, term_id, true));
+    fn enqueue_congruence(&mut self, term: u32) {
+        if self.compute_signature(term).is_some() && self.pending_congruence_set.insert(term) {
+            self.pending_congruence.push(term);
+        }
+    }
+
+    fn enqueue_all_congruence_terms(&mut self) {
+        self.sig_table.clear();
+        self.term_signatures.fill(None);
+        self.pending_congruence.clear();
+        self.pending_congruence_set.clear();
+        for term in 0..self.next_id {
+            self.enqueue_congruence(term);
+        }
+    }
+
+    /// Repair one canonical signature and merge a collision, if any.
+    fn rebuild_congruence(&mut self, term: u32) -> EgraphResult<u32> {
+        let Some(signature) = self.compute_signature(term) else {
+            self.term_signatures[term as usize] = None;
+            return EgraphResult::ok();
+        };
+
+        if let Some(old_signature) = self.term_signatures[term as usize].take()
+            && self.sig_table.get(&old_signature) == Some(&term)
+        {
+            self.sig_table.remove(&old_signature);
+        }
+
+        loop {
+            let Some(existing) = self.sig_table.get(&signature).copied() else {
+                self.sig_table.insert(signature.clone(), term);
+                self.term_signatures[term as usize] = Some(signature);
+                return EgraphResult::ok();
+            };
+
+            if existing == term {
+                self.term_signatures[term as usize] = Some(signature);
+                return EgraphResult::ok();
+            }
+
+            if self.compute_signature(existing).as_ref() != Some(&signature) {
+                self.sig_table.remove(&signature);
+                self.enqueue_congruence(existing);
+                continue;
+            }
+
+            self.term_signatures[existing as usize] = Some(signature.clone());
+            self.term_signatures[term as usize] = Some(signature);
+            if self.find(existing) == self.find(term) {
+                return EgraphResult::ok();
+            }
+            return self.congruence_merge(existing, term, self.decision_level);
+        }
     }
 
     /// Build a congruence proof edge and merge two terms that have the same signature.
@@ -921,7 +945,7 @@ impl Egraph {
     }
 
     /// Assert t1 = t2 at the current decision level.
-    /// Performs congruence closure. Returns a conflict if a disequality is violated.
+    /// Congruence consequences are deferred until `rebuild`.
     fn assert_equal(&mut self, t1: u32, t2: u32) -> EgraphResult<u32> {
         let level = self.decision_level;
         let proof_parent = ProofForestEdge::Equality {
@@ -1137,8 +1161,6 @@ impl Egraph {
         }
         self.pending_merges
             .retain(|_, entry_level| *entry_level <= level);
-        self.pending_conflicts
-            .retain(|(entry_level, _)| *entry_level <= level);
         let mut relocated_upgrades = Vec::new();
         for (upgrade_level, term) in &mut self.merge_tf_upgrades {
             if *upgrade_level > level {
@@ -1161,22 +1183,6 @@ impl Egraph {
             self.merge_tf_upgrades.clear();
         }
 
-        // Replay sig_trail in reverse AFTER UF is restored.
-        // Use the stored key directly — recomputing from find() would give the wrong key.
-        while let Some((entry_level, _, _, _)) = self.sig_trail.last() {
-            if *entry_level <= level {
-                break;
-            }
-            let (_, key, term_id, was_inserted) = self.sig_trail.pop().unwrap();
-            if was_inserted {
-                if self.sig_table.get(&key) == Some(&term_id) {
-                    self.sig_table.remove(&key);
-                }
-            } else {
-                self.sig_table.insert(key, term_id);
-            }
-        }
-
         // Re-add predecessors created by quantifiers at their new roots.
         // Skip entries added at or below `level`: their predecessor stamps are
         // still valid (predecessor_level only got bumped for levels > `level`)
@@ -1197,41 +1203,14 @@ impl Egraph {
             }
         }
 
-        // Any merges left in the arithmetic queue from before this backtrack
-        // are stale — they refer to unions at levels we've just undone. Clear
-        // them so that only re-fired congruence merges (added by the loop
-        // below) survive.
+        // Merges and signatures computed above the target level are stale.
         self.arithmetic_merge_queue.clear();
-
-        // Re-do union_to_eclass via sig table probe. Entries added at or below
-        // `level` were already reconciled with the sig_table at that level and
-        // their signatures are stable under this backtrack.
-        let union_to_eclass_info = self.union_to_eclass.clone();
-        for (term, added_at) in union_to_eclass_info {
-            if added_at <= level {
-                continue;
-            }
-            if let Some(sig) = self.compute_signature(term) {
-                if let Some(&existing) = self.sig_table.get(&sig) {
-                    if self.find(existing) != self.find(term)
-                        && let Some(conflict) = self
-                            .congruence_merge(existing, term, self.decision_level)
-                            .conflict
-                    {
-                        self.pending_conflicts.push((self.decision_level, conflict));
-                    }
-                } else {
-                    self.sig_table_insert(sig, term, self.decision_level);
-                }
-            }
-        }
+        self.enqueue_all_congruence_terms();
 
         // Clear at level 0
         if level == 0 {
             self.predecessors_created_by_quantifiers = DeterministicHashMap::new();
-            self.union_to_eclass = DeterministicHashMap::new();
             self.proof_forest_backtrack_stack = vec![];
-            self.sig_trail.clear();
             self.bool_assignment_trail.clear();
         }
     }
@@ -1610,14 +1589,9 @@ impl Egraph {
             }
         }
 
-        // No explicit sig_table removal phase needed: old entries keyed on y_root
-        // become stale (unreachable by compute_signature after the union) and are
-        // naturally superseded by the fresh insertions below.
-        // Reinsert y_root's predecessors into sig_table with new canonical forms
-        // and immediately merge any congruent pairs found.
-        // Also move predecessors from y_root to x_root.
+        // Move predecessors from the demoted root to the surviving root and
+        // defer all induced congruence reasoning until rebuild.
         let predecessors_v = std::mem::take(&mut self.predecessors[y_root as usize]);
-        let mut y_root_pred_keys: Vec<u32> = Vec::new();
         for (pred_key, pred_val) in &predecessors_v {
             let new_pred = Predecessor {
                 level,
@@ -1627,24 +1601,10 @@ impl Egraph {
             };
             self.add_predecessor(x_root, *pred_key, new_pred);
             if valid_hash(pred_val.hash, pred_val.level, &self.predecessor_level) {
-                y_root_pred_keys.push(*pred_key);
+                self.enqueue_congruence(*pred_key);
             }
         }
         self.predecessors[y_root as usize] = predecessors_v;
-        for &pred_id in &y_root_pred_keys {
-            if let Some(new_sig) = self.compute_signature(pred_id) {
-                if let Some(&existing) = self.sig_table.get(&new_sig) {
-                    if self.find(existing) != self.find(pred_id) {
-                        let sub_result = self.congruence_merge(existing, pred_id, level);
-                        if sub_result.conflict.is_some() {
-                            return sub_result;
-                        }
-                    }
-                } else {
-                    self.sig_table_insert(new_sig, pred_id, level);
-                }
-            }
-        }
 
         debug_assert!(
             !x_root_is_const || self.find(x_root) == x_root,
@@ -2007,6 +1967,10 @@ impl EgraphTrait for Egraph {
             self.arithmetic_merge_queue.is_empty(),
             "arithmetic queue must be drained before advancing decision level"
         );
+        assert!(
+            self.pending_congruence.is_empty() && self.pending_merges.is_empty(),
+            "egraph must be rebuilt before advancing decision level"
+        );
         self.decision_level += 1;
         while self.decision_level >= self.predecessor_level.len() {
             self.predecessor_level
@@ -2064,21 +2028,28 @@ impl EgraphTrait for Egraph {
 
     fn rebuild(&mut self) -> EgraphResult<Self::TermId> {
         let mut result = EgraphResult::ok();
-        // Surface conflicts first: each forces a backtrack, so any merge run
-        // beforehand would just be undone.
-        if let Some((_, conflict)) = self.pending_conflicts.pop() {
-            result.conflict = Some(conflict);
-            return result;
-        }
-        while let Some(((term, bool_constant), _)) = self.pending_merges.pop_first() {
-            let merge_result = self.assert_equal(term, bool_constant);
-            result.propagations.extend(merge_result.propagations);
-            if let Some(conflict) = merge_result.conflict {
+        loop {
+            if let Some(((term, bool_constant), _)) = self.pending_merges.pop_first() {
+                let merge_result = self.assert_equal(term, bool_constant);
+                result.propagations.extend(merge_result.propagations);
+                if let Some(conflict) = merge_result.conflict {
+                    result.conflict = Some(conflict);
+                    return result;
+                }
+                continue;
+            }
+
+            let Some(term) = self.pending_congruence.pop() else {
+                return result;
+            };
+            self.pending_congruence_set.remove(&term);
+            let congruence_result = self.rebuild_congruence(term);
+            result.propagations.extend(congruence_result.propagations);
+            if let Some(conflict) = congruence_result.conflict {
                 result.conflict = Some(conflict);
                 return result;
             }
         }
-        result
     }
 
     fn are_equal(&self, t1: Self::TermId, t2: Self::TermId) -> bool {

--- a/src/egraphs/basic/egraph.rs
+++ b/src/egraphs/basic/egraph.rs
@@ -17,6 +17,9 @@ use yaspar_ir::ast::Local;
 /// Key for the signature table: (operator, canonical children).
 type SigKey = (CanonicalOp, Children);
 
+/// A complete repair pass is worthwhile only when incremental work is dense.
+const FULL_REBUILD_MIN_TERMS: usize = 1024;
+
 /// A Boolean value attached to an e-class and its SAT witness. Constants use zero.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 struct BoolClassAssignment<T> {
@@ -231,12 +234,24 @@ pub struct Egraph {
         DeterministicHashMap<u32, DeterministicHashMap<u32, usize>>,
     /// Signature table for the last completed rebuild.
     sig_table: FastDeterministicHashMap<SigKey, u32>,
+    /// Backtrack trail for signature-table mutations.
+    sig_table_trail: Vec<(usize, SigKey, Option<u32>)>,
     /// Last rebuilt signature for each term.
     term_signatures: Vec<Option<SigKey>>,
+    /// All terms that participate in congruence, in registration order.
+    congruence_terms: Vec<u32>,
+    /// Backtrack trail for per-term signature-cache mutations.
+    term_signature_trail: Vec<(usize, u32, Option<SigKey>)>,
     /// Terms whose canonical signatures may have changed.
     pending_congruence: Vec<u32>,
-    /// Membership set for `pending_congruence`.
-    pending_congruence_set: FastDeterministicHashSet<u32>,
+    /// Dense membership flags for `pending_congruence`.
+    pending_congruence_flags: Vec<bool>,
+    /// Whether `pending_congruence` was expanded into a complete repair pass.
+    full_congruence_rebuild_active: bool,
+    /// Congruence-capable terms registered above level zero. Terms persist
+    /// after SAT backtracking, so their cache entries must be rebuilt at the
+    /// restored level.
+    congruence_registrations: Vec<(usize, u32)>,
     /// Whether to collect arithmetic-relevant merges for an incremental
     /// arithmetic backend.
     incremental_arithmetic: bool,
@@ -298,9 +313,14 @@ impl Egraph {
             decision_level: 0,
             predecessors_created_by_quantifiers: DeterministicHashMap::new(),
             sig_table: FastDeterministicHashMap::default(),
+            sig_table_trail: Vec::new(),
             term_signatures: vec![None],
+            congruence_terms: Vec::new(),
+            term_signature_trail: Vec::new(),
             pending_congruence: Vec::new(),
-            pending_congruence_set: FastDeterministicHashSet::default(),
+            pending_congruence_flags: vec![false],
+            full_congruence_rebuild_active: false,
+            congruence_registrations: Vec::new(),
             incremental_arithmetic: false,
             arithmetic_merge_queue: Vec::new(),
             merge_tf: vec![false],
@@ -411,7 +431,14 @@ impl Egraph {
             }
         }
 
-        self.enqueue_congruence(id);
+        if matches!(op, Op::App(_) | Op::Eq | Op::Ite) {
+            self.congruence_terms.push(id);
+            if self.decision_level > 0 {
+                self.congruence_registrations
+                    .push((self.decision_level, id));
+            }
+            self.enqueue_congruence(id);
+        }
 
         false
     }
@@ -443,6 +470,8 @@ impl Egraph {
                 .resize(self.bool_assignments.len() * 2, None);
             self.term_signatures
                 .resize(self.term_signatures.len() * 2, None);
+            self.pending_congruence_flags
+                .resize(self.pending_congruence_flags.len() * 2, false);
         }
     }
 
@@ -641,54 +670,117 @@ impl Egraph {
     }
 
     fn enqueue_congruence(&mut self, term: u32) {
-        if self.compute_signature(term).is_some() && self.pending_congruence_set.insert(term) {
+        let participates = matches!(
+            &self.terms[term as usize],
+            TermSlot::Term(TermEntry {
+                op: Op::App(_) | Op::Eq | Op::Ite,
+                ..
+            })
+        );
+        if participates && !self.pending_congruence_flags[term as usize] {
+            self.pending_congruence_flags[term as usize] = true;
             self.pending_congruence.push(term);
         }
     }
 
-    fn enqueue_all_congruence_terms(&mut self) {
-        self.sig_table.clear();
-        self.term_signatures.fill(None);
-        self.pending_congruence.clear();
-        self.pending_congruence_set.clear();
-        for term in 0..self.next_id {
-            self.enqueue_congruence(term);
+    fn clear_pending_congruence(&mut self) {
+        for term in self.pending_congruence.drain(..) {
+            self.pending_congruence_flags[term as usize] = false;
         }
+        self.full_congruence_rebuild_active = false;
+    }
+
+    fn maybe_schedule_full_congruence_rebuild(&mut self) {
+        let total = self.congruence_terms.len();
+        if self.full_congruence_rebuild_active
+            || total < FULL_REBUILD_MIN_TERMS
+            || self.pending_congruence.len().saturating_mul(2) < total
+        {
+            return;
+        }
+        if self.pending_congruence.len() == total {
+            self.full_congruence_rebuild_active = true;
+            return;
+        }
+
+        self.clear_pending_congruence();
+        for &term in &self.congruence_terms {
+            self.pending_congruence_flags[term as usize] = true;
+            self.pending_congruence.push(term);
+        }
+        self.full_congruence_rebuild_active = true;
+    }
+
+    fn set_sig_table_entry(&mut self, key: SigKey, value: Option<u32>) {
+        let previous = self.sig_table.get(&key).copied();
+        if previous == value {
+            return;
+        }
+        if self.decision_level > 0 {
+            self.sig_table_trail
+                .push((self.decision_level, key.clone(), previous));
+        }
+        if let Some(term) = value {
+            self.sig_table.insert(key, term);
+        } else {
+            self.sig_table.remove(&key);
+        }
+    }
+
+    fn set_term_signature(&mut self, term: u32, signature: Option<SigKey>) {
+        if self.term_signatures[term as usize] == signature {
+            return;
+        }
+        if self.decision_level > 0 {
+            self.term_signature_trail.push((
+                self.decision_level,
+                term,
+                self.term_signatures[term as usize].clone(),
+            ));
+        }
+        self.term_signatures[term as usize] = signature;
     }
 
     /// Repair one canonical signature and merge a collision, if any.
     fn rebuild_congruence(&mut self, term: u32) -> EgraphResult<u32> {
         let Some(signature) = self.compute_signature(term) else {
-            self.term_signatures[term as usize] = None;
+            self.set_term_signature(term, None);
             return EgraphResult::ok();
         };
 
-        if let Some(old_signature) = self.term_signatures[term as usize].take()
+        if self.term_signatures[term as usize].as_ref() == Some(&signature)
+            && self.sig_table.get(&signature) == Some(&term)
+        {
+            return EgraphResult::ok();
+        }
+
+        if let Some(old_signature) = self.term_signatures[term as usize].clone()
             && self.sig_table.get(&old_signature) == Some(&term)
         {
-            self.sig_table.remove(&old_signature);
+            self.set_sig_table_entry(old_signature, None);
         }
+        self.set_term_signature(term, None);
 
         loop {
             let Some(existing) = self.sig_table.get(&signature).copied() else {
-                self.sig_table.insert(signature.clone(), term);
-                self.term_signatures[term as usize] = Some(signature);
+                self.set_sig_table_entry(signature.clone(), Some(term));
+                self.set_term_signature(term, Some(signature));
                 return EgraphResult::ok();
             };
 
             if existing == term {
-                self.term_signatures[term as usize] = Some(signature);
+                self.set_term_signature(term, Some(signature));
                 return EgraphResult::ok();
             }
 
             if self.compute_signature(existing).as_ref() != Some(&signature) {
-                self.sig_table.remove(&signature);
+                self.set_sig_table_entry(signature.clone(), None);
                 self.enqueue_congruence(existing);
                 continue;
             }
 
-            self.term_signatures[existing as usize] = Some(signature.clone());
-            self.term_signatures[term as usize] = Some(signature);
+            self.set_term_signature(existing, Some(signature.clone()));
+            self.set_term_signature(term, Some(signature));
             if self.find(existing) == self.find(term) {
                 return EgraphResult::ok();
             }
@@ -1183,6 +1275,30 @@ impl Egraph {
             self.merge_tf_upgrades.clear();
         }
 
+        while let Some((entry_level, _, _)) = self.sig_table_trail.last() {
+            if *entry_level <= level {
+                break;
+            }
+            let (_, key, previous) = self.sig_table_trail.pop().unwrap();
+            if let Some(term) = previous {
+                self.sig_table.insert(key, term);
+            } else {
+                self.sig_table.remove(&key);
+            }
+        }
+
+        while let Some((entry_level, _, _)) = self.term_signature_trail.last() {
+            if *entry_level <= level {
+                break;
+            }
+            let (_, term, previous) = self.term_signature_trail.pop().unwrap();
+            self.term_signatures[term as usize] = previous;
+        }
+
+        // Pending work belongs to the abandoned suffix of the SAT trail. The
+        // target level was fully rebuilt before the solver advanced past it.
+        self.clear_pending_congruence();
+
         // Re-add predecessors created by quantifiers at their new roots.
         // Skip entries added at or below `level`: their predecessor stamps are
         // still valid (predecessor_level only got bumped for levels > `level`)
@@ -1203,15 +1319,28 @@ impl Egraph {
             }
         }
 
-        // Merges and signatures computed above the target level are stale.
+        let mut relocated_registrations = Vec::new();
+        for (registered_at, term) in &mut self.congruence_registrations {
+            if *registered_at > level {
+                *registered_at = level;
+                relocated_registrations.push(*term);
+            }
+        }
+        for term in relocated_registrations {
+            self.enqueue_congruence(term);
+        }
+
+        // Merges queued for arithmetic above the target level are stale.
         self.arithmetic_merge_queue.clear();
-        self.enqueue_all_congruence_terms();
 
         // Clear at level 0
         if level == 0 {
             self.predecessors_created_by_quantifiers = DeterministicHashMap::new();
             self.proof_forest_backtrack_stack = vec![];
             self.bool_assignment_trail.clear();
+            self.sig_table_trail.clear();
+            self.term_signature_trail.clear();
+            self.congruence_registrations.clear();
         }
     }
 
@@ -1423,10 +1552,10 @@ impl Egraph {
 
         // Ensure the constant (if any) remains the root: make the constant
         // side "x" so that x_root stays as root after the union.
-        let (x, y, x_root, y_root) = if y_root_is_const {
-            (y, x, y_root, x_root)
+        let (x, y, x_root, y_root, surviving_root_is_const) = if y_root_is_const {
+            (y, x, y_root, x_root, true)
         } else {
-            (x, y, x_root, y_root)
+            (x, y, x_root, y_root, x_root_is_const)
         };
 
         // `mark_arithmetic` runs *after* `register_term` in
@@ -1607,7 +1736,7 @@ impl Egraph {
         self.predecessors[y_root as usize] = predecessors_v;
 
         debug_assert!(
-            !x_root_is_const || self.find(x_root) == x_root,
+            !surviving_root_is_const || self.find(x_root) == x_root,
             "constant root invariant violated for {}",
             self.display_term(x_root)
         );
@@ -2039,10 +2168,13 @@ impl EgraphTrait for Egraph {
                 continue;
             }
 
+            self.maybe_schedule_full_congruence_rebuild();
             let Some(term) = self.pending_congruence.pop() else {
+                self.full_congruence_rebuild_active = false;
                 return result;
             };
-            self.pending_congruence_set.remove(&term);
+            debug_assert!(self.pending_congruence_flags[term as usize]);
+            self.pending_congruence_flags[term as usize] = false;
             let congruence_result = self.rebuild_congruence(term);
             result.propagations.extend(congruence_result.propagations);
             if let Some(conflict) = congruence_result.conflict {

--- a/src/egraphs/traits.rs
+++ b/src/egraphs/traits.rs
@@ -68,7 +68,8 @@ pub trait EgraphTrait {
 
     /// Register a term with its operator and children.
     /// The egraph assigns and returns the TermId.
-    /// If `dynamic` is true, finds and merges with existing congruent terms.
+    /// If `dynamic` is true, records any metadata needed for terms introduced
+    /// after the initial build. Congruence merging is deferred until `rebuild`.
     fn register_term(
         &mut self,
         op: Self::Op,
@@ -121,7 +122,8 @@ pub trait EgraphTrait {
     // --- Assertions ---
 
     /// Assert `t1 = t2` at the current decision level.
-    /// Performs congruence closure. Returns a conflict if a disequality is violated.
+    /// Returns a conflict if the direct union violates a disequality. Congruence
+    /// consequences are deferred until `rebuild`.
     fn assert_equal(&mut self, t1: Self::TermId, t2: Self::TermId) -> EgraphResult<Self::TermId>;
 
     /// Assert `t1 ≠ t2` at the current decision level.
@@ -155,10 +157,11 @@ pub trait EgraphTrait {
         bool_constant: Self::TermId,
     ) -> EgraphResult<Self::TermId>;
 
-    /// Restore congruence closure after deferred work.
+    /// Restore congruence closure after deferred registrations and unions.
     ///
-    /// A successful result means the egraph is up to date. A conflict may
-    /// leave additional work pending; call rebuild again after handling it.
+    /// A successful result means closure-dependent queries observe an
+    /// up-to-date egraph. A conflict may leave additional work pending; call
+    /// rebuild again after handling it.
     fn rebuild(&mut self) -> EgraphResult<Self::TermId>;
 
     /// Check if two terms are in the same equivalence class.

--- a/tests/egraph_rebuild.rs
+++ b/tests/egraph_rebuild.rs
@@ -1,0 +1,99 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use sundance_smt::egraphs::{Egraph, EgraphTrait, Op};
+
+fn term(egraph: &mut Egraph, op: &str, children: &[u32]) -> u32 {
+    egraph.register_term(Op::App(op.to_string()), children, false)
+}
+
+#[test]
+fn registration_congruence_is_deferred_until_rebuild() {
+    let mut egraph = Egraph::new();
+    let a = term(&mut egraph, "a", &[]);
+    let first = term(&mut egraph, "f", &[a]);
+    let second = term(&mut egraph, "f", &[a]);
+
+    assert!(!egraph.are_equal(first, second));
+    assert!(egraph.rebuild().conflict.is_none());
+    assert!(egraph.are_equal(first, second));
+}
+
+#[test]
+fn dynamic_registration_congruence_is_deferred_until_rebuild() {
+    let mut egraph = Egraph::new();
+    let a = term(&mut egraph, "a", &[]);
+    let b = term(&mut egraph, "b", &[]);
+    let first = term(&mut egraph, "f", &[a]);
+
+    assert!(egraph.rebuild().conflict.is_none());
+    assert!(egraph.assert_equal(a, b).conflict.is_none());
+    assert!(egraph.rebuild().conflict.is_none());
+
+    let second = egraph.register_term(Op::App("f".to_string()), &[b], true);
+    assert!(!egraph.are_equal(first, second));
+
+    assert!(egraph.rebuild().conflict.is_none());
+    assert!(egraph.are_equal(first, second));
+}
+
+#[test]
+fn rebuild_computes_congruence_to_a_fixed_point() {
+    let mut egraph = Egraph::new();
+    let a = term(&mut egraph, "a", &[]);
+    let b = term(&mut egraph, "b", &[]);
+    let f_a = term(&mut egraph, "f", &[a]);
+    let f_b = term(&mut egraph, "f", &[b]);
+    let g_f_a = term(&mut egraph, "g", &[f_a]);
+    let g_f_b = term(&mut egraph, "g", &[f_b]);
+
+    assert!(egraph.rebuild().conflict.is_none());
+    assert!(egraph.assert_equal(a, b).conflict.is_none());
+    assert!(!egraph.are_equal(f_a, f_b));
+    assert!(!egraph.are_equal(g_f_a, g_f_b));
+
+    assert!(egraph.rebuild().conflict.is_none());
+    assert!(egraph.are_equal(f_a, f_b));
+    assert!(egraph.are_equal(g_f_a, g_f_b));
+}
+
+#[test]
+fn rebuild_reports_conflicts_from_deferred_congruence() {
+    let mut egraph = Egraph::new();
+    let a = term(&mut egraph, "a", &[]);
+    let b = term(&mut egraph, "b", &[]);
+    let f_a = term(&mut egraph, "f", &[a]);
+    let f_b = term(&mut egraph, "f", &[b]);
+
+    assert!(egraph.rebuild().conflict.is_none());
+    assert!(egraph.assert_disequal(f_a, f_b, 7).conflict.is_none());
+    assert!(egraph.assert_equal(a, b).conflict.is_none());
+    assert!(!egraph.are_equal(f_a, f_b));
+
+    let conflict = egraph
+        .rebuild()
+        .conflict
+        .expect("deferred congruence must violate the asserted disequality");
+    assert_eq!(conflict.diseq_lit, Some(7));
+}
+
+#[test]
+fn backtracking_rebuilds_signatures_at_the_restored_level() {
+    let mut egraph = Egraph::new();
+    let a = term(&mut egraph, "a", &[]);
+    let b = term(&mut egraph, "b", &[]);
+    let f_a = term(&mut egraph, "f", &[a]);
+    let f_b = term(&mut egraph, "f", &[b]);
+
+    assert!(egraph.rebuild().conflict.is_none());
+    egraph.notify_new_decision_level();
+    assert!(egraph.assert_equal(a, b).conflict.is_none());
+    assert!(egraph.rebuild().conflict.is_none());
+    assert!(egraph.are_equal(f_a, f_b));
+
+    egraph.backtrack_to(0);
+    assert!(!egraph.are_equal(a, b));
+    assert!(!egraph.are_equal(f_a, f_b));
+    assert!(egraph.rebuild().conflict.is_none());
+    assert!(!egraph.are_equal(f_a, f_b));
+}

--- a/tests/egraph_rebuild.rs
+++ b/tests/egraph_rebuild.rs
@@ -58,6 +58,31 @@ fn rebuild_computes_congruence_to_a_fixed_point() {
 }
 
 #[test]
+fn adaptive_full_rebuild_merges_registered_congruences() {
+    let mut egraph = Egraph::new();
+    let mut duplicate_pairs = Vec::new();
+
+    for i in 0..600 {
+        term(&mut egraph, &format!("seed{i}"), &[]);
+    }
+    assert!(egraph.rebuild().conflict.is_none());
+
+    for i in 0..400 {
+        let child = term(&mut egraph, &format!("a{i}"), &[]);
+        let first = term(&mut egraph, "f", &[child]);
+        let second = term(&mut egraph, "f", &[child]);
+        duplicate_pairs.push((first, second));
+    }
+
+    assert!(egraph.rebuild().conflict.is_none());
+    assert!(
+        duplicate_pairs
+            .into_iter()
+            .all(|(first, second)| egraph.are_equal(first, second))
+    );
+}
+
+#[test]
 fn rebuild_reports_conflicts_from_deferred_congruence() {
     let mut egraph = Egraph::new();
     let a = term(&mut egraph, "a", &[]);
@@ -96,4 +121,72 @@ fn backtracking_rebuilds_signatures_at_the_restored_level() {
     assert!(!egraph.are_equal(f_a, f_b));
     assert!(egraph.rebuild().conflict.is_none());
     assert!(!egraph.are_equal(f_a, f_b));
+}
+
+#[test]
+fn backtracking_discards_abandoned_pending_congruence() {
+    let mut egraph = Egraph::new();
+    let a = term(&mut egraph, "a", &[]);
+    let b = term(&mut egraph, "b", &[]);
+    let f_a = term(&mut egraph, "f", &[a]);
+    let f_b = term(&mut egraph, "f", &[b]);
+
+    assert!(egraph.rebuild().conflict.is_none());
+    egraph.notify_new_decision_level();
+    assert!(egraph.assert_equal(a, b).conflict.is_none());
+    egraph.backtrack_to(0);
+
+    assert!(egraph.rebuild().conflict.is_none());
+    assert!(!egraph.are_equal(a, b));
+    assert!(!egraph.are_equal(f_a, f_b));
+}
+
+#[test]
+fn backtracking_restores_signature_cache_to_intermediate_level() {
+    let mut egraph = Egraph::new();
+    let a = term(&mut egraph, "a", &[]);
+    let b = term(&mut egraph, "b", &[]);
+    let c = term(&mut egraph, "c", &[]);
+    let f_a = term(&mut egraph, "f", &[a]);
+    let f_b = term(&mut egraph, "f", &[b]);
+    let f_c = term(&mut egraph, "f", &[c]);
+
+    assert!(egraph.rebuild().conflict.is_none());
+    egraph.notify_new_decision_level();
+    assert!(egraph.assert_equal(a, b).conflict.is_none());
+    assert!(egraph.rebuild().conflict.is_none());
+
+    egraph.notify_new_decision_level();
+    assert!(egraph.assert_equal(b, c).conflict.is_none());
+    assert!(egraph.rebuild().conflict.is_none());
+    assert!(egraph.are_equal(f_a, f_c));
+
+    egraph.backtrack_to(1);
+    assert!(egraph.are_equal(f_a, f_b));
+    assert!(!egraph.are_equal(f_a, f_c));
+    assert!(egraph.rebuild().conflict.is_none());
+    assert!(!egraph.are_equal(f_a, f_c));
+
+    egraph.backtrack_to(0);
+    assert!(!egraph.are_equal(f_a, f_b));
+    assert!(egraph.rebuild().conflict.is_none());
+    assert!(!egraph.are_equal(f_a, f_b));
+}
+
+#[test]
+fn backtracking_replays_persistent_dynamic_registration() {
+    let mut egraph = Egraph::new();
+    let a = term(&mut egraph, "a", &[]);
+    let first = term(&mut egraph, "f", &[a]);
+
+    assert!(egraph.rebuild().conflict.is_none());
+    egraph.notify_new_decision_level();
+    let second = egraph.register_term(Op::App("f".to_string()), &[a], true);
+    assert!(egraph.rebuild().conflict.is_none());
+    assert!(egraph.are_equal(first, second));
+
+    egraph.backtrack_to(0);
+    assert!(!egraph.are_equal(first, second));
+    assert!(egraph.rebuild().conflict.is_none());
+    assert!(egraph.are_equal(first, second));
 }


### PR DESCRIPTION
## Summary
- defer signature collision handling and induced congruence merges to EgraphTrait::rebuild
- queue newly registered terms and parents affected by explicit unions, then rebuild to a fixed point
- invalidate and requeue signature state on backtracking and rebuild at solver observation boundaries
- add focused tests for registration, dynamic registration, nested closure, conflicts, and backtracking

## Testing
- cargo fmt --all -- --check
- cargo clippy --no-default-features --all-targets -- -D warnings
- cargo test --no-default-features -- --skip regression_test
- cargo test --release --no-default-features --features local-z3 --test regression_test -- --nocapture

Regression result: 417 correct, 0 incorrect, 6 timeouts. The expected-unsat eq_diamond18 and eq_diamond19 cases return unsat with a longer limit. The expected-unknown quantifier_ite_no_error6 case still times out at 120 seconds.