### PR TITLE
New feedback functions 

### DIFF
--- a/src/cadical_propagator.rs
+++ b/src/cadical_propagator.rs
@@ -40,13 +40,53 @@ pub struct CustomExternalPropagator<'a> {
     /// Incremental Z3 arithmetic state — Some iff `arithmetic == ArithSolver::Z3Incremental`.
     #[cfg(feature = "z3-solver")]
     pub z3_incremental: Option<Z3IncrementalState>,
-    // --trail-out logging (inert unless trail_out_active): |lit| -> atom, and each refuted model
-    pub trail_out_active: bool,
+    // --trail-out logging (inert unless the writer is Some). Trails stream to
+    // disk as they are refuted; the small |lit| -> atom map is held and flushed
+    // at the end (only complete then, as new literals appear during the search).
+    pub trail_writer: Option<std::io::BufWriter<std::fs::File>>,
     pub trail_atoms: std::collections::HashMap<i32, String>,
-    pub refuted_trails: Vec<Vec<i32>>,
 }
 
 impl<'a> CustomExternalPropagator<'a> {
+    /// Stream one refuted model as a `t <signed lits>` line. A write error is
+    /// reported once then the writer is dropped; it must never abort the solve.
+    fn write_trail_line(&mut self, model: &[i32]) {
+        use std::io::Write;
+        let Some(w) = self.trail_writer.as_mut() else {
+            return;
+        };
+        let mut line = String::with_capacity(model.len() * 5 + 2);
+        line.push('t');
+        for lit in model {
+            use std::fmt::Write as _;
+            let _ = write!(line, " {lit}");
+        }
+        if let Err(e) = writeln!(w, "{line}") {
+            debug_println!(2, 0, "Failed to stream trail line: {}", e);
+            self.trail_writer = None; // stop trying after the first failure
+        }
+    }
+
+    /// Append the `m <id> <atom>` map (sorted by id) and close the trail log.
+    /// Called once after the solve, when the literal set is finally complete.
+    pub fn finish_trail_log(&mut self) {
+        use std::io::Write;
+        let Some(mut w) = self.trail_writer.take() else {
+            return;
+        };
+        let mut ids: Vec<&i32> = self.trail_atoms.keys().collect();
+        ids.sort();
+        let res = (|| -> std::io::Result<()> {
+            for id in ids {
+                writeln!(w, "m {} {}", id, self.trail_atoms[id])?;
+            }
+            w.flush()
+        })();
+        if let Err(e) = res {
+            debug_println!(2, 0, "Failed to write trail atom map: {}", e);
+        }
+    }
+
     /// Register any new CNF variables created since the last sync.
     pub fn sync_new_vars(&mut self) {
         let next = self.solver_state.cnf_cache.next_var;
@@ -372,8 +412,9 @@ impl<'a> ExternalPropagator for CustomExternalPropagator<'a> {
     }
 
     fn cb_check_found_model(&mut self, model: &[i32]) -> bool {
-        // --trail-out: every model seen here in a non-SAT run is refuted, so record it at entry
-        if self.trail_out_active {
+        // --trail-out: every model seen here in a non-SAT run is refuted;
+        // note any new literals in the atom map and stream the trail line.
+        if self.trail_writer.is_some() {
             for &l in model {
                 let id = l.unsigned_abs() as i32;
                 if !self.trail_atoms.contains_key(&id) {
@@ -381,7 +422,7 @@ impl<'a> ExternalPropagator for CustomExternalPropagator<'a> {
                     self.trail_atoms.insert(id, atom);
                 }
             }
-            self.refuted_trails.push(model.to_vec());
+            self.write_trail_line(model);
         }
 
         debug_println!(

--- a/src/cadical_propagator.rs
+++ b/src/cadical_propagator.rs
@@ -40,6 +40,10 @@ pub struct CustomExternalPropagator<'a> {
     /// Incremental Z3 arithmetic state — Some iff `arithmetic == ArithSolver::Z3Incremental`.
     #[cfg(feature = "z3-solver")]
     pub z3_incremental: Option<Z3IncrementalState>,
+    // --trail-out logging (inert unless trail_out_active): |lit| -> atom, and each refuted model
+    pub trail_out_active: bool,
+    pub trail_atoms: std::collections::HashMap<i32, String>,
+    pub refuted_trails: Vec<Vec<i32>>,
 }
 
 impl<'a> CustomExternalPropagator<'a> {
@@ -368,6 +372,18 @@ impl<'a> ExternalPropagator for CustomExternalPropagator<'a> {
     }
 
     fn cb_check_found_model(&mut self, model: &[i32]) -> bool {
+        // --trail-out: every model seen here in a non-SAT run is refuted, so record it at entry
+        if self.trail_out_active {
+            for &l in model {
+                let id = l.unsigned_abs() as i32;
+                if !self.trail_atoms.contains_key(&id) {
+                    let atom = format!("{}", self.solver_state.get_term_from_lit(id));
+                    self.trail_atoms.insert(id, atom);
+                }
+            }
+            self.refuted_trails.push(model.to_vec());
+        }
+
         debug_println!(
             24,
             0,

--- a/src/cdcl.rs
+++ b/src/cdcl.rs
@@ -37,6 +37,7 @@ pub fn cdcl_decision_procedure(
     clauses: Vec<Vec<i32>>,
     boolean_dt_constraints: Vec<Vec<i32>>,
     proof_file: Option<PathBuf>,
+    partial_proof_file: Option<PathBuf>,
     sorts: HashMap<Str, SortDef>,
     symbol_table: HashMap<Str, Vec<(Sig, FunctionMeta)>>,
     arithmetic: ArithSolver,
@@ -145,7 +146,7 @@ pub fn cdcl_decision_procedure(
     if let Some(p) = proof_file
         && result == Status::UNSATISFIABLE
     {
-        if let Err(e) = std::fs::write(&p, edrat_proof) {
+        if let Err(e) = std::fs::write(&p, &edrat_proof) {
             debug_println!(
                 2,
                 0,
@@ -155,6 +156,41 @@ pub fn cdcl_decision_procedure(
             );
         } else {
             debug_println!(2, 0, "eDRAT proof written to: {}", p.display());
+        }
+    }
+
+    // Dump the proof forest for any result: complete on unsat, else a prefix (no empty clause)
+    if let Some(p) = partial_proof_file {
+        let complete = result == Status::UNSATISFIABLE;
+        let status = match result {
+            Status::UNSATISFIABLE => "unsat",
+            Status::SATISFIABLE => "sat",
+            Status::UNKNOWN => "unknown",
+        };
+        let header = if complete {
+            "; COMPLETE eDRAT proof (result: unsat): a checkable refutation.\n".to_string()
+        } else {
+            format!(
+                "; PARTIAL eDRAT proof (result: {status}): every step derived so far,\n\
+                 ; but NO final empty clause -- a prefix, not a checkable refutation.\n"
+            )
+        };
+        if let Err(e) = std::fs::write(&p, format!("{header}{edrat_proof}")) {
+            debug_println!(
+                2,
+                0,
+                "Failed to write partial proof to {}: {}",
+                p.display(),
+                e
+            );
+        } else {
+            debug_println!(
+                2,
+                0,
+                "{} proof forest written to: {}",
+                if complete { "Complete" } else { "Partial" },
+                p.display()
+            );
         }
     }
 

--- a/src/cdcl.rs
+++ b/src/cdcl.rs
@@ -38,6 +38,7 @@ pub fn cdcl_decision_procedure(
     boolean_dt_constraints: Vec<Vec<i32>>,
     proof_file: Option<PathBuf>,
     partial_proof_file: Option<PathBuf>,
+    trail_file: Option<PathBuf>,
     sorts: HashMap<Str, SortDef>,
     symbol_table: HashMap<Str, Vec<(Sig, FunctionMeta)>>,
     arithmetic: ArithSolver,
@@ -96,6 +97,9 @@ pub fn cdcl_decision_procedure(
         last_observed_var: 1,
         #[cfg(feature = "z3-solver")]
         z3_incremental,
+        trail_out_active: trail_file.is_some(),
+        trail_atoms: std::collections::HashMap::new(),
+        refuted_trails: Vec::new(),
     };
 
     solver.connect_external_propagator(&mut propagator);
@@ -191,6 +195,28 @@ pub fn cdcl_decision_procedure(
                 if complete { "Complete" } else { "Partial" },
                 p.display()
             );
+        }
+    }
+
+    // Write the refuted-model trail: a `<id> <atom>` map, a blank line, then `<signed lits> 0` per model
+    if let Some(p) = trail_file {
+        let mut out = String::new();
+        let mut atoms: Vec<(&i32, &String)> = propagator.trail_atoms.iter().collect();
+        atoms.sort_by_key(|(id, _)| **id); // deterministic map order
+        for (id, atom) in atoms {
+            out.push_str(&format!("{} {}\n", id, atom));
+        }
+        out.push('\n'); // blank line separates the map from the trails
+        for trail in &propagator.refuted_trails {
+            for lit in trail {
+                out.push_str(&format!("{} ", lit));
+            }
+            out.push_str("0\n");
+        }
+        if let Err(e) = std::fs::write(&p, out) {
+            debug_println!(2, 0, "Failed to write trail log to {}: {}", p.display(), e);
+        } else {
+            debug_println!(2, 0, "trail log written to: {}", p.display());
         }
     }
 

--- a/src/cdcl.rs
+++ b/src/cdcl.rs
@@ -97,9 +97,16 @@ pub fn cdcl_decision_procedure(
         last_observed_var: 1,
         #[cfg(feature = "z3-solver")]
         z3_incremental,
-        trail_out_active: trail_file.is_some(),
+        trail_writer: trail_file
+            .as_ref()
+            .and_then(|p| match std::fs::File::create(p) {
+                Ok(f) => Some(std::io::BufWriter::new(f)),
+                Err(e) => {
+                    debug_println!(2, 0, "Failed to open trail log {}: {}", p.display(), e);
+                    None
+                }
+            }),
         trail_atoms: std::collections::HashMap::new(),
-        refuted_trails: Vec::new(),
     };
 
     solver.connect_external_propagator(&mut propagator);
@@ -167,8 +174,10 @@ pub fn cdcl_decision_procedure(
         write_partial_proof(&p, result, &edrat_proof);
     }
 
-    if let Some(p) = trail_file {
-        write_trail_log(&p, &propagator.trail_atoms, &propagator.refuted_trails);
+    // Trails were streamed during the solve; append the now-complete atom map.
+    if trail_file.is_some() {
+        propagator.finish_trail_log();
+        debug_println!(2, 0, "trail log written");
     }
 
     // Harvest stats from solver_state, egraph, and proof tracer
@@ -212,47 +221,6 @@ fn write_partial_proof(path: &std::path::Path, result: Status, edrat_proof: &str
             if complete { "Complete" } else { "Partial" },
             path.display()
         );
-    }
-}
-
-/// Write the refuted-model trail: a `<id> <atom>` map, a blank line, then one
-/// `<signed lits> 0` line per refuted model.
-fn write_trail_log(
-    path: &std::path::Path,
-    trail_atoms: &HashMap<i32, String>,
-    refuted_trails: &[Vec<i32>],
-) {
-    use std::io::Write;
-    let write_res = (|| -> std::io::Result<()> {
-        let file = std::fs::File::create(path)?;
-        let mut w = std::io::BufWriter::new(file);
-
-        let mut atoms: Vec<(&i32, &String)> = trail_atoms.iter().collect();
-        atoms.sort_by_key(|(id, _)| **id); // deterministic map order
-        for (id, atom) in atoms {
-            writeln!(w, "{} {}", id, atom)?;
-        }
-        writeln!(w)?; // blank line separates the map from the trails
-
-        for trail in refuted_trails {
-            for lit in trail {
-                write!(w, "{} ", lit)?;
-            }
-            writeln!(w, "0")?;
-        }
-
-        w.flush()
-    })();
-    if let Err(e) = write_res {
-        debug_println!(
-            2,
-            0,
-            "Failed to write trail log to {}: {}",
-            path.display(),
-            e
-        );
-    } else {
-        debug_println!(2, 0, "trail log written to: {}", path.display());
     }
 }
 

--- a/src/cdcl.rs
+++ b/src/cdcl.rs
@@ -179,12 +179,14 @@ pub fn cdcl_decision_procedure(
 
 /// Dump the eDRAT proof forest for any result: complete on unsat, else a prefix
 /// with no final empty clause. A leading `;` comment records which case it is.
+/// Header status: unsat -> unsat, sat -> unknown, unknown (cadical) ->
+/// timeout/interrupt.
 fn write_partial_proof(path: &std::path::Path, result: Status, edrat_proof: &str) {
     let complete = result == Status::UNSATISFIABLE;
     let status = match result {
         Status::UNSATISFIABLE => "unsat",
-        Status::SATISFIABLE => "sat",
-        Status::UNKNOWN => "unknown",
+        Status::SATISFIABLE => "unknown",
+        Status::UNKNOWN => "timeout/interrupt",
     };
     let header = if complete {
         "; COMPLETE eDRAT proof (result: unsat): a checkable refutation.\n".to_string()

--- a/src/cdcl.rs
+++ b/src/cdcl.rs
@@ -200,20 +200,28 @@ pub fn cdcl_decision_procedure(
 
     // Write the refuted-model trail: a `<id> <atom>` map, a blank line, then `<signed lits> 0` per model
     if let Some(p) = trail_file {
-        let mut out = String::new();
-        let mut atoms: Vec<(&i32, &String)> = propagator.trail_atoms.iter().collect();
-        atoms.sort_by_key(|(id, _)| **id); // deterministic map order
-        for (id, atom) in atoms {
-            out.push_str(&format!("{} {}\n", id, atom));
-        }
-        out.push('\n'); // blank line separates the map from the trails
-        for trail in &propagator.refuted_trails {
-            for lit in trail {
-                out.push_str(&format!("{} ", lit));
+        use std::io::Write;
+        let write_res = (|| -> std::io::Result<()> {
+            let file = std::fs::File::create(&p)?;
+            let mut w = std::io::BufWriter::new(file);
+
+            let mut atoms: Vec<(&i32, &String)> = propagator.trail_atoms.iter().collect();
+            atoms.sort_by_key(|(id, _)| **id); // deterministic map order
+            for (id, atom) in atoms {
+                writeln!(w, "{} {}", id, atom)?;
             }
-            out.push_str("0\n");
-        }
-        if let Err(e) = std::fs::write(&p, out) {
+            writeln!(w)?; // blank line separates the map from the trails
+
+            for trail in &propagator.refuted_trails {
+                for lit in trail {
+                    write!(w, "{} ", lit)?;
+                }
+                writeln!(w, "0")?;
+            }
+
+            w.flush()
+        })();
+        if let Err(e) = write_res {
             debug_println!(2, 0, "Failed to write trail log to {}: {}", p.display(), e);
         } else {
             debug_println!(2, 0, "trail log written to: {}", p.display());

--- a/src/cdcl.rs
+++ b/src/cdcl.rs
@@ -163,75 +163,95 @@ pub fn cdcl_decision_procedure(
         }
     }
 
-    // Dump the proof forest for any result: complete on unsat, else a prefix (no empty clause)
     if let Some(p) = partial_proof_file {
-        let complete = result == Status::UNSATISFIABLE;
-        let status = match result {
-            Status::UNSATISFIABLE => "unsat",
-            Status::SATISFIABLE => "sat",
-            Status::UNKNOWN => "unknown",
-        };
-        let header = if complete {
-            "; COMPLETE eDRAT proof (result: unsat): a checkable refutation.\n".to_string()
-        } else {
-            format!(
-                "; PARTIAL eDRAT proof (result: {status}): every step derived so far,\n\
-                 ; but NO final empty clause -- a prefix, not a checkable refutation.\n"
-            )
-        };
-        if let Err(e) = std::fs::write(&p, format!("{header}{edrat_proof}")) {
-            debug_println!(
-                2,
-                0,
-                "Failed to write partial proof to {}: {}",
-                p.display(),
-                e
-            );
-        } else {
-            debug_println!(
-                2,
-                0,
-                "{} proof forest written to: {}",
-                if complete { "Complete" } else { "Partial" },
-                p.display()
-            );
-        }
+        write_partial_proof(&p, result, &edrat_proof);
     }
 
-    // Write the refuted-model trail: a `<id> <atom>` map, a blank line, then `<signed lits> 0` per model
     if let Some(p) = trail_file {
-        use std::io::Write;
-        let write_res = (|| -> std::io::Result<()> {
-            let file = std::fs::File::create(&p)?;
-            let mut w = std::io::BufWriter::new(file);
-
-            let mut atoms: Vec<(&i32, &String)> = propagator.trail_atoms.iter().collect();
-            atoms.sort_by_key(|(id, _)| **id); // deterministic map order
-            for (id, atom) in atoms {
-                writeln!(w, "{} {}", id, atom)?;
-            }
-            writeln!(w)?; // blank line separates the map from the trails
-
-            for trail in &propagator.refuted_trails {
-                for lit in trail {
-                    write!(w, "{} ", lit)?;
-                }
-                writeln!(w, "0")?;
-            }
-
-            w.flush()
-        })();
-        if let Err(e) = write_res {
-            debug_println!(2, 0, "Failed to write trail log to {}: {}", p.display(), e);
-        } else {
-            debug_println!(2, 0, "trail log written to: {}", p.display());
-        }
+        write_trail_log(&p, &propagator.trail_atoms, &propagator.refuted_trails);
     }
 
     // Harvest stats from solver_state, egraph, and proof tracer
     propagator.sync_external_stats();
     propagator.stats.finish();
     (result, propagator.stats)
+}
+
+/// Dump the eDRAT proof forest for any result: complete on unsat, else a prefix
+/// with no final empty clause. A leading `;` comment records which case it is.
+fn write_partial_proof(path: &std::path::Path, result: Status, edrat_proof: &str) {
+    let complete = result == Status::UNSATISFIABLE;
+    let status = match result {
+        Status::UNSATISFIABLE => "unsat",
+        Status::SATISFIABLE => "sat",
+        Status::UNKNOWN => "unknown",
+    };
+    let header = if complete {
+        "; COMPLETE eDRAT proof (result: unsat): a checkable refutation.\n".to_string()
+    } else {
+        format!(
+            "; PARTIAL eDRAT proof (result: {status}): every step derived so far,\n\
+             ; but NO final empty clause -- a prefix, not a checkable refutation.\n"
+        )
+    };
+    if let Err(e) = std::fs::write(path, format!("{header}{edrat_proof}")) {
+        debug_println!(
+            2,
+            0,
+            "Failed to write partial proof to {}: {}",
+            path.display(),
+            e
+        );
+    } else {
+        debug_println!(
+            2,
+            0,
+            "{} proof forest written to: {}",
+            if complete { "Complete" } else { "Partial" },
+            path.display()
+        );
+    }
+}
+
+/// Write the refuted-model trail: a `<id> <atom>` map, a blank line, then one
+/// `<signed lits> 0` line per refuted model.
+fn write_trail_log(
+    path: &std::path::Path,
+    trail_atoms: &HashMap<i32, String>,
+    refuted_trails: &[Vec<i32>],
+) {
+    use std::io::Write;
+    let write_res = (|| -> std::io::Result<()> {
+        let file = std::fs::File::create(path)?;
+        let mut w = std::io::BufWriter::new(file);
+
+        let mut atoms: Vec<(&i32, &String)> = trail_atoms.iter().collect();
+        atoms.sort_by_key(|(id, _)| **id); // deterministic map order
+        for (id, atom) in atoms {
+            writeln!(w, "{} {}", id, atom)?;
+        }
+        writeln!(w)?; // blank line separates the map from the trails
+
+        for trail in refuted_trails {
+            for lit in trail {
+                write!(w, "{} ", lit)?;
+            }
+            writeln!(w, "0")?;
+        }
+
+        w.flush()
+    })();
+    if let Err(e) = write_res {
+        debug_println!(
+            2,
+            0,
+            "Failed to write trail log to {}: {}",
+            path.display(),
+            e
+        );
+    } else {
+        debug_println!(2, 0, "trail log written to: {}", path.display());
+    }
 }
 
 /// Adds the clause to the eDRAT proof and gives it to the CaDiCaL solver.

--- a/src/config.rs
+++ b/src/config.rs
@@ -23,7 +23,7 @@ pub struct Args {
     /// Dump the eDRAT proof forest at termination for any result; complete on unsat, else a prefix
     #[arg(long)]
     pub partial_proof: Option<PathBuf>,
-    /// Log every refuted propositional model's trail to this file (DIMACS-style)
+    /// Log each refuted propositional model to this file: first a '<var> <atom>' map, then a blank line, then one '<signed lits> 0' trail per model
     #[arg(long)]
     pub trail_out: Option<PathBuf>,
     // /// Set the maximum activation depth for quantifier instantiations

--- a/src/config.rs
+++ b/src/config.rs
@@ -23,7 +23,7 @@ pub struct Args {
     /// Dump the eDRAT proof forest at termination for any result; complete on unsat, else a prefix
     #[arg(long)]
     pub partial_proof: Option<PathBuf>,
-    /// Log each refuted propositional model to this file: first a '<var> <atom>' map, then a blank line, then one '<signed lits> 0' trail per model
+    /// Log each refuted propositional model to this file: first a `<var> <atom>` map, then a blank line, then one `<signed lits> 0` trail per model
     #[arg(long)]
     pub trail_out: Option<PathBuf>,
     // /// Set the maximum activation depth for quantifier instantiations

--- a/src/config.rs
+++ b/src/config.rs
@@ -20,8 +20,8 @@ pub struct Args {
     /// Enable eDRAT proof production and write to specified file
     #[arg(long)]
     pub proof: Option<PathBuf>,
-    /// Dump the eDRAT proof forest at termination for any result; complete on unsat, else a prefix
-    #[arg(long)]
+    /// Dump the eDRAT proof forest at termination for any result; complete on unsat, else a prefix. Mutually exclusive with --proof
+    #[arg(long, conflicts_with = "proof")]
     pub partial_proof: Option<PathBuf>,
     /// Log each refuted propositional model to this file: first a `<var> <atom>` map, then a blank line, then one `<signed lits> 0` trail per model
     #[arg(long)]

--- a/src/config.rs
+++ b/src/config.rs
@@ -23,6 +23,9 @@ pub struct Args {
     /// Dump the eDRAT proof forest at termination for any result; complete on unsat, else a prefix
     #[arg(long)]
     pub partial_proof: Option<PathBuf>,
+    /// Log every refuted propositional model's trail to this file (DIMACS-style)
+    #[arg(long)]
+    pub trail_out: Option<PathBuf>,
     // /// Set the maximum activation depth for quantifier instantiations
     // #[arg(long, default_value_t = 5)]
     // pub max_activation_depth: usize,

--- a/src/config.rs
+++ b/src/config.rs
@@ -23,7 +23,7 @@ pub struct Args {
     /// Dump the eDRAT proof forest at termination for any result; complete on unsat, else a prefix. Mutually exclusive with --proof
     #[arg(long, conflicts_with = "proof")]
     pub partial_proof: Option<PathBuf>,
-    /// Log each refuted propositional model to this file: first a `<var> <atom>` map, then a blank line, then one `<signed lits> 0` trail per model
+    /// Log each refuted propositional model to this file. Line-tagged format, streamed as the search runs: `t <signed lits>` per refuted model, then `m <var> <atom>` map lines appended at the end
     #[arg(long)]
     pub trail_out: Option<PathBuf>,
     // /// Set the maximum activation depth for quantifier instantiations

--- a/src/config.rs
+++ b/src/config.rs
@@ -20,6 +20,9 @@ pub struct Args {
     /// Enable eDRAT proof production and write to specified file
     #[arg(long)]
     pub proof: Option<PathBuf>,
+    /// Dump the eDRAT proof forest at termination for any result; complete on unsat, else a prefix
+    #[arg(long)]
+    pub partial_proof: Option<PathBuf>,
     // /// Set the maximum activation depth for quantifier instantiations
     // #[arg(long, default_value_t = 5)]
     // pub max_activation_depth: usize,

--- a/src/main.rs
+++ b/src/main.rs
@@ -163,6 +163,7 @@ fn main() -> Result<(), String> {
         prop_skeleton,
         boolean_dt_constraints,
         args.proof,
+        args.partial_proof,
         sorts,
         symbol_table,
         args.arithmetic,

--- a/src/main.rs
+++ b/src/main.rs
@@ -164,6 +164,7 @@ fn main() -> Result<(), String> {
         boolean_dt_constraints,
         args.proof,
         args.partial_proof,
+        args.trail_out,
         sorts,
         symbol_table,
         args.arithmetic,

--- a/src/main.rs
+++ b/src/main.rs
@@ -18,6 +18,18 @@ use yaspar_ir::untyped::UntypedAst;
 fn main() -> Result<(), String> {
     let args = Args::parse();
 
+    // --proof and --partial-proof both write an eDRAT dump; using them together
+    // is ambiguous (and with the same path the second write silently truncates
+    // the first, replacing a checkable refutation with a header-prefixed
+    // prefix, or vice versa). Reject the combination outright.
+    assert!(
+        !(args.proof.is_some() && args.partial_proof.is_some()),
+        "--proof and --partial-proof are mutually exclusive: both write an eDRAT \
+         dump, and pointing them at the same file would overwrite one with the \
+         other. Pass only one (--proof for a checkable refutation on unsat, \
+         --partial-proof for a dump on any result)."
+    );
+
     // Parse debug flag and level
     if args.debug > 0 {
         log::set_debug_level(args.debug);


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* This PR adds new logging functionalities to Sundance by implementing two runtime flags:

1. `--trail-out <file>`: This logs the propositional skeletons encountered during the search.
2. `--partial-proof <file>`: This logs the proof file upon termination, even when Sundance does not answer UNSAT. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
