### PR TITLE
Panic on Real arithmetic instead of returning unsound results

### DIFF
--- a/src/solver_state.rs
+++ b/src/solver_state.rs
@@ -509,7 +509,20 @@ impl SolverState {
         let num = term.uid();
 
         // Arithmetic term tracking
-        if term.get_sort(self.context.arena()).to_string() == "Int" {
+        let sort = term.get_sort(self.context.arena()).to_string();
+        // TODO: Real arithmetic is not yet plumbed through the arithmetic
+        // backends (they allocate integer variables and bucket Nelson-Oppen
+        // model values as integers). Registering Real terms as integer
+        // arithmetic is unsound, so panic instead of returning a wrong answer.
+        // Real support is planned; this guard is a stopgap until then.
+        if sort == "Real" {
+            panic!(
+                "Real arithmetic is not yet supported (term: {term}); \
+                 support for Reals is planned. For now the arithmetic \
+                 backends only handle Int."
+            );
+        }
+        if sort == "Int" {
             if !self.arithmetic_terms.contains(&num) {
                 self.arithmetic_terms.push(num);
             }


### PR DESCRIPTION
*Issue #, if available:* #177

*Description of changes:* Real-sorted terms are never registered with the arithmetic solver. `register_arithmetic_and_quantifier` only checks for the `Int` sort, so `Real` terms fall through and are treated as opaque uninterpreted constants.

This PR, adds a stopgap guard in `register_arithmetic_and_quantifier` that panics on Real-sorted terms.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
