### PR TITLE
Fixes holes in eDRAT proof production, so that we can support proof checking with Valido + external solver

### DIFF
--- a/src/cadical_propagator.rs
+++ b/src/cadical_propagator.rs
@@ -178,8 +178,23 @@ impl<'a> CustomExternalPropagator<'a> {
             let eq_lit = self.solver_state.get_or_allocate_lit_for_term(&eq_term);
             let clause = vec![lt_lit, gt_lit, eq_lit];
             self.sync_new_vars();
-            self.disequalities.borrow_mut().push(clause);
+            self.queue_theory_clause(clause, Theory::QfLia);
         }
+    }
+
+    /// Queues a clause whose proof step has already been recorded.
+    fn queue_external_clause(&self, clause: Vec<i32>) {
+        self.proof_tracer
+            .borrow_mut()
+            .register_clause_for_cadical_callback(&clause);
+        self.disequalities.borrow_mut().push(clause);
+    }
+
+    fn queue_theory_clause(&self, clause: Vec<i32>, theory: Theory) {
+        self.proof_tracer
+            .borrow_mut()
+            .add_theory_clause(&clause, theory);
+        self.queue_external_clause(clause);
     }
 
     pub fn sync_external_stats(&mut self) {
@@ -204,10 +219,7 @@ impl<'a> CustomExternalPropagator<'a> {
                 Skolemization { clauses } => clauses,
             };
             for clause in clauses {
-                self.proof_tracer
-                    .borrow_mut()
-                    .expect_original_clause_callback(clause);
-                self.disequalities.borrow_mut().push(clause.clone());
+                self.queue_external_clause(clause.clone());
             }
         }
         // Materializing an instance can enqueue arithmetic merges (via
@@ -332,15 +344,8 @@ impl<'a> ExternalPropagator for CustomExternalPropagator<'a> {
                         self.disequalities.borrow()
                     );
 
-                    // CC TODO: Are these congruence closure/EUF atoms? Comment just below this one suggests so.
-                    {
-                        let mut proof_tracer = self.proof_tracer.borrow_mut();
-                        proof_tracer.add_theory_clause(&shrunk_constraint, Theory::Background);
-                        proof_tracer.expect_original_clause_callback(&shrunk_constraint);
-                    }
-
                     // let theory_reason = format!("congruence_closure_level_{}", self.decision_level);
-                    self.disequalities.borrow_mut().push(shrunk_constraint);
+                    self.queue_theory_clause(shrunk_constraint, Theory::Background);
                     debug_println!(
                         14 - 3,
                         0,
@@ -519,7 +524,7 @@ impl<'a> ExternalPropagator for CustomExternalPropagator<'a> {
                         "PROPAGATOR: Arithmetic inconsistency detected: {:?}",
                         arithmetic_literals
                     );
-                    self.disequalities.borrow_mut().push(arithmetic_literals);
+                    self.queue_theory_clause(arithmetic_literals, Theory::QfLia);
                     self.stats.conflicts += 1;
                     return false;
                 }
@@ -614,7 +619,7 @@ impl<'a> ExternalPropagator for CustomExternalPropagator<'a> {
                         conflict_clause.push(-lit);
                     }
 
-                    self.disequalities.borrow_mut().push(conflict_clause);
+                    self.queue_theory_clause(conflict_clause, Theory::Background);
                 }
                 self.sync_new_vars();
 
@@ -649,7 +654,7 @@ impl<'a> ExternalPropagator for CustomExternalPropagator<'a> {
             if let Some(conflict_clause) =
                 crate::datatypes::occurs_check::datatype_occurs_check(self.solver_state)
             {
-                self.disequalities.borrow_mut().push(conflict_clause);
+                self.queue_theory_clause(conflict_clause, Theory::Datatypes);
                 self.stats.conflicts += 1;
                 return false;
             }
@@ -658,7 +663,9 @@ impl<'a> ExternalPropagator for CustomExternalPropagator<'a> {
             let new_clauses =
                 crate::datatypes::occurs_check::generate_deferred_tester_clauses(self.solver_state);
             if !new_clauses.is_empty() {
-                self.disequalities.borrow_mut().extend(new_clauses);
+                for clause in new_clauses {
+                    self.queue_theory_clause(clause, Theory::Datatypes);
+                }
                 self.sync_new_vars();
                 self.stats.conflicts += 1;
                 return false;

--- a/src/cadical_propagator.rs
+++ b/src/cadical_propagator.rs
@@ -196,18 +196,18 @@ impl<'a> CustomExternalPropagator<'a> {
         instances: &[crate::quantifiers::quantifier::QuantifierInstance],
     ) {
         for inst in instances {
-            match inst {
+            let clauses = match inst {
                 Instantiation { clauses } => {
-                    for clause in clauses {
-                        self.disequalities.borrow_mut().push(clause.clone());
-                    }
                     self.stats.instantiations += 1;
+                    clauses
                 }
-                Skolemization { clauses } => {
-                    for clause in clauses {
-                        self.disequalities.borrow_mut().push(clause.clone());
-                    }
-                }
+                Skolemization { clauses } => clauses,
+            };
+            for clause in clauses {
+                self.proof_tracer
+                    .borrow_mut()
+                    .expect_original_clause_callback(clause);
+                self.disequalities.borrow_mut().push(clause.clone());
             }
         }
         // Materializing an instance can enqueue arithmetic merges (via
@@ -333,9 +333,11 @@ impl<'a> ExternalPropagator for CustomExternalPropagator<'a> {
                     );
 
                     // CC TODO: Are these congruence closure/EUF atoms? Comment just below this one suggests so.
-                    self.proof_tracer
-                        .borrow_mut()
-                        .add_theory_clause(&shrunk_constraint, Theory::Background);
+                    {
+                        let mut proof_tracer = self.proof_tracer.borrow_mut();
+                        proof_tracer.add_theory_clause(&shrunk_constraint, Theory::Background);
+                        proof_tracer.expect_original_clause_callback(&shrunk_constraint);
+                    }
 
                     // let theory_reason = format!("congruence_closure_level_{}", self.decision_level);
                     self.disequalities.borrow_mut().push(shrunk_constraint);

--- a/src/cdcl.rs
+++ b/src/cdcl.rs
@@ -250,7 +250,13 @@ fn add_clause_to_solver_and_to_proof(
         proof_tracer.borrow_mut().add_original_clause(clause);
     }
 
+    proof_tracer
+        .borrow_mut()
+        .expect_original_clause_callback(clause);
     solver.clause6(clause); // TODO `clause1()`, `clause2()`, etc. might be more efficient
+    proof_tracer
+        .borrow_mut()
+        .clear_expected_original_clause_callback();
 }
 
 fn solve(solver: &mut CaDiCal) -> Status {

--- a/src/cdcl.rs
+++ b/src/cdcl.rs
@@ -224,7 +224,7 @@ fn write_partial_proof(path: &std::path::Path, result: Status, edrat_proof: &str
 /// Records a clause before CaDiCaL can synchronously simplify or delete it.
 /// A missing `theory` denotes an original CNF clause.
 fn add_clause_to_proof_and_solver(
-    clause: &Vec<i32>,
+    clause: &[i32],
     solver: &mut CaDiCal,
     proof_tracer: &RefCell<SMTProofTracer>,
     theory: Option<Theory>,

--- a/src/cdcl.rs
+++ b/src/cdcl.rs
@@ -244,19 +244,20 @@ fn add_clause_to_solver_and_to_proof(
     proof_tracer: Rc<RefCell<SMTProofTracer>>,
     theory: Option<Theory>,
 ) {
-    if let Some(theory) = theory {
-        proof_tracer.borrow_mut().add_theory_clause(clause, theory);
-    } else {
-        proof_tracer.borrow_mut().add_original_clause(clause);
+    {
+        let mut proof_tracer = proof_tracer.borrow_mut();
+        if let Some(theory) = theory {
+            proof_tracer.add_theory_clause(clause, theory);
+        } else {
+            proof_tracer.add_original_clause(clause);
+        }
+        proof_tracer.expect_original_clause_callback(clause);
     }
 
-    proof_tracer
-        .borrow_mut()
-        .expect_original_clause_callback(clause);
     solver.clause6(clause); // TODO `clause1()`, `clause2()`, etc. might be more efficient
     proof_tracer
         .borrow_mut()
-        .clear_expected_original_clause_callback();
+        .cancel_expected_original_clause_callback(clause);
 }
 
 fn solve(solver: &mut CaDiCal) -> Status {

--- a/src/cdcl.rs
+++ b/src/cdcl.rs
@@ -121,17 +121,12 @@ pub fn cdcl_decision_procedure(
     // Add all clauses to the solver
     for (i, clause) in clauses.iter().enumerate() {
         debug_println!(11, 2, "Adding clause #{}: {:?}", i + 1, clause);
-        add_clause_to_solver_and_to_proof(clause, &mut solver, proof_tracer.clone(), None);
+        add_clause_to_proof_and_solver(clause, &mut solver, &proof_tracer, None);
     }
 
     // adding this into disequalities instead so that it appears as a theory lemma
     for clause in &boolean_dt_constraints {
-        add_clause_to_solver_and_to_proof(
-            clause,
-            &mut solver,
-            proof_tracer.clone(),
-            Some(Theory::Datatypes),
-        );
+        add_clause_to_proof_and_solver(clause, &mut solver, &proof_tracer, Some(Theory::Datatypes));
     }
 
     // Observe all known CNF variables at startup
@@ -226,22 +221,12 @@ fn write_partial_proof(path: &std::path::Path, result: Status, edrat_proof: &str
     }
 }
 
-/// Adds the clause to the eDRAT proof and gives it to the CaDiCaL solver.
-/// Notably, the clause is added to the proof *before* it is given to CaDiCaL.
-/// If `theory` is `None`, the clause is treated as an original CNF clause.
-///
-/// During the development of eDRAT proof production in summer 2026,
-/// we found that calling `.clause6()` causes CaDiCaL to immediately process
-/// the clause. In some cases, CaDiCaL immediately deletes the clause
-/// (such as when the clause is a tautology or when it is subsumed by some other
-/// clause already in the solver), and this deletion leads to CaDiCaL invoking
-/// its callback in `proof_tracer.rs`. As a result, the eDRAT proof would try
-/// to delete a clause before it is introduced. This function adds the clause
-/// to the proof before it is given to CaDiCaL to avoid this scenario.
-fn add_clause_to_solver_and_to_proof(
+/// Records a clause before CaDiCaL can synchronously simplify or delete it.
+/// A missing `theory` denotes an original CNF clause.
+fn add_clause_to_proof_and_solver(
     clause: &Vec<i32>,
     solver: &mut CaDiCal,
-    proof_tracer: Rc<RefCell<SMTProofTracer>>,
+    proof_tracer: &RefCell<SMTProofTracer>,
     theory: Option<Theory>,
 ) {
     {
@@ -255,9 +240,6 @@ fn add_clause_to_solver_and_to_proof(
     }
 
     solver.clause6(clause); // TODO `clause1()`, `clause2()`, etc. might be more efficient
-    proof_tracer
-        .borrow_mut()
-        .cancel_expected_original_clause_callback(clause);
 }
 
 fn solve(solver: &mut CaDiCal) -> Status {

--- a/src/cdcl.rs
+++ b/src/cdcl.rs
@@ -236,7 +236,7 @@ fn add_clause_to_proof_and_solver(
         } else {
             proof_tracer.add_original_clause(clause);
         }
-        proof_tracer.expect_original_clause_callback(clause);
+        proof_tracer.register_clause_for_cadical_callback(clause);
     }
 
     solver.clause6(clause); // TODO `clause1()`, `clause2()`, etc. might be more efficient

--- a/src/proof/proof_callbacks.rs
+++ b/src/proof/proof_callbacks.rs
@@ -10,7 +10,8 @@ use cadical_sys::ProofTracer;
 /// instance of important events that occur during SAT solving.
 impl ProofTracer for SMTProofTracer {
     fn add_original_clause(&mut self, _id: u64, _redundant: bool, clause: &[i32], restored: bool) {
-        if restored || self.consume_expected_original_clause(clause) {
+        let expected = self.consume_expected_original_clause(clause);
+        if restored || expected {
             return;
         }
 
@@ -129,6 +130,16 @@ mod tests {
 
         ProofTracer::add_original_clause(&mut tracer, 3, false, &[], false);
         assert_eq!(tracer.generate_edrat(), "t bg 0\n");
+    }
+
+    #[test]
+    fn restored_callbacks_consume_matching_expectations() {
+        let mut tracer = tracer();
+        tracer.expect_original_clause_callback(&[1]);
+        ProofTracer::add_original_clause(&mut tracer, 1, false, &[1], true);
+
+        assert!(!tracer.consume_expected_original_clause(&[1]));
+        assert_eq!(tracer.generate_edrat(), "");
     }
 
     #[test]

--- a/src/proof/proof_callbacks.rs
+++ b/src/proof/proof_callbacks.rs
@@ -10,12 +10,13 @@ use cadical_sys::ProofTracer;
 /// instance of important events that occur during SAT solving.
 impl ProofTracer for SMTProofTracer {
     fn add_original_clause(&mut self, _id: u64, _redundant: bool, clause: &[i32], restored: bool) {
-        let expected = self.consume_expected_original_clause(clause);
-        if restored || expected {
+        let registered = self.consume_clause_callback_registration(clause);
+        if restored || registered {
             return;
         }
 
-        // TODO: Tag known external clauses with their source theory.
+        // Known external-clause producers register callbacks at their source.
+        // Preserve Background only as a fallback for untracked provenance.
         self.add_theory_clause(clause, Theory::Background);
     }
 
@@ -62,9 +63,11 @@ impl ProofTracer for SMTProofTracer {
         panic!("Do not currently support assumptions")
     }
 
-    fn add_constraint(&mut self, clause: &[i32]) {
-        // TODO: Preserve theory provenance for CaDiCaL constraints.
-        self.add_theory_clause(clause, Theory::Background);
+    fn add_constraint(&mut self, _clause: &[i32]) {
+        // This callback reports temporary clauses supplied through CaDiCaL's
+        // `constrain` API, not clauses derived by CaDiCaL or a Sundance theory.
+        // Sundance does not use that API and cannot soundly tag such a clause.
+        panic!("CaDiCaL constraints are not supported in eDRAT proofs");
     }
 
     fn reset_assumptions(&mut self) {
@@ -98,28 +101,30 @@ mod tests {
     fn classifies_original_clause_callbacks() {
         let mut startup = tracer();
         startup.add_original_clause(&[]);
-        startup.expect_original_clause_callback(&[]);
+        startup.register_clause_for_cadical_callback(&[]);
         ProofTracer::add_original_clause(&mut startup, 1, false, &[], false);
         assert_eq!(startup.generate_edrat(), "a 0\n");
 
         let mut external = tracer();
         ProofTracer::add_original_clause(&mut external, 1, false, &[], false);
         assert_eq!(external.generate_edrat(), "t bg 0\n");
-
-        let mut constraint = tracer();
-        ProofTracer::add_constraint(&mut constraint, &[]);
-        assert_eq!(constraint.generate_edrat(), "t bg 0\n");
     }
 
     #[test]
-    fn expected_original_clause_callbacks_ignore_order_and_count_duplicates() {
-        let mut tracer = tracer();
-        tracer.expect_original_clause_callback(&[2, -1]);
-        assert!(tracer.consume_expected_original_clause(&[-1, 2]));
-        assert!(!tracer.consume_expected_original_clause(&[2, -1]));
+    #[should_panic(expected = "CaDiCaL constraints are not supported in eDRAT proofs")]
+    fn rejects_cadical_constraints() {
+        ProofTracer::add_constraint(&mut tracer(), &[]);
+    }
 
-        tracer.expect_original_clause_callback(&[]);
-        tracer.expect_original_clause_callback(&[]);
+    #[test]
+    fn registered_clause_callbacks_ignore_order_and_count_duplicates() {
+        let mut tracer = tracer();
+        tracer.register_clause_for_cadical_callback(&[2, -1]);
+        assert!(tracer.consume_clause_callback_registration(&[-1, 2]));
+        assert!(!tracer.consume_clause_callback_registration(&[2, -1]));
+
+        tracer.register_clause_for_cadical_callback(&[]);
+        tracer.register_clause_for_cadical_callback(&[]);
         ProofTracer::add_original_clause(&mut tracer, 1, false, &[], false);
         ProofTracer::add_original_clause(&mut tracer, 2, false, &[], false);
         assert_eq!(tracer.generate_edrat(), "");
@@ -129,12 +134,12 @@ mod tests {
     }
 
     #[test]
-    fn restored_callbacks_consume_matching_expectations() {
+    fn restored_callbacks_consume_matching_registrations() {
         let mut tracer = tracer();
-        tracer.expect_original_clause_callback(&[1]);
+        tracer.register_clause_for_cadical_callback(&[1]);
         ProofTracer::add_original_clause(&mut tracer, 1, false, &[1], true);
 
-        assert!(!tracer.consume_expected_original_clause(&[1]));
+        assert!(!tracer.consume_clause_callback_registration(&[1]));
         assert_eq!(tracer.generate_edrat(), "");
     }
 }

--- a/src/proof/proof_callbacks.rs
+++ b/src/proof/proof_callbacks.rs
@@ -14,7 +14,9 @@ impl ProofTracer for SMTProofTracer {
             return;
         }
 
-        // Unmatched original-clause callbacks come from the external propagator.
+        // TODO(#186): Known external-clause producers should record their
+        // specific theory before queuing the clause. Keep Background as a
+        // fallback for callbacks whose provenance was not retained.
         self.add_theory_clause(&clause.to_vec(), Theory::Background);
     }
 
@@ -62,7 +64,8 @@ impl ProofTracer for SMTProofTracer {
     }
 
     fn add_constraint(&mut self, clause: &[i32]) {
-        // Clauses supplied by the external propagator are theory lemmas.
+        // TODO(#186): CaDiCaL does not include theory provenance in this
+        // callback, so constraints remain Background until recorded at source.
         self.add_theory_clause(&clause.to_vec(), Theory::Background);
     }
 

--- a/src/proof/proof_callbacks.rs
+++ b/src/proof/proof_callbacks.rs
@@ -15,9 +15,7 @@ impl ProofTracer for SMTProofTracer {
             return;
         }
 
-        // TODO: Known external-clause producers should record their
-        // specific theory before queuing the clause. Keep Background as a
-        // fallback for callbacks whose provenance was not retained.
+        // TODO: Tag known external clauses with their source theory.
         self.add_theory_clause(&clause.to_vec(), Theory::Background);
     }
 
@@ -65,8 +63,7 @@ impl ProofTracer for SMTProofTracer {
     }
 
     fn add_constraint(&mut self, clause: &[i32]) {
-        // TODO: CaDiCaL does not include theory provenance in this
-        // callback, so constraints remain Background until recorded at source.
+        // TODO: Preserve theory provenance for CaDiCaL constraints.
         self.add_theory_clause(&clause.to_vec(), Theory::Background);
     }
 
@@ -103,7 +100,6 @@ mod tests {
         startup.add_original_clause(&vec![]);
         startup.expect_original_clause_callback(&[]);
         ProofTracer::add_original_clause(&mut startup, 1, false, &[], false);
-        startup.cancel_expected_original_clause_callback(&[]);
         assert_eq!(startup.generate_edrat(), "a 0\n");
 
         let mut external = tracer();
@@ -140,16 +136,5 @@ mod tests {
 
         assert!(!tracer.consume_expected_original_clause(&[1]));
         assert_eq!(tracer.generate_edrat(), "");
-    }
-
-    #[test]
-    fn canceling_one_expected_callback_preserves_others() {
-        let mut tracer = tracer();
-        tracer.expect_original_clause_callback(&[1]);
-        tracer.expect_original_clause_callback(&[2]);
-        tracer.cancel_expected_original_clause_callback(&[1]);
-
-        assert!(tracer.consume_expected_original_clause(&[2]));
-        assert!(!tracer.consume_expected_original_clause(&[1]));
     }
 }

--- a/src/proof/proof_callbacks.rs
+++ b/src/proof/proof_callbacks.rs
@@ -16,7 +16,7 @@ impl ProofTracer for SMTProofTracer {
         }
 
         // TODO: Tag known external clauses with their source theory.
-        self.add_theory_clause(&clause.to_vec(), Theory::Background);
+        self.add_theory_clause(clause, Theory::Background);
     }
 
     fn add_derived_clause(
@@ -32,12 +32,12 @@ impl ProofTracer for SMTProofTracer {
         debug_println!(6, 0, "Antecedent clause IDs: {:?}", antecedents);
         debug_println!(6, 0, "Clause size: {}", clause.len());
 
-        self.add_sat_clause(&clause.to_vec());
+        self.add_sat_clause(clause);
     }
 
     fn delete_clause(&mut self, _id: u64, _redundant: bool, clause: &[i32]) {
         self.deleted_clauses += 1;
-        self.record_deletion(&clause.to_vec());
+        self.record_deletion(clause);
     }
 
     fn weaken_minus(&mut self, _id: u64, _clause: &[i32]) {
@@ -64,7 +64,7 @@ impl ProofTracer for SMTProofTracer {
 
     fn add_constraint(&mut self, clause: &[i32]) {
         // TODO: Preserve theory provenance for CaDiCaL constraints.
-        self.add_theory_clause(&clause.to_vec(), Theory::Background);
+        self.add_theory_clause(clause, Theory::Background);
     }
 
     fn reset_assumptions(&mut self) {
@@ -97,7 +97,7 @@ mod tests {
     #[test]
     fn classifies_original_clause_callbacks() {
         let mut startup = tracer();
-        startup.add_original_clause(&vec![]);
+        startup.add_original_clause(&[]);
         startup.expect_original_clause_callback(&[]);
         ProofTracer::add_original_clause(&mut startup, 1, false, &[], false);
         assert_eq!(startup.generate_edrat(), "a 0\n");

--- a/src/proof/proof_callbacks.rs
+++ b/src/proof/proof_callbacks.rs
@@ -9,18 +9,13 @@ use cadical_sys::ProofTracer;
 /// which uses callback functions to notify the owner of a CaDiCaL
 /// instance of important events that occur during SAT solving.
 impl ProofTracer for SMTProofTracer {
-    fn add_original_clause(
-        &mut self,
-        _id: u64,
-        _redundant: bool,
-        _clause: &[i32],
-        _restored: bool,
-    ) {
-        // Previously, this function added original formula clauses and theory clauses to the proof here.
-        // However, because this function could only see the clause itself and whether Sundance was
-        // still processing original formula clauses, it couldn't determine
-        // which theory was responsible for the clause (which eDRAT now requires).
-        // Thus, Sundance directly adds original and theory clauses elsewhere.
+    fn add_original_clause(&mut self, _id: u64, _redundant: bool, clause: &[i32], restored: bool) {
+        if restored || self.consume_expected_original_clause(clause) {
+            return;
+        }
+
+        // Unmatched original-clause callbacks come from the external propagator.
+        self.add_theory_clause(&clause.to_vec(), crate::proof::Theory::Background);
     }
 
     fn add_derived_clause(
@@ -66,8 +61,9 @@ impl ProofTracer for SMTProofTracer {
         panic!("Do not currently support assumptions")
     }
 
-    fn add_constraint(&mut self, _clause: &[i32]) {
-        // Optional: Adding constraints
+    fn add_constraint(&mut self, clause: &[i32]) {
+        // Clauses supplied by the external propagator are theory lemmas.
+        self.add_theory_clause(&clause.to_vec(), crate::proof::Theory::Background);
     }
 
     fn reset_assumptions(&mut self) {
@@ -86,4 +82,32 @@ impl ProofTracer for SMTProofTracer {
     fn conclude_unsat(&mut self, _conclusion_type: i32, _clause_ids: &[u64]) {}
 
     fn conclude_unknown(&mut self, _trail: &[i32]) {}
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashMap;
+
+    fn tracer() -> SMTProofTracer {
+        SMTProofTracer::new(HashMap::new(), HashMap::new())
+    }
+
+    #[test]
+    fn classifies_original_clause_callbacks() {
+        let mut startup = tracer();
+        startup.add_original_clause(&vec![]);
+        startup.expect_original_clause_callback(&[]);
+        ProofTracer::add_original_clause(&mut startup, 1, false, &[], false);
+        startup.clear_expected_original_clause_callback();
+        assert_eq!(startup.generate_edrat(), "a 0\n");
+
+        let mut external = tracer();
+        ProofTracer::add_original_clause(&mut external, 1, false, &[], false);
+        assert_eq!(external.generate_edrat(), "t bg 0\n");
+
+        let mut constraint = tracer();
+        ProofTracer::add_constraint(&mut constraint, &[]);
+        assert_eq!(constraint.generate_edrat(), "t bg 0\n");
+    }
 }

--- a/src/proof/proof_callbacks.rs
+++ b/src/proof/proof_callbacks.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::debug_println;
-use crate::proof::proof_tracer::SMTProofTracer;
+use crate::proof::{Theory, proof_tracer::SMTProofTracer};
 use cadical_sys::ProofTracer;
 
 /// An implementation of the cadical-sys `ProofTracer` trait,
@@ -15,7 +15,7 @@ impl ProofTracer for SMTProofTracer {
         }
 
         // Unmatched original-clause callbacks come from the external propagator.
-        self.add_theory_clause(&clause.to_vec(), crate::proof::Theory::Background);
+        self.add_theory_clause(&clause.to_vec(), Theory::Background);
     }
 
     fn add_derived_clause(
@@ -63,7 +63,7 @@ impl ProofTracer for SMTProofTracer {
 
     fn add_constraint(&mut self, clause: &[i32]) {
         // Clauses supplied by the external propagator are theory lemmas.
-        self.add_theory_clause(&clause.to_vec(), crate::proof::Theory::Background);
+        self.add_theory_clause(&clause.to_vec(), Theory::Background);
     }
 
     fn reset_assumptions(&mut self) {
@@ -99,7 +99,7 @@ mod tests {
         startup.add_original_clause(&vec![]);
         startup.expect_original_clause_callback(&[]);
         ProofTracer::add_original_clause(&mut startup, 1, false, &[], false);
-        startup.clear_expected_original_clause_callback();
+        startup.cancel_expected_original_clause_callback(&[]);
         assert_eq!(startup.generate_edrat(), "a 0\n");
 
         let mut external = tracer();
@@ -109,5 +109,33 @@ mod tests {
         let mut constraint = tracer();
         ProofTracer::add_constraint(&mut constraint, &[]);
         assert_eq!(constraint.generate_edrat(), "t bg 0\n");
+    }
+
+    #[test]
+    fn expected_original_clause_callbacks_ignore_order_and_count_duplicates() {
+        let mut tracer = tracer();
+        tracer.expect_original_clause_callback(&[2, -1]);
+        assert!(tracer.consume_expected_original_clause(&[-1, 2]));
+        assert!(!tracer.consume_expected_original_clause(&[2, -1]));
+
+        tracer.expect_original_clause_callback(&[]);
+        tracer.expect_original_clause_callback(&[]);
+        ProofTracer::add_original_clause(&mut tracer, 1, false, &[], false);
+        ProofTracer::add_original_clause(&mut tracer, 2, false, &[], false);
+        assert_eq!(tracer.generate_edrat(), "");
+
+        ProofTracer::add_original_clause(&mut tracer, 3, false, &[], false);
+        assert_eq!(tracer.generate_edrat(), "t bg 0\n");
+    }
+
+    #[test]
+    fn canceling_one_expected_callback_preserves_others() {
+        let mut tracer = tracer();
+        tracer.expect_original_clause_callback(&[1]);
+        tracer.expect_original_clause_callback(&[2]);
+        tracer.cancel_expected_original_clause_callback(&[1]);
+
+        assert!(tracer.consume_expected_original_clause(&[2]));
+        assert!(!tracer.consume_expected_original_clause(&[1]));
     }
 }

--- a/src/proof/proof_callbacks.rs
+++ b/src/proof/proof_callbacks.rs
@@ -14,7 +14,7 @@ impl ProofTracer for SMTProofTracer {
             return;
         }
 
-        // TODO(#186): Known external-clause producers should record their
+        // TODO: Known external-clause producers should record their
         // specific theory before queuing the clause. Keep Background as a
         // fallback for callbacks whose provenance was not retained.
         self.add_theory_clause(&clause.to_vec(), Theory::Background);
@@ -64,7 +64,7 @@ impl ProofTracer for SMTProofTracer {
     }
 
     fn add_constraint(&mut self, clause: &[i32]) {
-        // TODO(#186): CaDiCaL does not include theory provenance in this
+        // TODO: CaDiCaL does not include theory provenance in this
         // callback, so constraints remain Background until recorded at source.
         self.add_theory_clause(&clause.to_vec(), Theory::Background);
     }

--- a/src/proof/proof_tracer.rs
+++ b/src/proof/proof_tracer.rs
@@ -8,9 +8,13 @@ use crate::proof::{ProofStep, ProofStepType, Theory};
 use core::panic;
 use std::cmp::Eq;
 use std::collections::{HashMap, HashSet};
+use std::fmt;
 use std::hash::Hash;
 use std::ops::Neg;
-use yaspar_ir::ast::{ATerm::*, FunctionMeta, Repr, Sig, SortDef, Str, Term};
+use yaspar_ir::ast::{
+    ATerm::*, Attribute, DatatypeFunction, FunctionMeta, QualifiedIdentifier, Repr, Sig, Sort,
+    SortDef, Str, SymbolQuote, Term,
+};
 
 /// Implementation of ProofTracer both SAT solver clauses and theory clauses
 /// to generate an eDRAT proof.
@@ -20,6 +24,7 @@ pub struct SMTProofTracer {
     sorts: HashMap<Str, SortDef>,
     symbol_table: HashMap<Str, Vec<(Sig, FunctionMeta)>>,
     instantiations_for_smt2: Vec<(Term, Vec<(Term, bool)>)>,
+    expected_original_clause: Option<Vec<i32>>,
     /// Number of clauses deleted by CaDiCaL (for stats)
     pub(crate) deleted_clauses: u64,
 }
@@ -107,7 +112,11 @@ fn format_datatype_declaration(sorts: &HashMap<Str, SortDef>) -> String {
 }
 
 /// Format a function signature as a declare-fun command
-fn format_function_declaration(symbol_name: &Str, sigs: &[(Sig, FunctionMeta)]) -> String {
+fn format_function_declaration(
+    symbol_name: &Str,
+    sigs: &[(Sig, FunctionMeta)],
+    symbol_table: &HashMap<Str, Vec<(Sig, FunctionMeta)>>,
+) -> String {
     // overloading is only possible for generated functions; we skip them.
     if sigs.len() != 1 {
         return String::new();
@@ -132,9 +141,236 @@ fn format_function_declaration(symbol_name: &Str, sigs: &[(Sig, FunctionMeta)]) 
             if !meta.rec_deps.is_empty() {
                 panic!("We do not handle recursive function definitions!");
             }
-            format!("(define-fun {})", meta.def)
+            let variables = meta
+                .def
+                .vars
+                .iter()
+                .map(ToString::to_string)
+                .collect::<Vec<_>>()
+                .join(" ");
+            format!(
+                "(define-fun {} ({}) {} {})\n",
+                meta.def.name.sym_quote(),
+                variables,
+                meta.def.out_sort,
+                SmtTerm {
+                    term: &meta.def.body,
+                    symbol_table,
+                }
+            )
         }
         _ => String::new(),
+    }
+}
+
+// Yaspar's generic Display omits inferred sort ascriptions. Parametric
+// datatype constructors need those ascriptions to remain valid SMT-LIB.
+struct SmtTerm<'a> {
+    term: &'a Term,
+    symbol_table: &'a HashMap<Str, Vec<(Sig, FunctionMeta)>>,
+}
+
+impl SmtTerm<'_> {
+    fn is_parametric_constructor(&self, qid: &QualifiedIdentifier) -> bool {
+        self.symbol_table.get(&qid.0.symbol).is_some_and(|sigs| {
+            sigs.iter().any(|(sig, meta)| {
+                matches!(sig, Sig::ParFunc(_, params, _, _) if !params.is_empty())
+                    && matches!(
+                        meta,
+                        FunctionMeta::Datatype {
+                            kind: DatatypeFunction::Constructor,
+                            ..
+                        }
+                    )
+            })
+        })
+    }
+
+    fn fmt_identifier(
+        &self,
+        f: &mut fmt::Formatter<'_>,
+        qid: &QualifiedIdentifier,
+        inferred_sort: Option<&Sort>,
+    ) -> fmt::Result {
+        if qid.1.is_none()
+            && self.is_parametric_constructor(qid)
+            && let Some(sort) = inferred_sort
+        {
+            return write!(f, "(as {} {})", qid.0, sort);
+        }
+        write!(f, "{qid}")
+    }
+
+    fn fmt_terms(
+        &self,
+        f: &mut fmt::Formatter<'_>,
+        terms: &[Term],
+        separator: &str,
+    ) -> fmt::Result {
+        for (index, term) in terms.iter().enumerate() {
+            if index > 0 {
+                f.write_str(separator)?;
+            }
+            write!(
+                f,
+                "{}",
+                SmtTerm {
+                    term,
+                    symbol_table: self.symbol_table,
+                }
+            )?;
+        }
+        Ok(())
+    }
+
+    fn fmt_application(
+        &self,
+        f: &mut fmt::Formatter<'_>,
+        operator: &str,
+        terms: &[Term],
+    ) -> fmt::Result {
+        write!(f, "({operator}")?;
+        if !terms.is_empty() {
+            f.write_str(" ")?;
+            self.fmt_terms(f, terms, " ")?;
+        }
+        f.write_str(")")
+    }
+}
+
+impl fmt::Display for SmtTerm<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self.term.repr() {
+            Constant(constant, _) => write!(f, "{constant}"),
+            Global(qid, sort) => self.fmt_identifier(f, qid, sort.as_ref()),
+            Local(local) => write!(f, "{}", local.symbol.sym_quote()),
+            App(qid, terms, sort) => {
+                f.write_str("(")?;
+                self.fmt_identifier(f, qid, sort.as_ref())?;
+                if !terms.is_empty() {
+                    f.write_str(" ")?;
+                    self.fmt_terms(f, terms, " ")?;
+                }
+                f.write_str(")")
+            }
+            Let(bindings, body) => {
+                f.write_str("(let (")?;
+                for (index, binding) in bindings.iter().enumerate() {
+                    if index > 0 {
+                        f.write_str(" ")?;
+                    }
+                    write!(
+                        f,
+                        "({} {})",
+                        binding.0.sym_quote(),
+                        SmtTerm {
+                            term: &binding.2,
+                            symbol_table: self.symbol_table,
+                        }
+                    )?;
+                }
+                write!(
+                    f,
+                    ") {})",
+                    SmtTerm {
+                        term: body,
+                        symbol_table: self.symbol_table,
+                    }
+                )
+            }
+            Exists(bindings, body) | Forall(bindings, body) => {
+                let binder = if matches!(self.term.repr(), Exists(..)) {
+                    "exists"
+                } else {
+                    "forall"
+                };
+                write!(f, "({binder} (")?;
+                for (index, binding) in bindings.iter().enumerate() {
+                    if index > 0 {
+                        f.write_str(" ")?;
+                    }
+                    write!(f, "{binding}")?;
+                }
+                write!(
+                    f,
+                    ") {})",
+                    SmtTerm {
+                        term: body,
+                        symbol_table: self.symbol_table,
+                    }
+                )
+            }
+            Matching(scrutinee, arms) => {
+                write!(
+                    f,
+                    "(match {} (",
+                    SmtTerm {
+                        term: scrutinee,
+                        symbol_table: self.symbol_table,
+                    }
+                )?;
+                for (index, arm) in arms.iter().enumerate() {
+                    if index > 0 {
+                        f.write_str(" ")?;
+                    }
+                    write!(
+                        f,
+                        "({} {})",
+                        arm.pattern,
+                        SmtTerm {
+                            term: &arm.body,
+                            symbol_table: self.symbol_table,
+                        }
+                    )?;
+                }
+                f.write_str("))")
+            }
+            Annotated(term, attributes) => {
+                write!(
+                    f,
+                    "(! {}",
+                    SmtTerm {
+                        term,
+                        symbol_table: self.symbol_table,
+                    }
+                )?;
+                for attribute in attributes {
+                    f.write_str(" ")?;
+                    match attribute {
+                        Attribute::Pattern(terms) => {
+                            f.write_str(":pattern (")?;
+                            self.fmt_terms(f, terms, " ")?;
+                            f.write_str(")")?;
+                        }
+                        _ => write!(f, "{attribute}")?,
+                    }
+                }
+                f.write_str(")")
+            }
+            Eq(left, right) => self.fmt_application(f, "=", &[left.clone(), right.clone()]),
+            Distinct(terms) => self.fmt_application(f, "distinct", terms),
+            And(terms) => self.fmt_application(f, "and", terms),
+            Or(terms) => self.fmt_application(f, "or", terms),
+            Xor(terms) => self.fmt_application(f, "xor", terms),
+            Implies(premises, conclusion) => {
+                f.write_str("(=> ")?;
+                self.fmt_terms(f, premises, " ")?;
+                write!(
+                    f,
+                    " {})",
+                    SmtTerm {
+                        term: conclusion,
+                        symbol_table: self.symbol_table,
+                    }
+                )
+            }
+            Not(term) => self.fmt_application(f, "not", std::slice::from_ref(term)),
+            Ite(condition, then_term, else_term) => self.fmt_application(
+                f,
+                "ite",
+                &[condition.clone(), then_term.clone(), else_term.clone()],
+            ),
+        }
     }
 }
 
@@ -150,6 +386,7 @@ impl SMTProofTracer {
             sorts,
             symbol_table,
             instantiations_for_smt2: Vec::new(),
+            expected_original_clause: None,
             deleted_clauses: 0,
         }
     }
@@ -185,6 +422,24 @@ impl SMTProofTracer {
 
     pub fn add_theory_clause(&mut self, clause: &Vec<i32>, theory: Theory) {
         self.push_step(clause, ProofStepType::TheoryClause(theory));
+    }
+
+    pub fn expect_original_clause_callback(&mut self, clause: &[i32]) {
+        assert!(self.expected_original_clause.is_none());
+        self.expected_original_clause = Some(clause.to_vec());
+    }
+
+    pub fn consume_expected_original_clause(&mut self, clause: &[i32]) -> bool {
+        if self.expected_original_clause.as_deref() == Some(clause) {
+            self.expected_original_clause = None;
+            true
+        } else {
+            false
+        }
+    }
+
+    pub fn clear_expected_original_clause_callback(&mut self) {
+        self.expected_original_clause = None;
     }
 
     ////////////////////////////////////////////////////////////////////////////
@@ -240,7 +495,14 @@ impl SMTProofTracer {
                 );
 
                 if !literals_defined.contains(&lit) {
-                    temp_output.push_str(&format!("(edrat-literal {} {})\n", lit, polarized_term));
+                    temp_output.push_str(&format!(
+                        "(edrat-literal {} {})\n",
+                        lit,
+                        SmtTerm {
+                            term: &polarized_term,
+                            symbol_table: &self.symbol_table,
+                        }
+                    ));
                     literals_defined.insert(lit);
                 }
             } else {
@@ -332,7 +594,11 @@ impl SMTProofTracer {
         output.push_str(&datatype_string);
 
         for (symbol, sigs) in &self.symbol_table {
-            output.push_str(&format_function_declaration(symbol, sigs));
+            output.push_str(&format_function_declaration(
+                symbol,
+                sigs,
+                &self.symbol_table,
+            ));
         }
 
         // Depending on the proof step, introduce new eDRAT literals
@@ -376,5 +642,46 @@ impl SMTProofTracer {
             }
         }
         output
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use yaspar_ir::ast::{ACommand, Context, Typecheck};
+    use yaspar_ir::untyped::UntypedAst;
+
+    #[test]
+    fn ascribes_polymorphic_datatype_constructors() {
+        let script = "\
+(declare-sort Val 0)
+(declare-datatypes ((Option 1)) ((par (T) ((None) (Some (value T))))))
+(define-fun empty () (Option Val) (as None (Option Val)))
+(assert ((_ is None) (as None (Option Val))))
+";
+        let mut context = Context::new();
+        let commands = UntypedAst
+            .parse_script_str(script)
+            .unwrap()
+            .type_check(&mut context)
+            .unwrap();
+        let term = commands
+            .iter()
+            .find_map(|command| match command.repr() {
+                ACommand::Assert(term) => Some(term.clone()),
+                _ => None,
+            })
+            .unwrap();
+
+        let mut tracer = SMTProofTracer::new(
+            context.expose_sorts().clone(),
+            context.expose_symbol_table().clone(),
+        );
+        tracer.register_term(1, &term, true);
+        tracer.add_original_clause(&vec![1]);
+
+        let proof = tracer.generate_edrat();
+        assert!(proof.contains("(define-fun empty () (Option Val) (as None (Option Val)))"));
+        assert!(proof.contains("((_ is None) (as None (Option Val)))"));
     }
 }

--- a/src/proof/proof_tracer.rs
+++ b/src/proof/proof_tracer.rs
@@ -8,13 +8,9 @@ use crate::proof::{ProofStep, ProofStepType, Theory};
 use core::panic;
 use std::cmp::Eq;
 use std::collections::{HashMap, HashSet};
-use std::fmt;
 use std::hash::Hash;
 use std::ops::Neg;
-use yaspar_ir::ast::{
-    ATerm::*, Attribute, DatatypeFunction, FunctionMeta, QualifiedIdentifier, Repr, Sig, Sort,
-    SortDef, Str, SymbolQuote, Term,
-};
+use yaspar_ir::ast::{ATerm::*, FunctionMeta, Repr, Sig, SortDef, Str, SymbolQuote, Term};
 
 /// Implementation of ProofTracer both SAT solver clauses and theory clauses
 /// to generate an eDRAT proof.
@@ -119,11 +115,7 @@ fn format_datatype_declaration(sorts: &HashMap<Str, SortDef>) -> String {
 }
 
 /// Format a function signature as a declare-fun command
-fn format_function_declaration(
-    symbol_name: &Str,
-    sigs: &[(Sig, FunctionMeta)],
-    symbol_table: &HashMap<Str, Vec<(Sig, FunctionMeta)>>,
-) -> String {
+fn format_function_declaration(symbol_name: &Str, sigs: &[(Sig, FunctionMeta)]) -> String {
     // overloading is only possible for generated functions; we skip them.
     if sigs.len() != 1 {
         return String::new();
@@ -160,10 +152,7 @@ fn format_function_declaration(
                 meta.def.name.sym_quote(),
                 variables,
                 meta.def.out_sort,
-                SmtTerm {
-                    term: &meta.def.body,
-                    symbol_table,
-                }
+                meta.def.body
             )
         }
         _ => String::new(),
@@ -195,11 +184,7 @@ fn format_function_declarations(symbol_table: &HashMap<Str, Vec<(Sig, FunctionMe
         ) {
             definitions.push(symbol);
         } else {
-            output.push_str(&format_function_declaration(
-                symbol,
-                &symbol_table[symbol],
-                symbol_table,
-            ));
+            output.push_str(&format_function_declaration(symbol, &symbol_table[symbol]));
         }
     }
 
@@ -226,167 +211,11 @@ fn format_function_declarations(symbol_table: &HashMap<Str, Vec<(Sig, FunctionMe
             panic!("We do not handle recursive function definitions!");
         };
         let symbol = definitions.remove(index);
-        output.push_str(&format_function_declaration(
-            symbol,
-            &symbol_table[symbol],
-            symbol_table,
-        ));
+        output.push_str(&format_function_declaration(symbol, &symbol_table[symbol]));
         emitted.insert(symbol.clone());
     }
 
     output
-}
-
-// Print inferred sorts for parametric constructors, which Yaspar omits.
-struct SmtTerm<'a> {
-    term: &'a Term,
-    symbol_table: &'a HashMap<Str, Vec<(Sig, FunctionMeta)>>,
-}
-
-impl SmtTerm<'_> {
-    fn is_parametric_constructor(&self, qid: &QualifiedIdentifier) -> bool {
-        self.symbol_table.get(&qid.0.symbol).is_some_and(|sigs| {
-            sigs.iter().any(|(sig, meta)| {
-                matches!(sig, Sig::ParFunc(_, params, _, _) if !params.is_empty())
-                    && matches!(
-                        meta,
-                        FunctionMeta::Datatype {
-                            kind: DatatypeFunction::Constructor,
-                            ..
-                        }
-                    )
-            })
-        })
-    }
-
-    fn fmt_identifier(
-        &self,
-        f: &mut fmt::Formatter<'_>,
-        qid: &QualifiedIdentifier,
-        inferred_sort: Option<&Sort>,
-    ) -> fmt::Result {
-        if qid.1.is_none()
-            && self.is_parametric_constructor(qid)
-            && let Some(sort) = inferred_sort
-        {
-            return write!(f, "(as {} {})", qid.0, sort);
-        }
-        write!(f, "{qid}")
-    }
-
-    fn child<'a>(&'a self, term: &'a Term) -> SmtTerm<'a> {
-        SmtTerm {
-            term,
-            symbol_table: self.symbol_table,
-        }
-    }
-
-    fn fmt_terms<'a>(
-        &self,
-        f: &mut fmt::Formatter<'_>,
-        terms: impl IntoIterator<Item = &'a Term>,
-    ) -> fmt::Result {
-        for (index, term) in terms.into_iter().enumerate() {
-            if index > 0 {
-                f.write_str(" ")?;
-            }
-            write!(f, "{}", self.child(term))?;
-        }
-        Ok(())
-    }
-
-    fn fmt_application<'a>(
-        &self,
-        f: &mut fmt::Formatter<'_>,
-        operator: &str,
-        terms: impl IntoIterator<Item = &'a Term>,
-    ) -> fmt::Result {
-        write!(f, "({operator}")?;
-        for term in terms {
-            write!(f, " {}", self.child(term))?;
-        }
-        f.write_str(")")
-    }
-}
-
-impl fmt::Display for SmtTerm<'_> {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self.term.repr() {
-            Constant(constant, _) => write!(f, "{constant}"),
-            Global(qid, sort) => self.fmt_identifier(f, qid, sort.as_ref()),
-            Local(local) => write!(f, "{}", local.symbol.sym_quote()),
-            App(qid, terms, sort) => {
-                f.write_str("(")?;
-                self.fmt_identifier(f, qid, sort.as_ref())?;
-                for term in terms {
-                    write!(f, " {}", self.child(term))?;
-                }
-                f.write_str(")")
-            }
-            Let(bindings, body) => {
-                f.write_str("(let (")?;
-                for (index, binding) in bindings.iter().enumerate() {
-                    if index > 0 {
-                        f.write_str(" ")?;
-                    }
-                    write!(f, "({} {})", binding.0.sym_quote(), self.child(&binding.2))?;
-                }
-                write!(f, ") {})", self.child(body))
-            }
-            Exists(bindings, body) | Forall(bindings, body) => {
-                let binder = if matches!(self.term.repr(), Exists(..)) {
-                    "exists"
-                } else {
-                    "forall"
-                };
-                write!(f, "({binder} (")?;
-                for (index, binding) in bindings.iter().enumerate() {
-                    if index > 0 {
-                        f.write_str(" ")?;
-                    }
-                    write!(f, "{binding}")?;
-                }
-                write!(f, ") {})", self.child(body))
-            }
-            Matching(scrutinee, arms) => {
-                write!(f, "(match {} (", self.child(scrutinee))?;
-                for (index, arm) in arms.iter().enumerate() {
-                    if index > 0 {
-                        f.write_str(" ")?;
-                    }
-                    write!(f, "({} {})", arm.pattern, self.child(&arm.body))?;
-                }
-                f.write_str("))")
-            }
-            Annotated(term, attributes) => {
-                write!(f, "(! {}", self.child(term))?;
-                for attribute in attributes {
-                    f.write_str(" ")?;
-                    match attribute {
-                        Attribute::Pattern(terms) => {
-                            f.write_str(":pattern (")?;
-                            self.fmt_terms(f, terms)?;
-                            f.write_str(")")?;
-                        }
-                        _ => write!(f, "{attribute}")?,
-                    }
-                }
-                f.write_str(")")
-            }
-            Eq(left, right) => self.fmt_application(f, "=", [left, right]),
-            Distinct(terms) => self.fmt_application(f, "distinct", terms),
-            And(terms) => self.fmt_application(f, "and", terms),
-            Or(terms) => self.fmt_application(f, "or", terms),
-            Xor(terms) => self.fmt_application(f, "xor", terms),
-            Implies(premises, conclusion) => {
-                self.fmt_application(f, "=>", premises.iter().chain(std::iter::once(conclusion)))
-            }
-            Not(term) => self.fmt_application(f, "not", [term]),
-            Ite(condition, then_term, else_term) => {
-                self.fmt_application(f, "ite", [condition, then_term, else_term])
-            }
-        }
-    }
 }
 
 impl SMTProofTracer {
@@ -510,14 +339,7 @@ impl SMTProofTracer {
                 );
 
                 if !literals_defined.contains(&lit) {
-                    out.push_str(&format!(
-                        "(edrat-literal {} {})\n",
-                        lit,
-                        SmtTerm {
-                            term: &polarized_term,
-                            symbol_table: &self.symbol_table,
-                        }
-                    ));
+                    out.push_str(&format!("(edrat-literal {} {})\n", lit, polarized_term));
                     literals_defined.insert(lit);
                 }
             } else {
@@ -681,28 +503,6 @@ mod tests {
             })
             .unwrap();
         (context, assertion)
-    }
-
-    #[test]
-    fn ascribes_polymorphic_datatype_constructors() {
-        let script = "\
-(declare-sort Val 0)
-(declare-datatypes ((Option 1)) ((par (T) ((None) (Some (value T))))))
-(define-fun empty () (Option Val) (as None (Option Val)))
-(assert ((_ is None) (as None (Option Val))))
-";
-        let (context, term) = parse_assertion(script);
-
-        let mut tracer = SMTProofTracer::new(
-            context.expose_sorts().clone(),
-            context.expose_symbol_table().clone(),
-        );
-        tracer.register_term(1, &term, true);
-        tracer.add_original_clause(&[1]);
-
-        let proof = tracer.generate_edrat();
-        assert!(proof.contains("(define-fun empty () (Option Val) (as None (Option Val)))"));
-        assert!(proof.contains("((_ is None) (as None (Option Val)))"));
     }
 
     #[test]

--- a/src/proof/proof_tracer.rs
+++ b/src/proof/proof_tracer.rs
@@ -24,7 +24,7 @@ pub struct SMTProofTracer {
     sorts: HashMap<Str, SortDef>,
     symbol_table: HashMap<Str, Vec<(Sig, FunctionMeta)>>,
     instantiations_for_smt2: Vec<(Term, Vec<(Term, bool)>)>,
-    expected_original_clause: Option<Vec<i32>>,
+    expected_original_clauses: HashMap<Vec<i32>, usize>,
     /// Number of clauses deleted by CaDiCaL (for stats)
     pub(crate) deleted_clauses: u64,
 }
@@ -56,6 +56,13 @@ where
         seen.insert(lit);
     }
     false
+}
+
+fn normalized_clause(clause: &[i32]) -> Vec<i32> {
+    let mut normalized = clause.to_vec();
+    normalized.sort_unstable();
+    normalized.dedup();
+    normalized
 }
 
 /// Format a sort definition as a declare-sort command
@@ -161,6 +168,125 @@ fn format_function_declaration(
         }
         _ => String::new(),
     }
+}
+
+fn collect_global_symbols(term: &Term, symbols: &mut HashSet<Str>) {
+    match term.repr() {
+        Constant(..) | Local(..) => {}
+        Global(qid, ..) => {
+            symbols.insert(qid.0.symbol.clone());
+        }
+        App(qid, terms, ..) => {
+            symbols.insert(qid.0.symbol.clone());
+            for term in terms {
+                collect_global_symbols(term, symbols);
+            }
+        }
+        Let(bindings, body) => {
+            for binding in bindings {
+                collect_global_symbols(&binding.2, symbols);
+            }
+            collect_global_symbols(body, symbols);
+        }
+        Exists(_, body) | Forall(_, body) | Not(body) => {
+            collect_global_symbols(body, symbols);
+        }
+        Matching(scrutinee, arms) => {
+            collect_global_symbols(scrutinee, symbols);
+            for arm in arms {
+                collect_global_symbols(&arm.body, symbols);
+            }
+        }
+        Annotated(term, attributes) => {
+            collect_global_symbols(term, symbols);
+            for attribute in attributes {
+                if let Attribute::Pattern(terms) = attribute {
+                    for term in terms {
+                        collect_global_symbols(term, symbols);
+                    }
+                }
+            }
+        }
+        Eq(left, right) => {
+            collect_global_symbols(left, symbols);
+            collect_global_symbols(right, symbols);
+        }
+        Distinct(terms) | And(terms) | Or(terms) | Xor(terms) => {
+            for term in terms {
+                collect_global_symbols(term, symbols);
+            }
+        }
+        Implies(premises, conclusion) => {
+            for premise in premises {
+                collect_global_symbols(premise, symbols);
+            }
+            collect_global_symbols(conclusion, symbols);
+        }
+        Ite(condition, then_term, else_term) => {
+            collect_global_symbols(condition, symbols);
+            collect_global_symbols(then_term, symbols);
+            collect_global_symbols(else_term, symbols);
+        }
+    }
+}
+
+fn format_function_declarations(symbol_table: &HashMap<Str, Vec<(Sig, FunctionMeta)>>) -> String {
+    let mut symbols = symbol_table.keys().collect::<Vec<_>>();
+    symbols.sort_by_key(|symbol| symbol.to_string());
+
+    let mut output = String::new();
+    let mut definitions = Vec::new();
+    for symbol in symbols {
+        if matches!(
+            symbol_table.get(symbol).map(Vec::as_slice),
+            Some([(Sig::ParFunc(..), FunctionMeta::Defined(_))])
+        ) {
+            definitions.push(symbol);
+        } else {
+            output.push_str(&format_function_declaration(
+                symbol,
+                &symbol_table[symbol],
+                symbol_table,
+            ));
+        }
+    }
+
+    let defined_symbols = definitions
+        .iter()
+        .map(|symbol| (*symbol).clone())
+        .collect::<HashSet<_>>();
+    let dependencies = definitions
+        .iter()
+        .map(|symbol| {
+            let symbol = *symbol;
+            let [(_, FunctionMeta::Defined(meta))] = symbol_table[symbol].as_slice() else {
+                unreachable!();
+            };
+            let mut dependencies = HashSet::new();
+            collect_global_symbols(&meta.def.body, &mut dependencies);
+            (symbol.clone(), dependencies)
+        })
+        .collect::<HashMap<_, _>>();
+
+    let mut emitted = HashSet::new();
+    while !definitions.is_empty() {
+        let Some(index) = definitions.iter().position(|symbol| {
+            dependencies[*symbol].iter().all(|dependency| {
+                !defined_symbols.contains(dependency) || emitted.contains(dependency)
+            })
+        }) else {
+            panic!("We do not handle recursive function definitions!");
+        };
+        let symbol = definitions.remove(index);
+        output.push_str(&format_function_declaration(
+            symbol,
+            &symbol_table[symbol],
+            symbol_table,
+        ));
+        emitted.insert(symbol.clone());
+    }
+
+    output
 }
 
 // Yaspar's generic Display omits inferred sort ascriptions. Parametric
@@ -386,7 +512,7 @@ impl SMTProofTracer {
             sorts,
             symbol_table,
             instantiations_for_smt2: Vec::new(),
-            expected_original_clause: None,
+            expected_original_clauses: HashMap::new(),
             deleted_clauses: 0,
         }
     }
@@ -425,21 +551,27 @@ impl SMTProofTracer {
     }
 
     pub fn expect_original_clause_callback(&mut self, clause: &[i32]) {
-        assert!(self.expected_original_clause.is_none());
-        self.expected_original_clause = Some(clause.to_vec());
+        let clause = normalized_clause(clause);
+        *self.expected_original_clauses.entry(clause).or_default() += 1;
     }
 
     pub fn consume_expected_original_clause(&mut self, clause: &[i32]) -> bool {
-        if self.expected_original_clause.as_deref() == Some(clause) {
-            self.expected_original_clause = None;
-            true
-        } else {
-            false
+        let clause = normalized_clause(clause);
+        match self.expected_original_clauses.get_mut(&clause) {
+            Some(count) if *count > 1 => {
+                *count -= 1;
+                true
+            }
+            Some(_) => {
+                self.expected_original_clauses.remove(&clause);
+                true
+            }
+            None => false,
         }
     }
 
-    pub fn clear_expected_original_clause_callback(&mut self) {
-        self.expected_original_clause = None;
+    pub fn cancel_expected_original_clause_callback(&mut self, clause: &[i32]) {
+        self.consume_expected_original_clause(clause);
     }
 
     ////////////////////////////////////////////////////////////////////////////
@@ -593,13 +725,7 @@ impl SMTProofTracer {
         let datatype_string = format_datatype_declaration(&self.sorts);
         output.push_str(&datatype_string);
 
-        for (symbol, sigs) in &self.symbol_table {
-            output.push_str(&format_function_declaration(
-                symbol,
-                sigs,
-                &self.symbol_table,
-            ));
-        }
+        output.push_str(&format_function_declarations(&self.symbol_table));
 
         // Depending on the proof step, introduce new eDRAT literals
         for step in &self.proof_steps {
@@ -621,6 +747,13 @@ impl SMTProofTracer {
                         "The skolem vars for clause {:?}: {:?}",
                         clause,
                         skolem_vars
+                    );
+                    // The declaration refers to the parent eDRAT literal, while
+                    // the child literal may refer to the fresh Skolem symbols.
+                    self.introduce_literals(
+                        &mut literals_defined,
+                        &vec![*parent_term],
+                        &mut output,
                     );
                     for (i, var) in skolem_vars.iter().enumerate() {
                         // CC TODO think about negated parent term, if (negated forall)
@@ -648,6 +781,7 @@ impl SMTProofTracer {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::quantifiers::skolem::skolemize;
     use yaspar_ir::ast::{ACommand, Context, Typecheck};
     use yaspar_ir::untyped::UntypedAst;
 
@@ -683,5 +817,89 @@ mod tests {
         let proof = tracer.generate_edrat();
         assert!(proof.contains("(define-fun empty () (Option Val) (as None (Option Val)))"));
         assert!(proof.contains("((_ is None) (as None (Option Val)))"));
+    }
+
+    #[test]
+    fn orders_defined_functions_by_dependency() {
+        let script = "\
+(declare-fun a () Int)
+(define-fun f ((x Int)) Int (+ x a))
+(define-fun g ((x Int)) Int (f (f x)))
+(assert (= (g 0) 2))
+";
+        let mut context = Context::new();
+        let commands = UntypedAst
+            .parse_script_str(script)
+            .unwrap()
+            .type_check(&mut context)
+            .unwrap();
+        let term = commands
+            .iter()
+            .find_map(|command| match command.repr() {
+                ACommand::Assert(term) => Some(term.clone()),
+                _ => None,
+            })
+            .unwrap();
+
+        let mut tracer = SMTProofTracer::new(
+            context.expose_sorts().clone(),
+            context.expose_symbol_table().clone(),
+        );
+        tracer.register_term(1, &term, true);
+        tracer.add_original_clause(&vec![1]);
+
+        let proof = tracer.generate_edrat();
+        let declaration = proof.find("(declare-fun a () Int)").unwrap();
+        let f_definition = proof.find("(define-fun f ").unwrap();
+        let g_definition = proof.find("(define-fun g ").unwrap();
+        assert!(declaration < f_definition);
+        assert!(f_definition < g_definition);
+    }
+
+    #[test]
+    fn introduces_skolem_parent_before_declaration_and_child_after() {
+        let script = "(assert (exists ((x Int)) (> x 0)))";
+        let mut context = Context::new();
+        let commands = UntypedAst
+            .parse_script_str(script)
+            .unwrap()
+            .type_check(&mut context)
+            .unwrap();
+        let parent = commands
+            .iter()
+            .find_map(|command| match command.repr() {
+                ACommand::Assert(term) => Some(term.clone()),
+                _ => None,
+            })
+            .unwrap();
+        let (child, skolem_vars) = skolemize(&parent, &mut context, true);
+        let skolem_name = skolem_vars[0].0.to_string();
+
+        let mut tracer = SMTProofTracer::new(
+            context.expose_sorts().clone(),
+            context.expose_symbol_table().clone(),
+        );
+        tracer.register_term(1, &parent, true);
+        tracer.register_term(2, &child, true);
+        tracer.push_step(
+            &vec![-1, 2],
+            ProofStepType::Skolemization {
+                parent_term: 1,
+                skolem_vars,
+            },
+        );
+
+        let proof = tracer.generate_edrat();
+        let parent_definition = proof.find("(edrat-literal 1 ").unwrap();
+        let declaration = proof
+            .find(&format!("(declare-skolem 1 0 {} Int)", skolem_name))
+            .unwrap();
+        let child_definition = proof.find("(edrat-literal 2 ").unwrap();
+        let skolem_step = proof.find("s -1 2 0").unwrap();
+
+        assert!(parent_definition < declaration);
+        assert!(declaration < child_definition);
+        assert!(child_definition < skolem_step);
+        assert_eq!(proof.matches("(edrat-literal 1 ").count(), 1);
     }
 }

--- a/src/proof/proof_tracer.rs
+++ b/src/proof/proof_tracer.rs
@@ -362,6 +362,53 @@ impl SmtTerm<'_> {
         }
         f.write_str(")")
     }
+
+    fn fmt_binary_application(
+        &self,
+        f: &mut fmt::Formatter<'_>,
+        operator: &str,
+        left: &Term,
+        right: &Term,
+    ) -> fmt::Result {
+        write!(
+            f,
+            "({operator} {} {})",
+            SmtTerm {
+                term: left,
+                symbol_table: self.symbol_table,
+            },
+            SmtTerm {
+                term: right,
+                symbol_table: self.symbol_table,
+            }
+        )
+    }
+
+    fn fmt_ternary_application(
+        &self,
+        f: &mut fmt::Formatter<'_>,
+        operator: &str,
+        first: &Term,
+        second: &Term,
+        third: &Term,
+    ) -> fmt::Result {
+        write!(
+            f,
+            "({operator} {} {} {})",
+            SmtTerm {
+                term: first,
+                symbol_table: self.symbol_table,
+            },
+            SmtTerm {
+                term: second,
+                symbol_table: self.symbol_table,
+            },
+            SmtTerm {
+                term: third,
+                symbol_table: self.symbol_table,
+            }
+        )
+    }
 }
 
 impl fmt::Display for SmtTerm<'_> {
@@ -473,7 +520,7 @@ impl fmt::Display for SmtTerm<'_> {
                 }
                 f.write_str(")")
             }
-            Eq(left, right) => self.fmt_application(f, "=", &[left.clone(), right.clone()]),
+            Eq(left, right) => self.fmt_binary_application(f, "=", left, right),
             Distinct(terms) => self.fmt_application(f, "distinct", terms),
             And(terms) => self.fmt_application(f, "and", terms),
             Or(terms) => self.fmt_application(f, "or", terms),
@@ -491,11 +538,9 @@ impl fmt::Display for SmtTerm<'_> {
                 )
             }
             Not(term) => self.fmt_application(f, "not", std::slice::from_ref(term)),
-            Ite(condition, then_term, else_term) => self.fmt_application(
-                f,
-                "ite",
-                &[condition.clone(), then_term.clone(), else_term.clone()],
-            ),
+            Ite(condition, then_term, else_term) => {
+                self.fmt_ternary_application(f, "ite", condition, then_term, else_term)
+            }
         }
     }
 }

--- a/src/proof/proof_tracer.rs
+++ b/src/proof/proof_tracer.rs
@@ -172,61 +172,13 @@ fn format_function_declaration(
 
 fn collect_global_symbols(term: &Term, symbols: &mut HashSet<Str>) {
     match term.repr() {
-        Constant(..) | Local(..) => {}
-        Global(qid, ..) => {
+        Global(qid, ..) | App(qid, ..) => {
             symbols.insert(qid.0.symbol.clone());
         }
-        App(qid, terms, ..) => {
-            symbols.insert(qid.0.symbol.clone());
-            for term in terms {
-                collect_global_symbols(term, symbols);
-            }
-        }
-        Let(bindings, body) => {
-            for binding in bindings {
-                collect_global_symbols(&binding.2, symbols);
-            }
-            collect_global_symbols(body, symbols);
-        }
-        Exists(_, body) | Forall(_, body) | Not(body) => {
-            collect_global_symbols(body, symbols);
-        }
-        Matching(scrutinee, arms) => {
-            collect_global_symbols(scrutinee, symbols);
-            for arm in arms {
-                collect_global_symbols(&arm.body, symbols);
-            }
-        }
-        Annotated(term, attributes) => {
-            collect_global_symbols(term, symbols);
-            for attribute in attributes {
-                if let Attribute::Pattern(terms) = attribute {
-                    for term in terms {
-                        collect_global_symbols(term, symbols);
-                    }
-                }
-            }
-        }
-        Eq(left, right) => {
-            collect_global_symbols(left, symbols);
-            collect_global_symbols(right, symbols);
-        }
-        Distinct(terms) | And(terms) | Or(terms) | Xor(terms) => {
-            for term in terms {
-                collect_global_symbols(term, symbols);
-            }
-        }
-        Implies(premises, conclusion) => {
-            for premise in premises {
-                collect_global_symbols(premise, symbols);
-            }
-            collect_global_symbols(conclusion, symbols);
-        }
-        Ite(condition, then_term, else_term) => {
-            collect_global_symbols(condition, symbols);
-            collect_global_symbols(then_term, symbols);
-            collect_global_symbols(else_term, symbols);
-        }
+        _ => {}
+    }
+    for subterm in term.repr().sub_terms() {
+        collect_global_symbols(subterm, symbols);
     }
 }
 
@@ -289,8 +241,7 @@ fn format_function_declarations(symbol_table: &HashMap<Str, Vec<(Sig, FunctionMe
     output
 }
 
-// Yaspar's generic Display omits inferred sort ascriptions. Parametric
-// datatype constructors need those ascriptions to remain valid SMT-LIB.
+// Print inferred sorts for parametric constructors, which Yaspar omits.
 struct SmtTerm<'a> {
     term: &'a Term,
     symbol_table: &'a HashMap<Str, Vec<(Sig, FunctionMeta)>>,
@@ -327,87 +278,38 @@ impl SmtTerm<'_> {
         write!(f, "{qid}")
     }
 
-    fn fmt_terms(
+    fn child<'a>(&'a self, term: &'a Term) -> SmtTerm<'a> {
+        SmtTerm {
+            term,
+            symbol_table: self.symbol_table,
+        }
+    }
+
+    fn fmt_terms<'a>(
         &self,
         f: &mut fmt::Formatter<'_>,
-        terms: &[Term],
-        separator: &str,
+        terms: impl IntoIterator<Item = &'a Term>,
     ) -> fmt::Result {
-        for (index, term) in terms.iter().enumerate() {
+        for (index, term) in terms.into_iter().enumerate() {
             if index > 0 {
-                f.write_str(separator)?;
+                f.write_str(" ")?;
             }
-            write!(
-                f,
-                "{}",
-                SmtTerm {
-                    term,
-                    symbol_table: self.symbol_table,
-                }
-            )?;
+            write!(f, "{}", self.child(term))?;
         }
         Ok(())
     }
 
-    fn fmt_application(
+    fn fmt_application<'a>(
         &self,
         f: &mut fmt::Formatter<'_>,
         operator: &str,
-        terms: &[Term],
+        terms: impl IntoIterator<Item = &'a Term>,
     ) -> fmt::Result {
         write!(f, "({operator}")?;
-        if !terms.is_empty() {
-            f.write_str(" ")?;
-            self.fmt_terms(f, terms, " ")?;
+        for term in terms {
+            write!(f, " {}", self.child(term))?;
         }
         f.write_str(")")
-    }
-
-    fn fmt_binary_application(
-        &self,
-        f: &mut fmt::Formatter<'_>,
-        operator: &str,
-        left: &Term,
-        right: &Term,
-    ) -> fmt::Result {
-        write!(
-            f,
-            "({operator} {} {})",
-            SmtTerm {
-                term: left,
-                symbol_table: self.symbol_table,
-            },
-            SmtTerm {
-                term: right,
-                symbol_table: self.symbol_table,
-            }
-        )
-    }
-
-    fn fmt_ternary_application(
-        &self,
-        f: &mut fmt::Formatter<'_>,
-        operator: &str,
-        first: &Term,
-        second: &Term,
-        third: &Term,
-    ) -> fmt::Result {
-        write!(
-            f,
-            "({operator} {} {} {})",
-            SmtTerm {
-                term: first,
-                symbol_table: self.symbol_table,
-            },
-            SmtTerm {
-                term: second,
-                symbol_table: self.symbol_table,
-            },
-            SmtTerm {
-                term: third,
-                symbol_table: self.symbol_table,
-            }
-        )
     }
 }
 
@@ -420,9 +322,8 @@ impl fmt::Display for SmtTerm<'_> {
             App(qid, terms, sort) => {
                 f.write_str("(")?;
                 self.fmt_identifier(f, qid, sort.as_ref())?;
-                if !terms.is_empty() {
-                    f.write_str(" ")?;
-                    self.fmt_terms(f, terms, " ")?;
+                for term in terms {
+                    write!(f, " {}", self.child(term))?;
                 }
                 f.write_str(")")
             }
@@ -432,24 +333,9 @@ impl fmt::Display for SmtTerm<'_> {
                     if index > 0 {
                         f.write_str(" ")?;
                     }
-                    write!(
-                        f,
-                        "({} {})",
-                        binding.0.sym_quote(),
-                        SmtTerm {
-                            term: &binding.2,
-                            symbol_table: self.symbol_table,
-                        }
-                    )?;
+                    write!(f, "({} {})", binding.0.sym_quote(), self.child(&binding.2))?;
                 }
-                write!(
-                    f,
-                    ") {})",
-                    SmtTerm {
-                        term: body,
-                        symbol_table: self.symbol_table,
-                    }
-                )
+                write!(f, ") {})", self.child(body))
             }
             Exists(bindings, body) | Forall(bindings, body) => {
                 let binder = if matches!(self.term.repr(), Exists(..)) {
@@ -464,55 +350,26 @@ impl fmt::Display for SmtTerm<'_> {
                     }
                     write!(f, "{binding}")?;
                 }
-                write!(
-                    f,
-                    ") {})",
-                    SmtTerm {
-                        term: body,
-                        symbol_table: self.symbol_table,
-                    }
-                )
+                write!(f, ") {})", self.child(body))
             }
             Matching(scrutinee, arms) => {
-                write!(
-                    f,
-                    "(match {} (",
-                    SmtTerm {
-                        term: scrutinee,
-                        symbol_table: self.symbol_table,
-                    }
-                )?;
+                write!(f, "(match {} (", self.child(scrutinee))?;
                 for (index, arm) in arms.iter().enumerate() {
                     if index > 0 {
                         f.write_str(" ")?;
                     }
-                    write!(
-                        f,
-                        "({} {})",
-                        arm.pattern,
-                        SmtTerm {
-                            term: &arm.body,
-                            symbol_table: self.symbol_table,
-                        }
-                    )?;
+                    write!(f, "({} {})", arm.pattern, self.child(&arm.body))?;
                 }
                 f.write_str("))")
             }
             Annotated(term, attributes) => {
-                write!(
-                    f,
-                    "(! {}",
-                    SmtTerm {
-                        term,
-                        symbol_table: self.symbol_table,
-                    }
-                )?;
+                write!(f, "(! {}", self.child(term))?;
                 for attribute in attributes {
                     f.write_str(" ")?;
                     match attribute {
                         Attribute::Pattern(terms) => {
                             f.write_str(":pattern (")?;
-                            self.fmt_terms(f, terms, " ")?;
+                            self.fmt_terms(f, terms)?;
                             f.write_str(")")?;
                         }
                         _ => write!(f, "{attribute}")?,
@@ -520,26 +377,17 @@ impl fmt::Display for SmtTerm<'_> {
                 }
                 f.write_str(")")
             }
-            Eq(left, right) => self.fmt_binary_application(f, "=", left, right),
+            Eq(left, right) => self.fmt_application(f, "=", [left, right]),
             Distinct(terms) => self.fmt_application(f, "distinct", terms),
             And(terms) => self.fmt_application(f, "and", terms),
             Or(terms) => self.fmt_application(f, "or", terms),
             Xor(terms) => self.fmt_application(f, "xor", terms),
             Implies(premises, conclusion) => {
-                f.write_str("(=> ")?;
-                self.fmt_terms(f, premises, " ")?;
-                write!(
-                    f,
-                    " {})",
-                    SmtTerm {
-                        term: conclusion,
-                        symbol_table: self.symbol_table,
-                    }
-                )
+                self.fmt_application(f, "=>", premises.iter().chain(std::iter::once(conclusion)))
             }
-            Not(term) => self.fmt_application(f, "not", std::slice::from_ref(term)),
+            Not(term) => self.fmt_application(f, "not", [term]),
             Ite(condition, then_term, else_term) => {
-                self.fmt_ternary_application(f, "ite", condition, then_term, else_term)
+                self.fmt_application(f, "ite", [condition, then_term, else_term])
             }
         }
     }
@@ -615,10 +463,6 @@ impl SMTProofTracer {
         }
     }
 
-    pub fn cancel_expected_original_clause_callback(&mut self, clause: &[i32]) {
-        self.consume_expected_original_clause(clause);
-    }
-
     ////////////////////////////////////////////////////////////////////////////
 
     // TODO: If each literal is only needed once, then they can be removed from the hashmap
@@ -647,12 +491,11 @@ impl SMTProofTracer {
         self.get_lit_info(literal).is_some() || self.get_lit_info(-literal).is_some()
     }
 
-    /// Pushes literal definitions
-    /// If one of the literals is not in terms list, then this clause is useless and we return false
+    /// Emits definitions for the literals in `clause`.
     fn introduce_literals(
         &self,
         literals_defined: &mut HashSet<i32>,
-        clause: &Vec<i32>,
+        clause: &[i32],
         out: &mut String,
     ) {
         let mut temp_output = String::new();
@@ -793,11 +636,10 @@ impl SMTProofTracer {
                         clause,
                         skolem_vars
                     );
-                    // The declaration refers to the parent eDRAT literal, while
-                    // the child literal may refer to the fresh Skolem symbols.
+                    // Introduce the parent before declaring symbols used by the child.
                     self.introduce_literals(
                         &mut literals_defined,
-                        &vec![*parent_term],
+                        std::slice::from_ref(parent_term),
                         &mut output,
                     );
                     for (i, var) in skolem_vars.iter().enumerate() {
@@ -830,6 +672,23 @@ mod tests {
     use yaspar_ir::ast::{ACommand, Context, Typecheck};
     use yaspar_ir::untyped::UntypedAst;
 
+    fn parse_assertion(script: &str) -> (Context, Term) {
+        let mut context = Context::new();
+        let commands = UntypedAst
+            .parse_script_str(script)
+            .unwrap()
+            .type_check(&mut context)
+            .unwrap();
+        let assertion = commands
+            .iter()
+            .find_map(|command| match command.repr() {
+                ACommand::Assert(term) => Some(term.clone()),
+                _ => None,
+            })
+            .unwrap();
+        (context, assertion)
+    }
+
     #[test]
     fn ascribes_polymorphic_datatype_constructors() {
         let script = "\
@@ -838,19 +697,7 @@ mod tests {
 (define-fun empty () (Option Val) (as None (Option Val)))
 (assert ((_ is None) (as None (Option Val))))
 ";
-        let mut context = Context::new();
-        let commands = UntypedAst
-            .parse_script_str(script)
-            .unwrap()
-            .type_check(&mut context)
-            .unwrap();
-        let term = commands
-            .iter()
-            .find_map(|command| match command.repr() {
-                ACommand::Assert(term) => Some(term.clone()),
-                _ => None,
-            })
-            .unwrap();
+        let (context, term) = parse_assertion(script);
 
         let mut tracer = SMTProofTracer::new(
             context.expose_sorts().clone(),
@@ -867,56 +714,34 @@ mod tests {
     #[test]
     fn orders_defined_functions_by_dependency() {
         let script = "\
-(declare-fun a () Int)
-(define-fun f ((x Int)) Int (+ x a))
-(define-fun g ((x Int)) Int (f (f x)))
-(assert (= (g 0) 2))
+(declare-fun base () Int)
+(define-fun z ((x Int)) Int (+ x base))
+(define-fun a ((x Int)) Int (z (z x)))
 ";
         let mut context = Context::new();
-        let commands = UntypedAst
+        UntypedAst
             .parse_script_str(script)
             .unwrap()
             .type_check(&mut context)
-            .unwrap();
-        let term = commands
-            .iter()
-            .find_map(|command| match command.repr() {
-                ACommand::Assert(term) => Some(term.clone()),
-                _ => None,
-            })
             .unwrap();
 
         let mut tracer = SMTProofTracer::new(
             context.expose_sorts().clone(),
             context.expose_symbol_table().clone(),
         );
-        tracer.register_term(1, &term, true);
-        tracer.add_original_clause(&vec![1]);
 
         let proof = tracer.generate_edrat();
-        let declaration = proof.find("(declare-fun a () Int)").unwrap();
-        let f_definition = proof.find("(define-fun f ").unwrap();
-        let g_definition = proof.find("(define-fun g ").unwrap();
-        assert!(declaration < f_definition);
-        assert!(f_definition < g_definition);
+        let declaration = proof.find("(declare-fun base () Int)").unwrap();
+        let dependency = proof.find("(define-fun z ").unwrap();
+        let dependent = proof.find("(define-fun a ").unwrap();
+        assert!(declaration < dependency);
+        assert!(dependency < dependent);
     }
 
     #[test]
     fn introduces_skolem_parent_before_declaration_and_child_after() {
         let script = "(assert (exists ((x Int)) (> x 0)))";
-        let mut context = Context::new();
-        let commands = UntypedAst
-            .parse_script_str(script)
-            .unwrap()
-            .type_check(&mut context)
-            .unwrap();
-        let parent = commands
-            .iter()
-            .find_map(|command| match command.repr() {
-                ACommand::Assert(term) => Some(term.clone()),
-                _ => None,
-            })
-            .unwrap();
+        let (mut context, parent) = parse_assertion(script);
         let (child, skolem_vars) = skolemize(&parent, &mut context, true);
         let skolem_name = skolem_vars[0].0.to_string();
 

--- a/src/proof/proof_tracer.rs
+++ b/src/proof/proof_tracer.rs
@@ -7,6 +7,7 @@ use crate::debug_println;
 use crate::proof::{ProofStep, ProofStepType, Theory};
 use core::panic;
 use std::cmp::Eq;
+use std::collections::hash_map::Entry;
 use std::collections::{HashMap, HashSet};
 use std::hash::Hash;
 use std::ops::Neg;
@@ -20,7 +21,7 @@ pub struct SMTProofTracer {
     sorts: HashMap<Str, SortDef>,
     symbol_table: HashMap<Str, Vec<(Sig, FunctionMeta)>>,
     instantiations_for_smt2: Vec<(Term, Vec<(Term, bool)>)>,
-    expected_original_clauses: HashMap<Vec<i32>, usize>,
+    registered_clause_callbacks: HashMap<Vec<i32>, usize>,
     /// Number of clauses deleted by CaDiCaL (for stats)
     pub(crate) deleted_clauses: u64,
 }
@@ -54,7 +55,7 @@ where
     false
 }
 
-fn normalized_clause(clause: &[i32]) -> Vec<i32> {
+fn normalize_clause(clause: &[i32]) -> Vec<i32> {
     let mut normalized = clause.to_vec();
     normalized.sort_unstable();
     normalized.dedup();
@@ -230,7 +231,7 @@ impl SMTProofTracer {
             sorts,
             symbol_table,
             instantiations_for_smt2: Vec::new(),
-            expected_original_clauses: HashMap::new(),
+            registered_clause_callbacks: HashMap::new(),
             deleted_clauses: 0,
         }
     }
@@ -268,23 +269,25 @@ impl SMTProofTracer {
         self.push_step(clause, ProofStepType::TheoryClause(theory));
     }
 
-    pub fn expect_original_clause_callback(&mut self, clause: &[i32]) {
-        let clause = normalized_clause(clause);
-        *self.expected_original_clauses.entry(clause).or_default() += 1;
+    pub fn register_clause_for_cadical_callback(&mut self, clause: &[i32]) {
+        let clause = normalize_clause(clause);
+        *self.registered_clause_callbacks.entry(clause).or_default() += 1;
     }
 
-    pub fn consume_expected_original_clause(&mut self, clause: &[i32]) -> bool {
-        let clause = normalized_clause(clause);
-        match self.expected_original_clauses.get_mut(&clause) {
-            Some(count) if *count > 1 => {
-                *count -= 1;
+    pub fn consume_clause_callback_registration(&mut self, clause: &[i32]) -> bool {
+        match self
+            .registered_clause_callbacks
+            .entry(normalize_clause(clause))
+        {
+            Entry::Occupied(mut entry) => {
+                if *entry.get() == 1 {
+                    entry.remove();
+                } else {
+                    *entry.get_mut() -= 1;
+                }
                 true
             }
-            Some(_) => {
-                self.expected_original_clauses.remove(&clause);
-                true
-            }
-            None => false,
+            Entry::Vacant(_) => false,
         }
     }
 

--- a/src/proof/proof_tracer.rs
+++ b/src/proof/proof_tracer.rs
@@ -190,8 +190,8 @@ fn format_function_declarations(symbol_table: &HashMap<Str, Vec<(Sig, FunctionMe
     let mut definitions = Vec::new();
     for symbol in symbols {
         if matches!(
-            symbol_table.get(symbol).map(Vec::as_slice),
-            Some([(Sig::ParFunc(..), FunctionMeta::Defined(_))])
+            symbol_table[symbol].as_slice(),
+            [(Sig::ParFunc(..), FunctionMeta::Defined(_))]
         ) {
             definitions.push(symbol);
         } else {
@@ -203,10 +203,6 @@ fn format_function_declarations(symbol_table: &HashMap<Str, Vec<(Sig, FunctionMe
         }
     }
 
-    let defined_symbols = definitions
-        .iter()
-        .map(|symbol| (*symbol).clone())
-        .collect::<HashSet<_>>();
     let dependencies = definitions
         .iter()
         .map(|symbol| {
@@ -224,7 +220,7 @@ fn format_function_declarations(symbol_table: &HashMap<Str, Vec<(Sig, FunctionMe
     while !definitions.is_empty() {
         let Some(index) = definitions.iter().position(|symbol| {
             dependencies[*symbol].iter().all(|dependency| {
-                !defined_symbols.contains(dependency) || emitted.contains(dependency)
+                !dependencies.contains_key(dependency) || emitted.contains(dependency)
             })
         }) else {
             panic!("We do not handle recursive function definitions!");
@@ -412,34 +408,34 @@ impl SMTProofTracer {
 
     ////////////////////////////////////////////////////////////////////////////
 
-    pub fn push_step(&mut self, clause: &Vec<i32>, typ: ProofStepType) {
+    pub fn push_step(&mut self, clause: &[i32], typ: ProofStepType) {
         if !is_tautology(clause) {
             self.proof_steps.push(ProofStep {
-                clause: clause.clone(),
+                clause: clause.to_vec(),
                 typ,
             })
         }
     }
 
-    pub fn push_steps(&mut self, clauses: &Vec<Vec<i32>>, typ: ProofStepType) {
+    pub fn push_steps(&mut self, clauses: &[Vec<i32>], typ: ProofStepType) {
         for clause in clauses {
             self.push_step(clause, typ.clone());
         }
     }
 
-    pub fn add_original_clause(&mut self, clause: &Vec<i32>) {
+    pub fn add_original_clause(&mut self, clause: &[i32]) {
         self.push_step(clause, ProofStepType::OriginalClause);
     }
 
-    pub fn add_sat_clause(&mut self, clause: &Vec<i32>) {
+    pub fn add_sat_clause(&mut self, clause: &[i32]) {
         self.push_step(clause, ProofStepType::SATClause);
     }
 
-    pub fn record_deletion(&mut self, clause: &Vec<i32>) {
+    pub fn record_deletion(&mut self, clause: &[i32]) {
         self.push_step(clause, ProofStepType::Deletion);
     }
 
-    pub fn add_theory_clause(&mut self, clause: &Vec<i32>, theory: Theory) {
+    pub fn add_theory_clause(&mut self, clause: &[i32], theory: Theory) {
         self.push_step(clause, ProofStepType::TheoryClause(theory));
     }
 
@@ -498,7 +494,6 @@ impl SMTProofTracer {
         clause: &[i32],
         out: &mut String,
     ) {
-        let mut temp_output = String::new();
         for &lit in clause {
             debug_println!(12, 2, "Introducing the literal {}", lit);
             if let Some((lit, _id, term, polarity)) = self.get_lit_info(lit) {
@@ -515,7 +510,7 @@ impl SMTProofTracer {
                 );
 
                 if !literals_defined.contains(&lit) {
-                    temp_output.push_str(&format!(
+                    out.push_str(&format!(
                         "(edrat-literal {} {})\n",
                         lit,
                         SmtTerm {
@@ -532,7 +527,6 @@ impl SMTProofTracer {
                 );
             }
         }
-        out.push_str(&temp_output);
     }
 
     ////////////////////////////////////////////////////////////////////////////
@@ -704,7 +698,7 @@ mod tests {
             context.expose_symbol_table().clone(),
         );
         tracer.register_term(1, &term, true);
-        tracer.add_original_clause(&vec![1]);
+        tracer.add_original_clause(&[1]);
 
         let proof = tracer.generate_edrat();
         assert!(proof.contains("(define-fun empty () (Option Val) (as None (Option Val)))"));
@@ -752,7 +746,7 @@ mod tests {
         tracer.register_term(1, &parent, true);
         tracer.register_term(2, &child, true);
         tracer.push_step(
-            &vec![-1, 2],
+            &[-1, 2],
             ProofStepType::Skolemization {
                 parent_term: 1,
                 skolem_vars,


### PR DESCRIPTION
*Issue #, if available:* #112

*Description of changes:* This fixes gaps in eDRAT proof production so Valido can check Sundance proofs with an external theory solver.

1. Records otherwise-untracked CaDiCaL original-clause and constraint callbacks as background theory clauses. Theory-specific provenance remains follow-up #186.
2. Tracks expected original-clause callbacks by normalized clause to avoid duplicate or misclassified proof steps.
3. Generates complete SMT-LIB preludes, including dependency-ordered `define-fun` commands and quoted symbols.
4. Preserves required sort ascriptions for polymorphic datatype constructors.
5. Emits each Skolem parent literal before `declare-skolem`, and the child literal afterward.
6. Adds focused regression tests for callback classification, SMT-LIB formatting, dependency ordering, and Skolem ordering.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.