### PR TITLE
Unset rustflags target-cpu to fix CI

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,5 +1,8 @@
 [env]
 Z3_SYS_BUNDLED_DIR_OVERRIDE = { value = "z3", relative = true }
 
-[target.x86_64-unknown-linux-gnu]
-rustflags = ["-C", "target-cpu=native"]
+# Do NOT set `-C target-cpu=native` here. GitHub CI caches `target/` across jobs
+# (Swatinem/rust-cache), and the cache key does not include the runner's CPU model.
+# A cache built on a runner with AVX-512 then restored onto an older runner yields
+# SIGILL (illegal instruction) at test time. For a local speedup, opt in per-shell
+# instead: `RUSTFLAGS="-C target-cpu=native" cargo build --release`.


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

In an effort to fix repeated SIGILL problems on GitHub runners, this change removes the flag from .cargo/config.toml:4, replacing it with a comment explaining why it must not come back and how to opt in locally.

  Verified by disassembling before/after test binaries:

| Binary  | %zmm/vpternlog instructions |
| ------------- | ------------- |
| Before fix  | 11,398  |
| After fix  | 0  |


```
  cargo test --release --no-default-features --lib → 155 passed, 0 failed.
```

----
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
