### PR TITLE
[draft] Fix egraph-ID panic on Boolean bridge literals

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ bundled-z3 = ["z3-solver", "z3/bundled"]
 local-z3 = ["z3-solver"]
 
 [dependencies]
-yaspar-ir = "=2.7.5"
+yaspar-ir = { version = "=2.7.6", features = ["no-pattern"] }
 sat-interface = "0.1.1"
 # Pin the elevate fork until upstream cadical-sys exposes CaDiCaL's elevate option.
 cadical-sys = { git = "https://github.com/amarshah1/cadical-sys.git", rev = "2f234ec95dd36ca74057691cf2fd4e8766a3c40f" }

--- a/src/quantifiers/mod.rs
+++ b/src/quantifiers/mod.rs
@@ -3,3 +3,4 @@
 
 pub mod quantifier;
 pub mod skolem;
+pub mod trigger_inference;

--- a/src/quantifiers/trigger_inference.rs
+++ b/src/quantifiers/trigger_inference.rs
@@ -1,0 +1,261 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Automatic trigger (pattern) inference for quantifiers that carry no
+//! `:pattern` annotation.
+//!
+//! Boogie/Dafny and F* emit many quantified axioms without explicit triggers
+//! and rely on the solver to infer them (Z3/Simplify) or to fall back to MBQI.
+//! Sundance only does pattern-based (e-matching) instantiation, so without a
+//! trigger such a quantifier cannot be instantiated at all — historically we
+//! `panic!`ed on it.
+//!
+//! This module implements the classic Simplify/Z3 auto-trigger algorithm
+//! (Detlefs, Nelson & Saxe 2005, §5; see also Leino & Pit-Claudel, CAV 2016):
+//!
+//!   1. Collect *candidate* subterms of the body: applications whose head is an
+//!      **uninterpreted** function/predicate and that contain at least one bound
+//!      variable. Interpreted symbols (`=`, `and`, `+`, `<`, `ite`, …) are never
+//!      admissible pattern heads — the theory solvers already reason about them,
+//!      and e-matching on them explodes.
+//!   2. If any candidates jointly with the *fewest* function symbols cover all
+//!      bound variables on their own, emit them as **single-term triggers**
+//!      (preferring shallow/minimal terms).
+//!   3. Otherwise greedily assemble a **multi-pattern**: a minimal set of
+//!      candidates whose covered-variable sets union to all bound variables.
+//!   4. If some bound variable never appears under any uninterpreted symbol, no
+//!      valid trigger exists; we return `None` and the caller decides the
+//!      fallback (skip the quantifier — sound for unsat, incomplete otherwise).
+
+use std::collections::BTreeSet;
+
+use yaspar_ir::ast::ATerm::*;
+use yaspar_ir::ast::{Repr, Term};
+
+/// A candidate trigger term together with the set of bound-variable names it
+/// covers and a rough size (number of nested applications), used to prefer
+/// shallow triggers.
+struct Candidate {
+    term: Term,
+    vars: BTreeSet<String>,
+    depth: usize,
+}
+
+/// Returns `true` if `name` is an interpreted/theory symbol that must never be
+/// used as a pattern head. Uninterpreted-function heads (everything else) are
+/// admissible. Arithmetic operators appear as `App(name)` in this IR, so they
+/// are rejected here by name.
+fn is_interpreted_head(name: &str) -> bool {
+    matches!(
+        name,
+        "=" | "distinct"
+            | "and"
+            | "or"
+            | "not"
+            | "=>"
+            | "xor"
+            | "ite"
+            | "+"
+            | "-"
+            | "*"
+            | "/"
+            | "div"
+            | "mod"
+            | "rem"
+            | "abs"
+            | "<"
+            | "<="
+            | ">"
+            | ">="
+            | "true"
+            | "false"
+    )
+}
+
+/// Recursively collect candidate trigger subterms of `body`.
+///
+/// `bound` is the set of bound-variable names of the quantifier. A subterm is a
+/// candidate iff it is an application with an uninterpreted head and it contains
+/// at least one bound variable. We collect candidates from every level so that
+/// step 2/3 can prefer the shallowest covering terms.
+fn collect_candidates(term: &Term, bound: &BTreeSet<String>, out: &mut Vec<Candidate>) {
+    // Compute the bound variables occurring in `term` and recurse into children.
+    let vars = free_bound_vars(term, bound);
+
+    match term.repr() {
+        App(func, args, _) => {
+            let name = func.id_str().get().clone();
+            // Recurse into arguments first (collect nested candidates too).
+            for a in args.iter() {
+                collect_candidates(a, bound, out);
+            }
+            if !is_interpreted_head(&name) && !vars.is_empty() {
+                out.push(Candidate {
+                    term: term.clone(),
+                    vars,
+                    depth: term_depth(term),
+                });
+            }
+        }
+        // Interpreted logical/relational connectives: never candidates
+        // themselves, but their subterms can be.
+        Eq(l, r) => {
+            collect_candidates(l, bound, out);
+            collect_candidates(r, bound, out);
+        }
+        Not(t) => collect_candidates(t, bound, out),
+        Ite(c, t, e) => {
+            collect_candidates(c, bound, out);
+            collect_candidates(t, bound, out);
+            collect_candidates(e, bound, out);
+        }
+        And(items) | Or(items) | Distinct(items) | Xor(items) => {
+            for it in items.iter() {
+                collect_candidates(it, bound, out);
+            }
+        }
+        Implies(ante, cons) => {
+            for a in ante.iter() {
+                collect_candidates(a, bound, out);
+            }
+            collect_candidates(cons, bound, out);
+        }
+        // Do not descend into nested quantifiers: their bound variables shadow
+        // ours and their triggers are handled when they are registered.
+        Forall(..) | Exists(..) => {}
+        Annotated(inner, _) => collect_candidates(inner, bound, out),
+        Let(..) => {} // Lets are inlined before registration.
+        _ => {}
+    }
+}
+
+/// The subset of `bound` variable names that occur free in `term`
+/// (i.e. not shadowed by a nested binder).
+fn free_bound_vars(term: &Term, bound: &BTreeSet<String>) -> BTreeSet<String> {
+    let mut set = BTreeSet::new();
+    collect_bound_vars(term, bound, &mut set);
+    set
+}
+
+fn collect_bound_vars(term: &Term, bound: &BTreeSet<String>, out: &mut BTreeSet<String>) {
+    match term.repr() {
+        Local(local) => {
+            let name = local.symbol.get().clone();
+            if bound.contains(&name) {
+                out.insert(name);
+            }
+        }
+        App(_, args, _) => {
+            for a in args.iter() {
+                collect_bound_vars(a, bound, out);
+            }
+        }
+        Eq(l, r) => {
+            collect_bound_vars(l, bound, out);
+            collect_bound_vars(r, bound, out);
+        }
+        Not(t) => collect_bound_vars(t, bound, out),
+        Ite(c, t, e) => {
+            collect_bound_vars(c, bound, out);
+            collect_bound_vars(t, bound, out);
+            collect_bound_vars(e, bound, out);
+        }
+        And(items) | Or(items) | Distinct(items) | Xor(items) => {
+            for it in items.iter() {
+                collect_bound_vars(it, bound, out);
+            }
+        }
+        Implies(ante, cons) => {
+            for a in ante.iter() {
+                collect_bound_vars(a, bound, out);
+            }
+            collect_bound_vars(cons, bound, out);
+        }
+        Annotated(inner, _) => collect_bound_vars(inner, bound, out),
+        // Nested binders shadow; conservatively don't descend (their inner
+        // variables are not ours, and any of our variables used inside would
+        // still be covered by an enclosing candidate).
+        Forall(..) | Exists(..) => {}
+        _ => {}
+    }
+}
+
+/// Rough structural depth of a term (max nesting of applications), used to
+/// prefer shallow triggers.
+fn term_depth(term: &Term) -> usize {
+    match term.repr() {
+        App(_, args, _) => 1 + args.iter().map(term_depth).max().unwrap_or(0),
+        Annotated(inner, _) => term_depth(inner),
+        _ => 0,
+    }
+}
+
+/// Infer a set of triggers (multi-patterns) for a quantifier body.
+///
+/// `body` is the (de-annotated) body term; `bound_names` are the names of the
+/// quantifier's bound variables. Returns a list of multi-patterns, where each
+/// multi-pattern is a conjunctive list of trigger terms (matching the
+/// `Vec<Vec<_>>` shape used by the rest of the solver): the outer list is
+/// disjunctive (any multi-pattern may fire), the inner list conjunctive.
+///
+/// Returns `None` if no admissible trigger set covers all bound variables.
+pub fn infer_triggers(body: &Term, bound_names: &[String]) -> Option<Vec<Vec<Term>>> {
+    let bound: BTreeSet<String> = bound_names.iter().cloned().collect();
+    if bound.is_empty() {
+        // Ground body under a (degenerate) quantifier: nothing to instantiate on.
+        return None;
+    }
+
+    let mut candidates: Vec<Candidate> = Vec::new();
+    collect_candidates(body, &bound, &mut candidates);
+
+    if candidates.is_empty() {
+        return None;
+    }
+
+    // Deduplicate candidates by printed form, keeping the shallowest.
+    candidates.sort_by(|a, b| {
+        a.depth
+            .cmp(&b.depth)
+            .then(a.term.to_string().cmp(&b.term.to_string()))
+    });
+    let mut seen = BTreeSet::new();
+    candidates.retain(|c| seen.insert(c.term.to_string()));
+
+    // Step 2: single-term triggers that cover ALL bound variables on their own.
+    // Prefer the shallowest; emit each as its own (disjunctive) single trigger.
+    let full_singletons: Vec<&Candidate> = candidates.iter().filter(|c| c.vars == bound).collect();
+    if !full_singletons.is_empty() {
+        // Use the shallowest single trigger. (Emitting just one keeps the search
+        // space small; additional ones rarely help and can cause redundant
+        // instantiations.)
+        let best = full_singletons[0];
+        return Some(vec![vec![best.term.clone()]]);
+    }
+
+    // Step 3: greedy minimal multi-pattern. Repeatedly pick the candidate that
+    // covers the most still-uncovered bound variables (ties broken by shallower
+    // depth), until all are covered or no progress can be made.
+    let mut uncovered: BTreeSet<String> = bound.clone();
+    let mut chosen: Vec<Term> = Vec::new();
+    while !uncovered.is_empty() {
+        let best = candidates
+            .iter()
+            .map(|c| (c.vars.intersection(&uncovered).count(), c))
+            .filter(|(gain, _)| *gain > 0)
+            .max_by(|(g1, c1), (g2, c2)| g1.cmp(g2).then(c2.depth.cmp(&c1.depth)));
+
+        match best {
+            Some((_, cand)) => {
+                for v in &cand.vars {
+                    uncovered.remove(v);
+                }
+                chosen.push(cand.term.clone());
+            }
+            // No candidate covers any remaining variable: uncoverable.
+            None => return None,
+        }
+    }
+
+    Some(vec![chosen])
+}

--- a/src/quantifiers/trigger_inference.rs
+++ b/src/quantifiers/trigger_inference.rs
@@ -186,13 +186,19 @@ fn term_depth(term: &Term) -> usize {
 /// Infer a set of triggers (multi-patterns) for a quantifier body.
 ///
 /// `body` is the (de-annotated) body term; `bound_names` are the names of the
-/// quantifier's bound variables. Returns a list of multi-patterns, where each
-/// multi-pattern is a conjunctive list of trigger terms (matching the
-/// `Vec<Vec<_>>` shape used by the rest of the solver): the outer list is
-/// disjunctive (any multi-pattern may fire), the inner list conjunctive.
+/// quantifier's bound variables. `excluded` holds the terms named by any
+/// `:no-pattern` annotations — anti-trigger hints that must never be used as a
+/// trigger. Returns a list of multi-patterns, where each multi-pattern is a
+/// conjunctive list of trigger terms (matching the `Vec<Vec<_>>` shape used by
+/// the rest of the solver): the outer list is disjunctive (any multi-pattern
+/// may fire), the inner list conjunctive.
 ///
 /// Returns `None` if no admissible trigger set covers all bound variables.
-pub fn infer_triggers(body: &Term, bound_names: &[String]) -> Option<Vec<Vec<Term>>> {
+pub fn infer_triggers(
+    body: &Term,
+    bound_names: &[String],
+    excluded: &[Term],
+) -> Option<Vec<Vec<Term>>> {
     let bound: BTreeSet<String> = bound_names.iter().cloned().collect();
     if bound.is_empty() {
         // Ground body under a (degenerate) quantifier: nothing to instantiate on.
@@ -201,6 +207,12 @@ pub fn infer_triggers(body: &Term, bound_names: &[String]) -> Option<Vec<Vec<Ter
 
     let mut candidates: Vec<Candidate> = Vec::new();
     collect_candidates(body, &bound, &mut candidates);
+
+    // Drop `:no-pattern` terms: they are explicitly forbidden as triggers.
+    if !excluded.is_empty() {
+        let excluded: BTreeSet<String> = excluded.iter().map(|t| t.to_string()).collect();
+        candidates.retain(|c| !excluded.contains(&c.term.to_string()));
+    }
 
     if candidates.is_empty() {
         return None;

--- a/src/quantifiers/trigger_inference.rs
+++ b/src/quantifiers/trigger_inference.rs
@@ -1,17 +1,11 @@
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-//! Automatic trigger (pattern) inference for quantifiers that carry no
-//! `:pattern` annotation.
+//! Automatic trigger (pattern) inference for quantifiers with no `:pattern`.
 //!
-//! Boogie/Dafny and F* emit many quantified axioms without explicit triggers
-//! and rely on the solver to infer them (Z3/Simplify) or to fall back to MBQI.
-//! Sundance only does pattern-based (e-matching) instantiation, so without a
-//! trigger such a quantifier cannot be instantiated at all — historically we
-//! `panic!`ed on it.
-//!
-//! This module implements the classic Simplify/Z3 auto-trigger algorithm
-//! (Detlefs, Nelson & Saxe 2005, §5; see also Leino & Pit-Claudel, CAV 2016):
+//! Sundance only instantiates by e-matching, so an untriggered `forall` needs
+//! an inferred trigger. This implements the Simplify/Z3 auto-trigger algorithm
+//! (Detlefs, Nelson & Saxe 2005, §5):
 //!
 //!   1. Collect *candidate* subterms of the body: applications whose head is an
 //!      **uninterpreted** function/predicate and that contain at least one bound
@@ -24,8 +18,7 @@
 //!   3. Otherwise greedily assemble a **multi-pattern**: a minimal set of
 //!      candidates whose covered-variable sets union to all bound variables.
 //!   4. If some bound variable never appears under any uninterpreted symbol, no
-//!      valid trigger exists; we return `None` and the caller decides the
-//!      fallback (skip the quantifier — sound for unsat, incomplete otherwise).
+//!      valid trigger exists and we return `None`.
 
 use std::collections::BTreeSet;
 

--- a/src/solver_state.rs
+++ b/src/solver_state.rs
@@ -559,16 +559,13 @@ impl SolverState {
                         }
                     }
                 }
-                // If inference found nothing, `trigger_ids` stays empty: the
-                // quantifier simply won't be instantiated (sound for unsat,
-                // incomplete otherwise). The instantiation loop already handles
-                // the empty-trigger case gracefully.
+                // If inference still yields no usable trigger, we cannot
+                // instantiate this quantifier by e-matching. Rather than
+                // silently dropping it (which would risk an unsound/incomplete
+                // answer), fail loudly so the case is surfaced.
                 if trigger_ids.is_empty() {
-                    debug_println!(
-                        0,
-                        0,
-                        "Warning: could not infer a trigger for forall {term}; \
-                         it will not be instantiated"
+                    panic!(
+                        "Could not infer a trigger for untriggered forall: {term}"
                     );
                 }
             }

--- a/src/solver_state.rs
+++ b/src/solver_state.rs
@@ -70,9 +70,11 @@ fn get_subterms(term: &Term) -> (String, Vec<&Term>) {
                         }
                     }
                     (inner_term, patterns)
-                } else if let Forall(..) = term.repr() {
-                    panic!("Unannotated forall quantifier (no triggers): {term}")
                 } else {
+                    // Unannotated quantifier: no explicit pattern subterms.
+                    // For foralls, triggers are inferred at registration time
+                    // (see register_arithmetic_and_quantifier); here we only need
+                    // the body, so return it with no pattern subterms.
                     (middle_term, vec![])
                 };
             let mut subterms = vec![inner_term];
@@ -519,23 +521,57 @@ impl SolverState {
 
         // Quantifier registration
         if let Exists(sorted_vars, middle_term) | Forall(sorted_vars, middle_term) = term.repr() {
-            let (inner_term, trigger_ids) = if let Annotated(inner_term, attrs) = middle_term.repr()
-            {
-                let mut trigger_ids = vec![];
-                for attr in attrs.iter() {
-                    if let Attribute::Pattern(s_exprs) = attr {
+            let is_forall = matches!(term.repr(), Forall(..));
+
+            // Collect any explicit `:pattern` triggers and the de-annotated body.
+            let (inner_term, mut trigger_ids) =
+                if let Annotated(inner_term, attrs) = middle_term.repr() {
+                    let mut trigger_ids = vec![];
+                    for attr in attrs.iter() {
+                        if let Attribute::Pattern(s_exprs) = attr {
+                            let pattern_ids: Vec<crate::egraphs::repr::PatternId> =
+                                s_exprs.iter().map(|p| self.build_pattern(p)).collect();
+                            trigger_ids.push(pattern_ids);
+                        }
+                    }
+                    (inner_term.clone(), trigger_ids)
+                } else {
+                    (middle_term.clone(), vec![])
+                };
+
+            // Universally-quantified formulas are instantiated by e-matching, so
+            // they need at least one trigger. Boogie/Dafny and F* emit many
+            // axioms with no `:pattern` (they rely on Z3's auto-trigger inference
+            // + MBQI). When a forall arrives without triggers, infer them using
+            // the Simplify/Z3 algorithm rather than failing. Existentials are
+            // skolemized instead, so they need no triggers.
+            if is_forall && trigger_ids.is_empty() {
+                let bound_names: Vec<String> =
+                    sorted_vars.iter().map(|x| x.0.get().clone()).collect();
+                if let Some(multipatterns) =
+                    crate::quantifiers::trigger_inference::infer_triggers(&inner_term, &bound_names)
+                {
+                    for mp in multipatterns {
                         let pattern_ids: Vec<crate::egraphs::repr::PatternId> =
-                            s_exprs.iter().map(|p| self.build_pattern(p)).collect();
-                        trigger_ids.push(pattern_ids);
+                            mp.iter().map(|p| self.build_pattern(p)).collect();
+                        if !pattern_ids.is_empty() {
+                            trigger_ids.push(pattern_ids);
+                        }
                     }
                 }
-                (inner_term, trigger_ids)
-            } else if let Forall(..) = term.repr() {
-                panic!("Unannotated forall quantifier (no triggers): {term}")
-            } else {
-                // Unannotated existential (no triggers) — will be skolemized on assignment
-                (middle_term, vec![])
-            };
+                // If inference found nothing, `trigger_ids` stays empty: the
+                // quantifier simply won't be instantiated (sound for unsat,
+                // incomplete otherwise). The instantiation loop already handles
+                // the empty-trigger case gracefully.
+                if trigger_ids.is_empty() {
+                    debug_println!(
+                        0,
+                        0,
+                        "Warning: could not infer a trigger for forall {term}; \
+                         it will not be instantiated"
+                    );
+                }
+            }
 
             // Store quantifier body in terms_list (needed for substitution during instantiation)
             let body_uid = inner_term.uid();

--- a/src/solver_state.rs
+++ b/src/solver_state.rs
@@ -534,8 +534,8 @@ impl SolverState {
                                     s_exprs.iter().map(|p| self.build_pattern(p)).collect();
                                 trigger_ids.push(pattern_ids);
                             }
-                            Attribute::NoPattern(s_exprs) => {
-                                no_pattern_terms.extend(s_exprs.iter().cloned());
+                            Attribute::NoPattern(t) => {
+                                no_pattern_terms.push(t.clone());
                             }
                             _ => {}
                         }

--- a/src/solver_state.rs
+++ b/src/solver_state.rs
@@ -564,9 +564,7 @@ impl SolverState {
                 // silently dropping it (which would risk an unsound/incomplete
                 // answer), fail loudly so the case is surfaced.
                 if trigger_ids.is_empty() {
-                    panic!(
-                        "Could not infer a trigger for untriggered forall: {term}"
-                    );
+                    panic!("Could not infer a trigger for untriggered forall: {term}");
                 }
             }
 

--- a/src/solver_state.rs
+++ b/src/solver_state.rs
@@ -71,10 +71,8 @@ fn get_subterms(term: &Term) -> (String, Vec<&Term>) {
                     }
                     (inner_term, patterns)
                 } else {
-                    // Unannotated quantifier: no explicit pattern subterms.
-                    // For foralls, triggers are inferred at registration time
-                    // (see register_arithmetic_and_quantifier); here we only need
-                    // the body, so return it with no pattern subterms.
+                    // Unannotated quantifier: body only; triggers are inferred
+                    // at registration (see register_arithmetic_and_quantifier).
                     (middle_term, vec![])
                 };
             let mut subterms = vec![inner_term];
@@ -539,12 +537,9 @@ impl SolverState {
                     (middle_term.clone(), vec![])
                 };
 
-            // Universally-quantified formulas are instantiated by e-matching, so
-            // they need at least one trigger. Boogie/Dafny and F* emit many
-            // axioms with no `:pattern` (they rely on Z3's auto-trigger inference
-            // + MBQI). When a forall arrives without triggers, infer them using
-            // the Simplify/Z3 algorithm rather than failing. Existentials are
-            // skolemized instead, so they need no triggers.
+            // Foralls are instantiated by e-matching and need a trigger;
+            // infer one when none was given (see `trigger_inference`).
+            // Existentials are skolemized, so they need none.
             if is_forall && trigger_ids.is_empty() {
                 let bound_names: Vec<String> =
                     sorted_vars.iter().map(|x| x.0.get().clone()).collect();
@@ -559,10 +554,8 @@ impl SolverState {
                         }
                     }
                 }
-                // If inference still yields no usable trigger, we cannot
-                // instantiate this quantifier by e-matching. Rather than
-                // silently dropping it (which would risk an unsound/incomplete
-                // answer), fail loudly so the case is surfaced.
+                // No inferable trigger: fail loudly rather than silently drop
+                // the axiom (which could give an unsound/incomplete answer).
                 if trigger_ids.is_empty() {
                     panic!("Could not infer a trigger for untriggered forall: {term}");
                 }

--- a/src/solver_state.rs
+++ b/src/solver_state.rs
@@ -521,15 +521,23 @@ impl SolverState {
         if let Exists(sorted_vars, middle_term) | Forall(sorted_vars, middle_term) = term.repr() {
             let is_forall = matches!(term.repr(), Forall(..));
 
-            // Collect any explicit `:pattern` triggers and the de-annotated body.
+            // Collect explicit `:pattern` triggers, `:no-pattern` exclusions,
+            // and the de-annotated body.
+            let mut no_pattern_terms: Vec<Term> = vec![];
             let (inner_term, mut trigger_ids) =
                 if let Annotated(inner_term, attrs) = middle_term.repr() {
                     let mut trigger_ids = vec![];
                     for attr in attrs.iter() {
-                        if let Attribute::Pattern(s_exprs) = attr {
-                            let pattern_ids: Vec<crate::egraphs::repr::PatternId> =
-                                s_exprs.iter().map(|p| self.build_pattern(p)).collect();
-                            trigger_ids.push(pattern_ids);
+                        match attr {
+                            Attribute::Pattern(s_exprs) => {
+                                let pattern_ids: Vec<crate::egraphs::repr::PatternId> =
+                                    s_exprs.iter().map(|p| self.build_pattern(p)).collect();
+                                trigger_ids.push(pattern_ids);
+                            }
+                            Attribute::NoPattern(s_exprs) => {
+                                no_pattern_terms.extend(s_exprs.iter().cloned());
+                            }
+                            _ => {}
                         }
                     }
                     (inner_term.clone(), trigger_ids)
@@ -538,13 +546,18 @@ impl SolverState {
                 };
 
             // Foralls are instantiated by e-matching and need a trigger;
-            // infer one when none was given (see `trigger_inference`).
-            // Existentials are skolemized, so they need none.
+            // infer one when none was given, honoring any `:no-pattern`
+            // exclusions (see `trigger_inference`). Existentials are
+            // skolemized, so they need none.
             if is_forall && trigger_ids.is_empty() {
                 let bound_names: Vec<String> =
                     sorted_vars.iter().map(|x| x.0.get().clone()).collect();
                 if let Some(multipatterns) =
-                    crate::quantifiers::trigger_inference::infer_triggers(&inner_term, &bound_names)
+                    crate::quantifiers::trigger_inference::infer_triggers(
+                        &inner_term,
+                        &bound_names,
+                        &no_pattern_terms,
+                    )
                 {
                     for mp in multipatterns {
                         let pattern_ids: Vec<crate::egraphs::repr::PatternId> =

--- a/src/solver_state.rs
+++ b/src/solver_state.rs
@@ -324,6 +324,15 @@ impl SolverState {
             .unwrap_or_else(|| panic!("to_egraph_id: no egraph ID for solver uid {}", solver_uid))
     }
 
+    /// Like [`Self::to_egraph_id`] but returns `None` instead of panicking when
+    /// the term has no egraph ID. Some literals — e.g. the pre-NNF form of an
+    /// instantiated/skolemized quantifier body — get a SAT variable (via
+    /// [`Self::get_or_allocate_lit_for_term`]) as a Boolean bridge without being
+    /// registered in the egraph; their NNF form carries the theory content.
+    pub fn to_egraph_id_opt(&self, solver_uid: u64) -> Option<u32> {
+        self.id_map.get_by_left(&solver_uid).copied()
+    }
+
     /// Convert an egraph term ID to the corresponding solver UID.
     pub fn to_solver_uid(&self, egraph_id: u32) -> u64 {
         *self
@@ -659,8 +668,9 @@ pub fn process_assignment(
     let true_egraph_id = solver_state.to_egraph_id(solver_state.true_uid);
     let false_egraph_id = solver_state.to_egraph_id(solver_state.false_uid);
 
-    if let Some(t) = solver_state.cnf_cache.var_map_reverse.get(&lit) {
-        let egraph_t = solver_state.to_egraph_id(*t);
+    if let Some(t) = solver_state.cnf_cache.var_map_reverse.get(&lit).copied()
+        && let Some(egraph_t) = solver_state.to_egraph_id_opt(t)
+    {
         debug_println!(
             16,
             0,
@@ -683,8 +693,9 @@ pub fn process_assignment(
         }
     }
 
-    if let Some(t) = solver_state.cnf_cache.var_map_reverse.get(&-lit) {
-        let egraph_t = solver_state.to_egraph_id(*t);
+    if let Some(t) = solver_state.cnf_cache.var_map_reverse.get(&-lit).copied()
+        && let Some(egraph_t) = solver_state.to_egraph_id_opt(t)
+    {
         debug_println!(
             16,
             0,

--- a/tests/regression/expected_results.json
+++ b/tests/regression/expected_results.json
@@ -114,6 +114,8 @@
     "edge_cases_quantifiers/eclass_merge_after_backtrack11.smt2": "unsat",
     "edge_cases_quantifiers/eclass_merge_after_backtrack12.smt2": "unsat",
     "edge_cases_quantifiers/quantifier_ite_true_union_false.smt2": "unsat",
+    "edge_cases_quantifiers/no_pattern_excludes_trigger.smt2": "unsat",
+    "edge_cases_quantifiers/inferred_trigger_untriggered_forall.smt2": "unsat",
     "edge_cases_quantifiers/multipattern.smt2": "unsat",
     "edge_cases_quantifiers/multipattern2.smt2": "unsat",
     "edge_cases_quantifiers/multipattern3.smt2": "unsat",

--- a/tests/regression/smt_files/edge_cases_quantifiers/inferred_trigger_untriggered_forall.smt2
+++ b/tests/regression/smt_files/edge_cases_quantifiers/inferred_trigger_untriggered_forall.smt2
@@ -1,0 +1,6 @@
+; No :pattern given; trigger inference selects (p x), which fires on (p 5).
+(set-logic ALL)
+(declare-fun p (Int) Bool)
+(assert (forall ((x Int)) (p x)))
+(assert (not (p 5)))
+(check-sat)

--- a/tests/regression/smt_files/edge_cases_quantifiers/no_pattern_excludes_trigger.smt2
+++ b/tests/regression/smt_files/edge_cases_quantifiers/no_pattern_excludes_trigger.smt2
@@ -1,0 +1,10 @@
+; `:no-pattern (g x)` forbids (g x) as a trigger, so trigger inference must
+; instead pick (f x); it fires on (f 7) and instantiates x := 7 -> unsat.
+(set-logic ALL)
+(declare-fun f (Int) Int)
+(declare-fun g (Int) Int)
+(declare-fun p (Int) Bool)
+(assert (forall ((x Int)) (! (=> (p (f x)) (= (g x) 0)) :no-pattern (g x))))
+(assert (p (f 7)))
+(assert (not (= (g 7) 0)))
+(check-sat)


### PR DESCRIPTION
Fixes a `to_egraph_id: no egraph ID for solver uid` panic hit on the Dafny (d_komodo) benchmarks. Targets `pattern-inference`.

## Root cause

When a quantifier is instantiated or skolemized, the instance term is registered in the egraph in its **NNF form** (`insert_predecessor(&nnf_term)`), but a SAT literal is *also* allocated for the **raw, pre-NNF term** as a Boolean bridge (`get_or_allocate_lit_for_term`, in `quantifier.rs`) whenever `t.uid() != nnf_term.uid()`.

NNF rewriting changes the uid — e.g. `(=> true true)` becomes `(or (not true) true)` — so the raw term ends up in `var_map_reverse` (it has a SAT variable) but has **no `id_map` entry** (it was never registered in the egraph). When that bridge literal is later assigned, `process_assignment` looked up the term via `var_map_reverse` and called `to_egraph_id`, which panicked.

## Fix

- Add `to_egraph_id_opt`, returning `Option<u32>` instead of panicking.
- In `process_assignment`, guard both egraph-union sites with it: a literal whose term has no egraph ID is a pure Boolean bridge and carries no theory content (its NNF form does), so the union is safely skipped.

## Verification

- The originally-panicking d_komodo file now passes `:324` (it reaches a separate, pre-existing `lialp.rs:212` div/mod-with-non-constant-divisor limitation later — unrelated).
- 24-file d_komodo batch: **0 `:324` panics** (previously widespread); 1 solves `unsat`, 15 advance to the next blocker, none regress.
- Full regression suite passes (0 failures) — important since the fix is in the hot `process_assignment` path.

Draft pending review of the trigger-inference base (`pattern-inference`).