### PR TITLE
Include sort on parametric-datatype 0-ary constructors

### DIFF
--- a/src/datatypes/axioms.rs
+++ b/src/datatypes/axioms.rs
@@ -330,18 +330,9 @@ pub fn learn_ctor_selector_clauses(
             .collect();
     }
 
-    // A nullary constructor of a *parametric* datatype (e.g. `None : (Option Val)`) is a
-    // polymorphic identifier: printing it as a bare symbol produces SMT-LIB that fails to
-    // re-typecheck, because a polymorphic nullary identifier requires an explicit sort
-    // ascription. The ascription has to live *inside* the qualified identifier so that
-    // `Term::Global`'s printer emits `(as None (Option Val))` -- yaspar-ir does exactly this
-    // in its type checker (tc/app.rs tags the identifier via `with_sort` when the constructor
-    // needs non-trivial sort unification, i.e. when the datatype is parametric).
-    //
-    // A monomorphic nullary constructor (arity-0 result sort, e.g. an enum literal) needs no
-    // ascription, matching the type checker's empty-substitution case, so it keeps the simple
-    // identifier. Applied constructors and selectors are disambiguated by their arguments and
-    // likewise use the simple identifier.
+    // A nullary constructor of a parametric datatype (e.g. `None : (Option Val)`) must carry
+    // its sort on the identifier, else it prints as bare `None` and fails to re-typecheck.
+    // Monomorphic constructors (arity-0 sort) stay bare; applied ones are fixed by their args.
     let ctor_app = if selector_apps.is_empty() {
         let ctor_id = if sort.1.is_empty() {
             QualifiedIdentifier::simple(ctor_name.clone())

--- a/src/datatypes/axioms.rs
+++ b/src/datatypes/axioms.rs
@@ -330,22 +330,20 @@ pub fn learn_ctor_selector_clauses(
             .collect();
     }
 
-    // A nullary constructor of a parametric datatype (e.g. `None : (Option Val)`) must carry
-    // its sort on the identifier, else it prints as bare `None` and fails to re-typecheck.
-    // Monomorphic constructors (arity-0 sort) stay bare; applied ones are fixed by their args.
+    // A constructor of a parametric datatype must carry its ground sort on the identifier,
+    // else it prints bare and fails to re-typecheck: a nullary constructor (e.g. `None`) has
+    // no arguments to pin down the type parameters, and even an applied constructor can't when
+    // a parameter is phantom (appears in no field). Constructors of a non-parametric datatype
+    // (a result sort with no sort parameters) stay bare.
+    let ctor_id = if sort.1.is_empty() {
+        QualifiedIdentifier::simple(ctor_name.clone())
+    } else {
+        QualifiedIdentifier::simple_sorted(ctor_name.clone(), sort.clone())
+    };
     let ctor_app = if selector_apps.is_empty() {
-        let ctor_id = if sort.1.is_empty() {
-            QualifiedIdentifier::simple(ctor_name.clone())
-        } else {
-            QualifiedIdentifier::simple_sorted(ctor_name.clone(), sort.clone())
-        };
         solver_state.global(ctor_id, Some(sort.clone()))
     } else {
-        solver_state.app(
-            QualifiedIdentifier::simple(ctor_name.clone()),
-            selector_apps,
-            Some(sort.clone()),
-        )
+        solver_state.app(ctor_id, selector_apps, Some(sort.clone()))
     };
     let eq = solver_state.eq(term.clone(), ctor_app);
 

--- a/src/datatypes/axioms.rs
+++ b/src/datatypes/axioms.rs
@@ -330,12 +330,31 @@ pub fn learn_ctor_selector_clauses(
             .collect();
     }
 
-    // have the simple_sorted id for the global case and the simple id for the app case
-    let ctor_id = QualifiedIdentifier::simple(ctor_name.clone());
+    // A nullary constructor of a *parametric* datatype (e.g. `None : (Option Val)`) is a
+    // polymorphic identifier: printing it as a bare symbol produces SMT-LIB that fails to
+    // re-typecheck, because a polymorphic nullary identifier requires an explicit sort
+    // ascription. The ascription has to live *inside* the qualified identifier so that
+    // `Term::Global`'s printer emits `(as None (Option Val))` -- yaspar-ir does exactly this
+    // in its type checker (tc/app.rs tags the identifier via `with_sort` when the constructor
+    // needs non-trivial sort unification, i.e. when the datatype is parametric).
+    //
+    // A monomorphic nullary constructor (arity-0 result sort, e.g. an enum literal) needs no
+    // ascription, matching the type checker's empty-substitution case, so it keeps the simple
+    // identifier. Applied constructors and selectors are disambiguated by their arguments and
+    // likewise use the simple identifier.
     let ctor_app = if selector_apps.is_empty() {
+        let ctor_id = if sort.1.is_empty() {
+            QualifiedIdentifier::simple(ctor_name.clone())
+        } else {
+            QualifiedIdentifier::simple_sorted(ctor_name.clone(), sort.clone())
+        };
         solver_state.global(ctor_id, Some(sort.clone()))
     } else {
-        solver_state.app(ctor_id, selector_apps, Some(sort.clone()))
+        solver_state.app(
+            QualifiedIdentifier::simple(ctor_name.clone()),
+            selector_apps,
+            Some(sort.clone()),
+        )
     };
     let eq = solver_state.eq(term.clone(), ctor_app);
 

--- a/tests/regression/expected_results.json
+++ b/tests/regression/expected_results.json
@@ -263,6 +263,7 @@
     "datatypes/poly_nested_adt_sat.smt2": "sat",
     "datatypes/poly_option_sat.smt2": "sat",
     "datatypes/poly_option_unsat.smt2": "unsat",
+    "datatypes/phantom_param_unsat.smt2": "unsat",
     "datatypes/backtracking_new_terms.smt2": "unsat",
     "datatypes/insert_pred_sel_apps.smt2": "unsat",
     "datatypes/insert_pred_sel_apps2.smt2": "unsat",

--- a/tests/regression/smt_files/datatypes/phantom_param_unsat.smt2
+++ b/tests/regression/smt_files/datatypes/phantom_param_unsat.smt2
@@ -1,0 +1,11 @@
+; Parametric datatype with a PHANTOM type parameter: `T` appears in no field of any
+; constructor, so an applied constructor `(mk ...)` cannot have `T` inferred from its
+; arguments and must be printed with an explicit sort ascription. Regression guard for
+; parametric-constructor sort ascription (both nullary and applied constructors).
+(declare-sort Val 0)
+(declare-datatypes ((Box 1)) ((par (T) ((mk (v Int))))))
+(declare-const b1 (Box Val))
+(declare-const b2 (Box Val))
+(assert (= (v b1) (v b2)))
+(assert (not (= b1 b2)))
+(check-sat)


### PR DESCRIPTION
*Issue #, if available:* #189

*Description of changes:* Previously, eDRAT proofs did not include type annotation for parametric datatypes and thus were not being accepted by Valido. We fix this by including the type annotations when we produced datatype axioms


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
