### PR TITLE
Enable merge queue to run CI on branches it creates

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -3,6 +3,7 @@ on:
   pull_request:
     branches:
       - main
+  merge_group:
   workflow_dispatch:
   push:
     branches:


### PR DESCRIPTION


*Description of changes:*

https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/managing-a-merge-queue#triggering-merge-group-checks-with-github-actions

----
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
