### PR TITLE
Reject unsupported sorts and operators before they are registered in the egraph

### DIFF
--- a/scripts/run_verus.py
+++ b/scripts/run_verus.py
@@ -85,8 +85,10 @@ def categorize_result(stdout: str, stderr: str) -> str:
     # Check for timeout
     if "TIMEOUT" in stderr:
         return "timeout"
-    # Check for errors
-    if "ERROR" in stderr:
+    # Check for errors: this script's own ERROR sentinel (see run_cargo_on_file), a solver
+    # panic, or the solver refusing to answer -- `main` reports the latter as `Error: "..."`
+    # on stderr, e.g. when an assertion uses an unsupported theory such as bitvectors.
+    if "ERROR" in stderr or "Error:" in stderr or "panicked at" in stderr:
         return "error"
     # Otherwise categorize as other
     return "other"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,3 +17,4 @@ mod quantifiers;
 pub mod solver_state;
 pub mod solver_types;
 pub mod stats;
+pub mod theory_check;

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,6 +9,7 @@ use sundance_smt::cnf::CNFConversion;
 use sundance_smt::config::Args;
 use sundance_smt::preprocess::check_for_function_bool;
 use sundance_smt::solver_state::SolverState;
+use sundance_smt::theory_check::reject_unsupported_theories;
 use sundance_smt::{debug_println, log};
 use yaspar_ir::ast::alg::{self};
 use yaspar_ir::ast::{Context, LetElim, ObjectAllocatorExt, Repr, Term, Typecheck};
@@ -71,6 +72,11 @@ fn main() -> Result<(), String> {
             }
         })
         .collect::<Vec<_>>();
+
+    // Bail out before the assertions reach the egraph when operators from theories we do not
+    // implement would silently become uninterpreted functions and could yield `sat` on an `unsat`
+    // problem.
+    reject_unsupported_theories(&assertions, &mut context)?;
 
     let mut prop_skeleton: Vec<Vec<i32>> = vec![];
 

--- a/src/theory_check.rs
+++ b/src/theory_check.rs
@@ -5,23 +5,40 @@
 //!
 //! Any operator that `SolverState::extract_op` does not recognise is registered in the egraph as an
 //! ordinary application (`Op::App`), so it is only constrained by congruence closure. For a theory
-//! operator that is unsound. Rather than answer incorrectly, we reject the input with an error
+//! operator, that is unsound. Rather than answer incorrectly, we reject the input with an error
 //! naming the theory and the offending term.
 
 use yaspar_ir::ast::{Context, FetchSort, Repr, Term};
+use yaspar_ir::statics::{BITVEC, STRING, ARRAY, REGLAN, SET};
 
-/// Sorts whose theory Sundance has no decision procedure for, paired with the
-/// human-readable theory name used in the diagnostic.
-const UNSUPPORTED_SORTS: &[(&str, &str)] = &[(yaspar_ir::statics::BITVEC, "fixed-size bitvectors")];
+/// The theory name for a sort Sundance has no decision procedure for, or `None` if the sort is
+/// supported.
+fn unsupported_theory(sort_name: &str) -> Option<&'static str> {
+    match sort_name {
+        BITVEC => Some("fixed-size bitvectors"),
+        STRING => Some("strings"),
+        REGLAN => Some("regular expressions"),
+        ARRAY => Some("arrays"),
+        SET => Some("sets"),
+        _ => None,
+    }
+}
 
 /// Reject `assertions` if any subterm belongs to an unsupported theory.
 ///
 /// Detection is by sort rather than by operator.
+///
+/// Call this as early as possible: it wants the raw typechecked assertions, before let-elimination,
+/// NNF, or any egraph registration, so detecting an unsupported input costs little beyond parsing.
+/// `sub_terms` descends into let bindings and quantifier bodies, so nothing has to be expanded
+/// first for the walk to be complete.
 pub fn reject_unsupported_theories(
     assertions: &[Term],
     context: &mut Context,
 ) -> Result<(), String> {
-    let mut stack: Vec<Term> = assertions.to_vec();
+    let mut stack: Vec<&Term> = assertions.iter().collect();
+    // Terms are hash-consed, so subterms are shared within and across assertions. Memoizing on
+    // uid keeps the walk linear in the number of distinct subterms.
     let mut seen = crate::utils::FastDeterministicHashSet::default();
 
     while let Some(term) = stack.pop() {
@@ -30,15 +47,14 @@ pub fn reject_unsupported_theories(
         }
 
         let sort = term.get_sort(context);
-        let sort_name = sort.sort_name().as_str();
-        if let Some((_, theory)) = UNSUPPORTED_SORTS.iter().find(|(s, _)| *s == sort_name) {
+        if let Some(theory) = unsupported_theory(sort.sort_name().as_str()) {
             return Err(format!(
-                "Error: unsupported theory: {theory}. The term `{term}` has sort `{sort}`, \
+                "unsupported theory: {theory}. The term `{term}` has sort `{sort}`, \
                  and Sundance has no decision procedure for this theory."
             ));
         }
 
-        stack.extend(term.repr().sub_terms().cloned());
+        stack.extend(term.repr().sub_terms());
     }
 
     Ok(())

--- a/src/theory_check.rs
+++ b/src/theory_check.rs
@@ -1,0 +1,135 @@
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Up-front rejection of inputs that use theories Sundance cannot reason about.
+//!
+//! Any operator that `SolverState::extract_op` does not recognise is registered in the egraph as an
+//! ordinary application (`Op::App`), so it is only constrained by congruence closure. For a theory
+//! operator that is unsound. Rather than answer incorrectly, we reject the input with an error
+//! naming the theory and the offending term.
+
+use yaspar_ir::ast::{Context, FetchSort, Repr, Term};
+
+/// Sorts whose theory Sundance has no decision procedure for, paired with the
+/// human-readable theory name used in the diagnostic.
+const UNSUPPORTED_SORTS: &[(&str, &str)] = &[(yaspar_ir::statics::BITVEC, "fixed-size bitvectors")];
+
+/// Reject `assertions` if any subterm belongs to an unsupported theory.
+///
+/// Detection is by sort rather than by operator.
+pub fn reject_unsupported_theories(
+    assertions: &[Term],
+    context: &mut Context,
+) -> Result<(), String> {
+    let mut stack: Vec<Term> = assertions.to_vec();
+    let mut seen = crate::utils::FastDeterministicHashSet::default();
+
+    while let Some(term) = stack.pop() {
+        if !seen.insert(term.uid()) {
+            continue;
+        }
+
+        let sort = term.get_sort(context);
+        let sort_name = sort.sort_name().as_str();
+        if let Some((_, theory)) = UNSUPPORTED_SORTS.iter().find(|(s, _)| *s == sort_name) {
+            return Err(format!(
+                "Error: unsupported theory: {theory}. The term `{term}` has sort `{sort}`, \
+                 and Sundance has no decision procedure for this theory."
+            ));
+        }
+
+        stack.extend(term.repr().sub_terms().cloned());
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use yaspar_ir::ast::{Typecheck, alg};
+    use yaspar_ir::untyped::UntypedAst;
+
+    /// Parse and typecheck `input`, then run the theory check over its assertions.
+    fn check(input: &str) -> Result<(), String> {
+        let commands = UntypedAst.parse_script_str(input).expect("parse failed");
+        let mut context = Context::new();
+        let typed = commands.type_check(&mut context).expect("typecheck failed");
+        let assertions: Vec<Term> = typed
+            .iter()
+            .filter_map(|c| match c.repr() {
+                alg::Command::Assert(t) => Some(t.clone()),
+                _ => None,
+            })
+            .collect();
+        reject_unsupported_theories(&assertions, &mut context)
+    }
+
+    #[test]
+    fn accepts_uf_and_arithmetic() {
+        let result = check(
+            r#"
+(declare-fun f (Int) Int)
+(declare-const x Int)
+(assert (= (f x) (+ x 1)))
+(check-sat)
+"#,
+        );
+        assert!(result.is_ok(), "unexpected rejection: {result:?}");
+    }
+
+    #[test]
+    fn rejects_bitvector_operator() {
+        let result = check(
+            r#"
+(declare-const x (_ BitVec 8))
+(assert (= (bvor x #b00000000) x))
+(check-sat)
+"#,
+        );
+        let msg = result.expect_err("bitvector input should be rejected");
+        assert!(msg.contains("fixed-size bitvectors"), "{msg}");
+        assert!(msg.contains("BitVec"), "{msg}");
+    }
+
+    /// `bvult` returns Bool, so the rejection has to come from its arguments.
+    #[test]
+    fn rejects_bitvector_predicate() {
+        let result = check(
+            r#"
+(declare-const x (_ BitVec 8))
+(declare-const y (_ BitVec 8))
+(assert (bvult x y))
+(check-sat)
+"#,
+        );
+        assert!(result.is_err(), "bitvector predicate should be rejected");
+    }
+
+    /// Bitvectors reachable only through a let binding are still caught.
+    #[test]
+    fn rejects_bitvector_under_let() {
+        let result = check(
+            r#"
+(declare-const x (_ BitVec 4))
+(assert (let ((y (bvnot x))) (= y x)))
+(check-sat)
+"#,
+        );
+        assert!(result.is_err(), "bitvector under let should be rejected");
+    }
+
+    /// A declared bitvector constant that no assertion mentions is harmless.
+    #[test]
+    fn accepts_unused_bitvector_declaration() {
+        let result = check(
+            r#"
+(declare-const unused (_ BitVec 8))
+(declare-const b Bool)
+(assert (or b (not b)))
+(check-sat)
+"#,
+        );
+        assert!(result.is_ok(), "unexpected rejection: {result:?}");
+    }
+}

--- a/src/theory_check.rs
+++ b/src/theory_check.rs
@@ -9,7 +9,7 @@
 //! naming the theory and the offending term.
 
 use yaspar_ir::ast::{Context, FetchSort, Repr, Term};
-use yaspar_ir::statics::{BITVEC, STRING, ARRAY, REGLAN, SET};
+use yaspar_ir::statics::{ARRAY, BITVEC, REGLAN, SET, STRING};
 
 /// The theory name for a sort Sundance has no decision procedure for, or `None` if the sort is
 /// supported.

--- a/tests/regression/rejection/bitvector_verus_extract_or.smt2
+++ b/tests/regression/rejection/bitvector_verus_extract_or.smt2
@@ -1,0 +1,21 @@
+; Rejection test: fixed-size bitvectors are an unsupported theory.
+; Verus VC benchmark (solver flavor: cvc5), expected unsat (Verus proved this VC).
+; Every bitvector operator here (bvor, bvshl, bvand, extract, zero_extend) used to be
+; registered as an uninterpreted function, so congruence closure alone constrained it and
+; the solver reported `sat` for this unsat problem. Sundance must reject the input instead.
+(declare-sort %%Function%% 0)
+(declare-const prefix! (_ BitVec 64))
+(declare-const low_word! (_ BitVec 64))
+(assert
+ true
+)
+(declare-const %%location_label%%0 Bool)
+(assert
+ (not (=>
+   %%location_label%%0
+   (= ((_ extract 31 0) (bvor (bvshl prefix! ((_ zero_extend 58) (_ bv32 6))) (bvand low_word!
+       ((_ zero_extend 32) (_ bv4294967295 32))
+     ))
+    ) ((_ extract 31 0) low_word!)
+))))
+(check-sat)


### PR DESCRIPTION

*Issue #, if available:* https://github.com/yaspar-org/Sundance-SMT/issues/202

----
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
